### PR TITLE
Update outdated framework info in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Get the latest stable build from the [nuget feed](https://www.nuget.org/packages
 | master | [![Master branch build status](https://img.shields.io/appveyor/ci/Washi1337/AsmResolver/master.svg)](https://ci.appveyor.com/project/Washi1337/asmresolver/branch/master) |
 | development | [![Development branch build status](https://img.shields.io/appveyor/ci/Washi1337/AsmResolver/development.svg)](https://ci.appveyor.com/project/Washi1337/asmresolver/branch/development)
 
-Alternatively, you can build the project yourself using MSBuild or an IDE that works with MSBuild (such as Visual Studio and JetBrains Rider). The project is built upon .NET Framework 4.0. If you want to compile the test libraries as well, make sure to also restore all nuget packages.
+Alternatively, you can build the project yourself using MSBuild or an IDE that works with MSBuild (such as Visual Studio and JetBrains Rider), assuming you have the .NET Core toolchain installed. If you want to compile the test libraries as well, make sure to also restore all nuget packages.
 
 Documentation
 -------------


### PR DESCRIPTION
README mentioned that AsmResolver targets .NET Framework 4.0, but it has been targeting .NET Standard exclusively since cba273df6e8deeda0bb72e23bab99352f0864056. This PR removes it, and mentions that the .NET Core SDK is required.