### PR TITLE
Bugfix/methodsig as operand

### DIFF
--- a/src/AsmResolver.DotNet/Code/Cil/CilInstructionExtensions.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilInstructionExtensions.cs
@@ -149,6 +149,7 @@ namespace AsmResolver.DotNet.Code.Cil
             {
                 IMethodDescriptor method => method.Signature,
                 StandAloneSignature standAloneSig => standAloneSig.Signature as MethodSignature,
+                MethodSignature methodSig => methodSig,
                 _ => null
             };
 

--- a/src/AsmResolver.DotNet/Code/Cil/CilInstructionExtensions.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilInstructionExtensions.cs
@@ -81,6 +81,7 @@ namespace AsmResolver.DotNet.Code.Cil
             {
                 IMethodDescriptor method => method.Signature,
                 StandAloneSignature standAloneSig => standAloneSig.Signature as MethodSignature,
+                MethodSignature methodSig => methodSig,
                 _ => null
             };
 

--- a/test/AsmResolver.DotNet.Tests/Code/Cil/CilInstructionExtensionsTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Code/Cil/CilInstructionExtensionsTest.cs
@@ -159,5 +159,35 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
             var instruction = new CilInstruction(CilOpCodes.Calli, member.Signature);
             Assert.Equal(1, instruction.GetStackPushCount());
         }
+        
+        [Fact]
+        public void CalliMethodWithoutParametersShouldPopOne()
+        {
+            var method = new MethodDefinition("Method", MethodAttributes.Static,
+                MethodSignature.CreateStatic(_module.CorLibTypeFactory.Int32));
+            method.CilMethodBody = new CilMethodBody(method);
+            
+            var type = new TypeReference(_module, null, "SomeType");
+            var member = new MemberReference(type, "SomeMethod",
+                MethodSignature.CreateStatic(_module.CorLibTypeFactory.Void));
+            
+            var instruction = new CilInstruction(CilOpCodes.Calli,member.Signature);
+            Assert.Equal(1, instruction.GetStackPopCount(method.CilMethodBody));
+        }
+        
+        [Fact]
+        public void CalliMethodWithParametersShouldPopTwo()
+        {
+            var method = new MethodDefinition("Method", MethodAttributes.Static,
+                MethodSignature.CreateStatic(_module.CorLibTypeFactory.Int32));
+            method.CilMethodBody = new CilMethodBody(method);
+            
+            var type = new TypeReference(_module, null, "SomeType");
+            var member = new MemberReference(type, "SomeMethod",
+                MethodSignature.CreateStatic(_module.CorLibTypeFactory.Void,_module.CorLibTypeFactory.Int32));
+            
+            var instruction = new CilInstruction(CilOpCodes.Calli,member.Signature);
+            Assert.Equal(2, instruction.GetStackPopCount(method.CilMethodBody));
+        }
     }
 }

--- a/test/AsmResolver.DotNet.Tests/Code/Cil/CilInstructionExtensionsTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Code/Cil/CilInstructionExtensionsTest.cs
@@ -137,5 +137,27 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
             var instruction = new CilInstruction(CilOpCodes.Newobj, member);
             Assert.Equal(1, instruction.GetStackPushCount());
         }
+        
+        [Fact]
+        public void CalliVoidMethodShouldPushZeroElement()
+        {
+            var type = new TypeReference(_module, null, "SomeType");
+            var member = new MemberReference(type, "SomeMethod",
+                MethodSignature.CreateInstance(_module.CorLibTypeFactory.Void));
+            
+            var instruction = new CilInstruction(CilOpCodes.Calli, member.Signature);
+            Assert.Equal(0, instruction.GetStackPushCount());
+        }
+        
+        [Fact]
+        public void CalliNonVoidMethodShouldPushOneElement()
+        {
+            var type = new TypeReference(_module, null, "SomeType");
+            var member = new MemberReference(type, "SomeMethod",
+                MethodSignature.CreateInstance(_module.CorLibTypeFactory.Int32));
+            
+            var instruction = new CilInstruction(CilOpCodes.Calli, member.Signature);
+            Assert.Equal(1, instruction.GetStackPushCount());
+        }
     }
 }


### PR DESCRIPTION
Asmresolver seemed to not check if operand is methodsig while calculating push&pops.