### PR TITLE
Fixed IsFat property in CilMethodBody.

### DIFF
--- a/src/AsmResolver.DotNet/Code/Cil/CilMethodBody.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilMethodBody.cs
@@ -282,7 +282,7 @@ namespace AsmResolver.DotNet.Code.Cil
                     return false;
 
                 var last = Instructions[Instructions.Count - 1];
-                return last.Offset + last.Size > 64;
+                return last.Offset + last.Size >= 64;
             }
         }
 


### PR DESCRIPTION
As ECMA states, "Tiny headers" use 6-bit length encoding, therefore the length should be not longer than 63. Previous code would categorize a body with a length of 64 as "Tiny", while it is actually a "Fat" format. This would lead to an ArgumentException on writing.