### PR TITLE
AssemblyDefinition is now able to write the ManifestModule to a stream. ModuleDefinition now has .ToPEImage()

### DIFF
--- a/src/AsmResolver.DotNet/AssemblyDefinition.cs
+++ b/src/AsmResolver.DotNet/AssemblyDefinition.cs
@@ -138,7 +138,7 @@ namespace AsmResolver.DotNet
                 return _securityDeclarations;
             }
         }
-        
+
         /// <summary>
         /// Gets or sets the public key of the assembly to use for verification of a signature.
         /// </summary>
@@ -247,9 +247,9 @@ namespace AsmResolver.DotNet
         /// Rebuilds the manifest module and writes it to the stream specified. 
         /// </summary>
         /// <param name="stream">The output stream of the manifest module file.</param>
-        public void Write(Stream stream)
+        public void WriteManifest(Stream stream)
         {
-            Write(stream, new ManagedPEImageBuilder(), new ManagedPEFileBuilder());
+            WriteManifest(stream, new ManagedPEImageBuilder(), new ManagedPEFileBuilder());
         }
 
         /// <summary>
@@ -257,9 +257,9 @@ namespace AsmResolver.DotNet
         /// </summary>
         /// <param name="stream">The output stream of the manifest module file.</param>
         /// <param name="imageBuilder">The engine to use for reconstructing a PE image.</param>
-        public void Write(Stream stream, IPEImageBuilder imageBuilder)
+        public void WriteManifest(Stream stream, IPEImageBuilder imageBuilder)
         {
-            Write(stream, imageBuilder, new ManagedPEFileBuilder());
+            WriteManifest(stream, imageBuilder, new ManagedPEFileBuilder());
         }
 
         /// <summary>
@@ -268,7 +268,7 @@ namespace AsmResolver.DotNet
         /// <param name="stream">The output stream of the manifest module file.</param>
         /// <param name="imageBuilder">The engine to use for reconstructing a PE image.</param>
         /// <param name="fileBuilder">The engine to use for reconstructing a PE file.</param>
-        public void Write(Stream stream, IPEImageBuilder imageBuilder, IPEFileBuilder fileBuilder)
+        public void WriteManifest(Stream stream, IPEImageBuilder imageBuilder, IPEFileBuilder fileBuilder)
         {
             ManifestModule.Write(stream, imageBuilder, fileBuilder);
         }

--- a/src/AsmResolver.DotNet/AssemblyDefinition.cs
+++ b/src/AsmResolver.DotNet/AssemblyDefinition.cs
@@ -20,7 +20,7 @@ namespace AsmResolver.DotNet
     /// Represents an assembly of self-describing modules of an executable file hosted by a common language runtime (CLR).
     /// </summary>
     public class AssemblyDefinition : AssemblyDescriptor, IHasSecurityDeclaration
-    { 
+    {
         /// <summary>
         /// Reads a .NET assembly from the provided input buffer.
         /// </summary>
@@ -73,7 +73,7 @@ namespace AsmResolver.DotNet
         public static AssemblyDefinition FromImage(IPEImage peImage, ModuleReadParameters readParameters) =>
             ModuleDefinition.FromImage(peImage, readParameters).Assembly
             ?? throw new BadImageFormatException("The provided PE image does not contain an assembly manifest.");
-        
+
         private IList<ModuleDefinition> _modules;
         private IList<SecurityDeclaration> _securityDeclarations;
         private readonly LazyVariable<byte[]> _publicKey;
@@ -126,7 +126,7 @@ namespace AsmResolver.DotNet
                     Interlocked.CompareExchange(ref _modules, GetModules(), null);
                 return _modules;
             }
-        } 
+        }
 
         /// <inheritdoc />
         public IList<SecurityDeclaration> SecurityDeclarations
@@ -166,7 +166,7 @@ namespace AsmResolver.DotNet
         /// </remarks>
         protected virtual IList<ModuleDefinition> GetModules()
             => new OwnedCollection<AssemblyDefinition, ModuleDefinition>(this);
-        
+
         /// <summary>
         /// Obtains the list of security declarations assigned to the member.
         /// </summary>
@@ -174,9 +174,9 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="SecurityDeclarations"/> property.
         /// </remarks>
-        protected virtual IList<SecurityDeclaration> GetSecurityDeclarations() => 
+        protected virtual IList<SecurityDeclaration> GetSecurityDeclarations() =>
             new OwnedCollection<IHasSecurityDeclaration, SecurityDeclaration>(this);
-        
+
         /// <summary>
         /// Obtains the public key of the assembly definition.
         /// </summary>
@@ -232,7 +232,7 @@ namespace AsmResolver.DotNet
             string directory = Path.GetDirectoryName(filePath);
             if (!Directory.Exists(directory))
                 throw new DirectoryNotFoundException();
-            
+
             foreach (var module in Modules)
             {
                 string modulePath = module == ManifestModule
@@ -241,6 +241,36 @@ namespace AsmResolver.DotNet
 
                 module.Write(modulePath, imageBuilder, fileBuilder);
             }
+        }
+
+        /// <summary>
+        /// Rebuilds the manifest module and writes it to the stream specified. 
+        /// </summary>
+        /// <param name="stream">The output stream of the manifest module file.</param>
+        public void Write(Stream stream)
+        {
+            Write(stream, new ManagedPEImageBuilder(), new ManagedPEFileBuilder());
+        }
+
+        /// <summary>
+        /// Rebuilds the manifest module and writes it to the stream specified. 
+        /// </summary>
+        /// <param name="stream">The output stream of the manifest module file.</param>
+        /// <param name="imageBuilder">The engine to use for reconstructing a PE image.</param>
+        public void Write(Stream stream, IPEImageBuilder imageBuilder)
+        {
+            Write(stream, imageBuilder, new ManagedPEFileBuilder());
+        }
+
+        /// <summary>
+        /// Rebuilds the manifest module and writes it to the stream specified. 
+        /// </summary>
+        /// <param name="stream">The output stream of the manifest module file.</param>
+        /// <param name="imageBuilder">The engine to use for reconstructing a PE image.</param>
+        /// <param name="fileBuilder">The engine to use for reconstructing a PE file.</param>
+        public void Write(Stream stream, IPEImageBuilder imageBuilder, IPEFileBuilder fileBuilder)
+        {
+            ManifestModule.Write(stream, imageBuilder, fileBuilder);
         }
     }
 }

--- a/src/AsmResolver.DotNet/ModuleDefinition.cs
+++ b/src/AsmResolver.DotNet/ModuleDefinition.cs
@@ -88,25 +88,25 @@ namespace AsmResolver.DotNet
         /// <param name="readParameters">The parameters to use while reading the module.</param>
         /// <returns>The module.</returns>
         /// <exception cref="BadImageFormatException">Occurs when the image does not contain a valid .NET data directory.</exception>
-        public static ModuleDefinition FromImage(IPEImage peImage, ModuleReadParameters readParameters) => 
+        public static ModuleDefinition FromImage(IPEImage peImage, ModuleReadParameters readParameters) =>
             new SerializedModuleDefinition(peImage, readParameters);
 
         private readonly LazyVariable<string> _name;
         private readonly LazyVariable<Guid> _mvid;
         private readonly LazyVariable<Guid> _encId;
         private readonly LazyVariable<Guid> _encBaseId;
-        
+
         private IList<TypeDefinition> _topLevelTypes;
         private IList<AssemblyReference> _assemblyReferences;
         private IList<CustomAttribute> _customAttributes;
-        
+
         private LazyVariable<IManagedEntrypoint> _managedEntrypoint;
         private IList<ModuleReference> _moduleReferences;
         private IList<FileReference> _fileReferences;
         private IList<ManifestResource> _resources;
         private IList<ExportedType> _exportedTypes;
         private TokenAllocator _tokenAllocator;
-        
+
         private readonly LazyVariable<string> _runtimeVersion;
         private readonly LazyVariable<IResourceDirectory> _nativeResources;
 
@@ -135,11 +135,11 @@ namespace AsmResolver.DotNet
             : this(new MetadataToken(TableIndex.Module, 0))
         {
             Name = name;
-            
+
             CorLibTypeFactory = CorLibTypeFactory.CreateMscorlib40TypeFactory(this);
-            AssemblyReferences.Add((AssemblyReference) CorLibTypeFactory.CorLibScope);
+            AssemblyReferences.Add((AssemblyReference)CorLibTypeFactory.CorLibScope);
             MetadataResolver = new DefaultMetadataResolver(new NetFrameworkAssemblyResolver());
-            
+
             TopLevelTypes.Add(new TypeDefinition(null, "<Module>", 0));
         }
 
@@ -152,16 +152,16 @@ namespace AsmResolver.DotNet
             : this(new MetadataToken(TableIndex.Module, 0))
         {
             Name = name;
-            
+
             var importer = new ReferenceImporter(this);
-            corLib = (AssemblyReference) importer.ImportScope(corLib);
-            
+            corLib = (AssemblyReference)importer.ImportScope(corLib);
+
             CorLibTypeFactory = new CorLibTypeFactory(corLib);
             AssemblyReferences.Add(corLib);
 
             var resolver = CreateAssemblyResolver(corLib);
             MetadataResolver = new DefaultMetadataResolver(resolver);
-            
+
             TopLevelTypes.Add(new TypeDefinition(null, "<Module>", 0));
         }
 
@@ -388,7 +388,7 @@ namespace AsmResolver.DotNet
             get;
             set;
         } = Characteristics.Image | Characteristics.LargeAddressAware;
-        
+
         /// <summary>
         /// Gets or sets the magic optional header signature, determining whether the underlying PE image is a
         /// PE32 (32-bit) or a PE32+ (64-bit) image.
@@ -446,7 +446,7 @@ namespace AsmResolver.DotNet
         public IResourceDirectory NativeResourceDirectory
         {
             get => _nativeResources.Value;
-            set => _nativeResources.Value = value; 
+            set => _nativeResources.Value = value;
         }
 
         /// <summary>
@@ -575,7 +575,7 @@ namespace AsmResolver.DotNet
             get => _managedEntrypoint.Value;
             set => _managedEntrypoint.Value = value;
         }
-        
+
         /// <summary>
         /// Looks up a member by its metadata token.
         /// </summary>
@@ -658,7 +658,7 @@ namespace AsmResolver.DotNet
                     agenda.Enqueue(nestedType);
             }
         }
-  
+
         /// <summary>
         /// Gets the module static constructor of this metadata image. That is, the first method that is executed
         /// upon loading the .NET module. 
@@ -693,7 +693,7 @@ namespace AsmResolver.DotNet
                 var moduleType = new TypeDefinition(null, "<Module>", 0);
                 TopLevelTypes.Insert(0, moduleType);
             }
-            
+
             return TopLevelTypes[0];
         }
 
@@ -760,7 +760,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="ModuleReferences"/> property.
         /// </remarks>
-        protected virtual IList<ModuleReference> GetModuleReferences() => 
+        protected virtual IList<ModuleReference> GetModuleReferences() =>
             new OwnedCollection<ModuleDefinition, ModuleReference>(this);
 
         /// <summary>
@@ -782,7 +782,7 @@ namespace AsmResolver.DotNet
         /// </remarks>
         protected virtual IList<ManifestResource> GetResources() =>
             new OwnedCollection<ModuleDefinition, ManifestResource>(this);
-        
+
         /// <summary>
         /// Obtains the list of types that are redirected to another external module. 
         /// </summary>
@@ -790,7 +790,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="ExportedTypes"/> property.
         /// </remarks>
-        protected virtual IList<ExportedType> GetExportedTypes() => 
+        protected virtual IList<ExportedType> GetExportedTypes() =>
             new OwnedCollection<ModuleDefinition, ExportedType>(this);
 
         /// <summary>
@@ -829,15 +829,15 @@ namespace AsmResolver.DotNet
         /// <param name="corLib">The corlib reference.</param>
         /// <param name="workingDirectory">The working directory to search</param>
         /// <returns>The resolver.</returns>
-        protected static IAssemblyResolver CreateAssemblyResolver(IResolutionScope corLib, string workingDirectory=null)
+        protected static IAssemblyResolver CreateAssemblyResolver(IResolutionScope corLib, string workingDirectory = null)
         {
             var resolver = corLib.Name == "mscorlib"
-                ? (AssemblyResolverBase) new NetFrameworkAssemblyResolver()
+                ? (AssemblyResolverBase)new NetFrameworkAssemblyResolver()
                 : new NetCoreAssemblyResolver();
 
             if (!string.IsNullOrEmpty(workingDirectory))
                 resolver.SearchDirectories.Add(workingDirectory);
-            
+
             return resolver;
         }
 
@@ -857,14 +857,14 @@ namespace AsmResolver.DotNet
         /// Rebuilds the .NET module to a portable executable file and writes it to the file system. 
         /// </summary>
         /// <param name="filePath">The output path of the manifest module file.</param>
-        public void Write(string filePath) => 
+        public void Write(string filePath) =>
             Write(filePath, new ManagedPEImageBuilder(), new ManagedPEFileBuilder());
 
         /// <summary>
         /// Rebuilds the .NET module to a portable executable file and writes it to the file system. 
         /// </summary>
         /// <param name="outputStream">The output stream of the manifest module file.</param>
-        public void Write(Stream outputStream) => 
+        public void Write(Stream outputStream) =>
             Write(outputStream, new ManagedPEImageBuilder(), new ManagedPEFileBuilder());
 
         /// <summary>
@@ -872,7 +872,7 @@ namespace AsmResolver.DotNet
         /// </summary>
         /// <param name="filePath">The output path of the manifest module file.</param>
         /// <param name="imageBuilder">The engine to use for reconstructing a PE image.</param>
-        public void Write(string filePath, IPEImageBuilder imageBuilder) => 
+        public void Write(string filePath, IPEImageBuilder imageBuilder) =>
             Write(filePath, imageBuilder, new ManagedPEFileBuilder());
 
         /// <summary>
@@ -880,7 +880,7 @@ namespace AsmResolver.DotNet
         /// </summary>
         /// <param name="outputStream">The output stream of the manifest module file.</param>
         /// <param name="imageBuilder">The engine to use for reconstructing a PE image.</param>
-        public void Write(Stream outputStream, IPEImageBuilder imageBuilder) => 
+        public void Write(Stream outputStream, IPEImageBuilder imageBuilder) =>
             Write(outputStream, imageBuilder, new ManagedPEFileBuilder());
 
         /// <summary>
@@ -919,5 +919,18 @@ namespace AsmResolver.DotNet
             var file = fileBuilder.CreateFile(image);
             file.Write(writer);
         }
+
+        /// <summary>
+        /// Rebuilds the .NET module to a portable executable file and returns the IPEImage.
+        /// /// </summary>
+        /// <returns>IPEImage built using <see cref="ManagedPEImageBuilder"/> by default</returns>
+        public IPEImage ToPEImage() => ToPEImage(new ManagedPEImageBuilder());
+
+        /// <summary>
+        /// Rebuilds the .NET module to a portable executable file and returns the IPEImage.
+        /// </summary>
+        /// <param name="imageBuilder">The engine to use for reconstructing a PE image.</param>
+        /// <returns>IPEImage built by the specified IPEImageBuilder</returns>
+        public IPEImage ToPEImage(IPEImageBuilder imageBuilder) => imageBuilder.CreateImage(this);
     }
-}
+ }


### PR DESCRIPTION
Added 3 Write() methods to allow AssemblyDefinition to write the manifest module to a stream.