### PR TITLE
BUGFIX: Make up for discrepancies in spec of TypeNameParser and actual implementation

### DIFF
--- a/src/AsmResolver.DotNet/Signatures/CustomAttributeArgumentReader.cs
+++ b/src/AsmResolver.DotNet/Signatures/CustomAttributeArgumentReader.cs
@@ -7,6 +7,8 @@ using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
 namespace AsmResolver.DotNet.Signatures
 {
+    // src/coreclr/src/vm/customattribute.cpp
+    
     internal sealed class CustomAttributeArgumentReader
     {
         private readonly ModuleDefinition _parentModule;

--- a/src/AsmResolver.DotNet/Signatures/Types/Parsing/TypeNameLexer.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/Parsing/TypeNameLexer.cs
@@ -7,7 +7,7 @@ namespace AsmResolver.DotNet.Signatures.Types.Parsing
 {
     internal class TypeNameLexer
     {
-        private static readonly ISet<char> ReservedChars = new HashSet<char>("*+=.,&[]…");
+        internal static readonly ISet<char> ReservedChars = new HashSet<char>("*+=.,&[]…");
         
         private readonly TextReader _reader;
         private readonly StringBuilder _buffer = new StringBuilder();

--- a/src/AsmResolver.DotNet/Signatures/Types/Parsing/TypeNameLexer.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/Parsing/TypeNameLexer.cs
@@ -7,7 +7,7 @@ namespace AsmResolver.DotNet.Signatures.Types.Parsing
 {
     internal class TypeNameLexer
     {
-        private static readonly ISet<char> RservedChars = new HashSet<char>("*+=.,&[]…");
+        private static readonly ISet<char> ReservedChars = new HashSet<char>("*+=.,&[]…");
         
         private readonly TextReader _reader;
         private readonly StringBuilder _buffer = new StringBuilder();
@@ -86,8 +86,12 @@ namespace AsmResolver.DotNet.Signatures.Types.Parsing
                     break;
                 
                 char currentChar = (char) c;
-                if (char.IsWhiteSpace(currentChar) || RservedChars.Contains(currentChar))
+                if (terminal == TypeNameTerminal.Number && char.IsWhiteSpace(currentChar)
+                    || ReservedChars.Contains(currentChar))
+                {
                     break;
+                }
+
                 if (!char.IsDigit(currentChar))
                     terminal = TypeNameTerminal.Identifier;
 
@@ -95,7 +99,7 @@ namespace AsmResolver.DotNet.Signatures.Types.Parsing
                 _buffer.Append(currentChar);
             }
             
-            return new TypeNameToken(terminal, _buffer.ToString());
+            return new TypeNameToken(terminal, _buffer.ToString().Trim());
         }
 
         private TypeNameToken ReadIdentifierToken()
@@ -107,14 +111,14 @@ namespace AsmResolver.DotNet.Signatures.Types.Parsing
                     break;
                 
                 char currentChar = (char) c;
-                if (char.IsWhiteSpace(currentChar) || RservedChars.Contains(currentChar))
+                if (ReservedChars.Contains(currentChar))
                     break;
 
                 _reader.Read();
                 _buffer.Append(currentChar);
             }
             
-            return new TypeNameToken(TypeNameTerminal.Identifier, _buffer.ToString());
+            return new TypeNameToken(TypeNameTerminal.Identifier, _buffer.ToString().Trim());
         }
 
         private TypeNameToken ReadSymbolToken(TypeNameTerminal terminal)

--- a/src/AsmResolver.DotNet/Signatures/Types/Parsing/TypeNameParser.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/Parsing/TypeNameParser.cs
@@ -112,6 +112,7 @@ namespace AsmResolver.DotNet.Signatures.Types.Parsing
             switch (_lexer.Peek().Terminal)
             {
                 case TypeNameTerminal.OpenBracket:
+                case TypeNameTerminal.Identifier:
                     return ParseGenericTypeSpec(typeName);
                 
                 default:
@@ -213,9 +214,10 @@ namespace AsmResolver.DotNet.Signatures.Types.Parsing
 
         private TypeSignature ParseGenericTypeArgument(GenericInstanceTypeSignature genericInstance)
         {
-            Expect(TypeNameTerminal.OpenBracket);
+            var extraBracketToken = TryExpect(TypeNameTerminal.OpenBracket);
             var result = ParseTypeSpec();
-            Expect(TypeNameTerminal.CloseBracket);
+            if (extraBracketToken.HasValue)
+                Expect(TypeNameTerminal.CloseBracket);
             return result;
         }
 

--- a/src/AsmResolver.DotNet/Signatures/Types/Parsing/TypeNameParser.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/Parsing/TypeNameParser.cs
@@ -13,6 +13,7 @@ namespace AsmResolver.DotNet.Signatures.Types.Parsing
     {
         private static readonly SignatureComparer Comparer = new SignatureComparer();
         
+        // src/coreclr/src/vm/typeparse.cpp
         // https://docs.microsoft.com/en-us/dotnet/framework/reflection-and-codedom/specifying-fully-qualified-type-names
         
         /// <summary>

--- a/src/AsmResolver.DotNet/Signatures/Types/TypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/TypeSignature.cs
@@ -354,7 +354,7 @@ namespace AsmResolver.DotNet.Signatures.Types
         {
             return string.IsNullOrEmpty(FullName)
                 ? $"<<<{ElementType}>>>"
-                : Name;
+                : FullName;
         }
     }
 }

--- a/src/AsmResolver.DotNet/TypeReference.cs
+++ b/src/AsmResolver.DotNet/TypeReference.cs
@@ -101,7 +101,7 @@ namespace AsmResolver.DotNet
             protected set;
         }
 
-        AssemblyDescriptor IResolutionScope.GetAssembly() => Module?.Assembly;
+        AssemblyDescriptor IResolutionScope.GetAssembly() => Scope?.GetAssembly();
 
         /// <inheritdoc />
         public ITypeDefOrRef DeclaringType => Scope as ITypeDefOrRef;

--- a/test/AsmResolver.DotNet.Tests/CustomAttributeTest.cs
+++ b/test/AsmResolver.DotNet.Tests/CustomAttributeTest.cs
@@ -1,10 +1,14 @@
+using System;
 using System.IO;
 using System.Linq;
+using AsmResolver.DotNet.Builder;
+using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Types;
 using AsmResolver.DotNet.TestCases.CustomAttributes;
 using AsmResolver.DotNet.TestCases.Properties;
 using AsmResolver.PE;
+using AsmResolver.PE.DotNet.Cil;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 using Xunit;
@@ -385,6 +389,5 @@ namespace AsmResolver.DotNet.Tests
                 1, 2, 3, 4
             }, boxedArgument.Value);
         }
-        
     }
 }

--- a/test/AsmResolver.DotNet.Tests/TypeNameParserTest.cs
+++ b/test/AsmResolver.DotNet.Tests/TypeNameParserTest.cs
@@ -109,5 +109,35 @@ namespace AsmResolver.DotNet.Tests
             var actual = TypeNameParser.Parse(_module, $"{ns}.{name}[,,,]");
             Assert.Equal(expected, actual, _comparer);
         }
+
+        [Fact]
+        public void GenericTypeSingleBrackets()
+        {
+            const string ns = "MyNamespace";
+            const string name = "MyType";
+            
+            var elementType = new TypeReference(_module, ns, name);
+            var argumentType = _module.CorLibTypeFactory.Object;
+
+            var expected = new GenericInstanceTypeSignature(elementType, false, argumentType);
+
+            var actual = TypeNameParser.Parse(_module, $"{ns}.{name}[{argumentType.Namespace}.{argumentType.Name}]");
+            Assert.Equal(expected, actual, _comparer);
+        }
+
+        [Fact]
+        public void GenericTypeMultiBrackets()
+        {
+            const string ns = "MyNamespace";
+            const string name = "MyType";
+            
+            var elementType = new TypeReference(_module, ns, name);
+            var argumentType = _module.CorLibTypeFactory.Object;
+
+            var expected = new GenericInstanceTypeSignature(elementType, false, argumentType);
+
+            var actual = TypeNameParser.Parse(_module, $"{ns}.{name}[[{argumentType.Namespace}.{argumentType.Name}]]");
+            Assert.Equal(expected, actual, _comparer);
+        }
     }
 }

--- a/test/AsmResolver.DotNet.Tests/TypeNameParserTest.cs
+++ b/test/AsmResolver.DotNet.Tests/TypeNameParserTest.cs
@@ -153,5 +153,18 @@ namespace AsmResolver.DotNet.Tests
             var actual = TypeNameParser.Parse(_module, $"{ns}.{name}, {assemblyRef}, Version={scope.Version}");
             Assert.Equal(expected, actual, _comparer);
         }
+
+        [Fact]
+        public void ReadEscapedTypeName()
+        {
+            const string ns = "MyNamespace";
+            const string escapedName = "MyType\\+WithPlus";
+            const string name = "MyType+WithPlus";
+
+            var expected = new TypeReference(_module, ns, name).ToTypeSignature();
+            
+            var actual = TypeNameParser.Parse(_module, $"{ns}.{escapedName}");
+            Assert.Equal(expected, actual, _comparer);
+        }
     }
 }

--- a/test/AsmResolver.DotNet.Tests/TypeNameParserTest.cs
+++ b/test/AsmResolver.DotNet.Tests/TypeNameParserTest.cs
@@ -139,5 +139,19 @@ namespace AsmResolver.DotNet.Tests
             var actual = TypeNameParser.Parse(_module, $"{ns}.{name}[[{argumentType.Namespace}.{argumentType.Name}]]");
             Assert.Equal(expected, actual, _comparer);
         }
+
+        [Fact]
+        public void SpacesInAssemblySpec()
+        {
+            const string ns = "MyNamespace";
+            const string name = "MyType";
+            const string assemblyRef = "Some Assembly";
+
+            var scope = new AssemblyReference(assemblyRef, new Version(1, 0, 0, 0));
+            var expected = new TypeReference(_module, scope, ns, name).ToTypeSignature();
+
+            var actual = TypeNameParser.Parse(_module, $"{ns}.{name}, {assemblyRef}, Version={scope.Version}");
+            Assert.Equal(expected, actual, _comparer);
+        }
     }
 }


### PR DESCRIPTION
Grammar specified in the msdn docs and actual implementation is different. This PR makes up for these differences:
- Type arguments added to a generic type are not necessary enclosed by extra brackets `[ ]`.
- Assembly names can have spaces.
- Adds support for escape characters. 

See [src/coreclr/src/vm/typeparse.cpp](https://github.com/dotnet/runtime/blob/master/src/coreclr/src/vm/typeparse.cpp).

Closes #109 
