### PR TITLE
Fixed the issue with writing GenericParams

### DIFF
--- a/src/AsmResolver.DotNet/Cloning/MemberCloner.cs
+++ b/src/AsmResolver.DotNet/Cloning/MemberCloner.cs
@@ -385,8 +385,6 @@ namespace AsmResolver.DotNet.Cloning
         {
             var clonedParameter = new GenericParameter(parameter.Name, parameter.Attributes);
 
-            //clonedParameter.Number = parameter.Number;
-
             foreach (var constraint in parameter.Constraints)
                 clonedParameter.Constraints.Add(CloneGenericParameterConstraint(context, constraint));
 

--- a/src/AsmResolver.DotNet/Cloning/MemberCloner.cs
+++ b/src/AsmResolver.DotNet/Cloning/MemberCloner.cs
@@ -8,12 +8,12 @@ using AsmResolver.PE.DotNet.Metadata.Tables;
 namespace AsmResolver.DotNet.Cloning
 {
     /// <summary>
-    /// Provides a mechanism for deep-copying metadata members from external .NET modules into another module. 
+    /// Provides a mechanism for deep-copying metadata members from external .NET modules into another module.
     /// </summary>
     /// <remarks>
-    /// When multiple members are cloned in one go, the member cloner will fix up any references between the cloned members. 
+    /// When multiple members are cloned in one go, the member cloner will fix up any references between the cloned members.
     /// For example, if a type or member is referenced in a method body, and this type or member is also included in the
-    /// cloning process, the reference will be updated to the cloned member instead of imported. 
+    /// cloning process, the reference will be updated to the cloned member instead of imported.
     /// </remarks>
     public partial class MemberCloner
     {
@@ -154,9 +154,9 @@ namespace AsmResolver.DotNet.Cloning
         /// </summary>
         /// <param name="types">The types to include.</param>
         /// <returns>The metadata cloner that the types were added to.</returns>
-        public MemberCloner Include(params TypeDefinition[] types) => 
+        public MemberCloner Include(params TypeDefinition[] types) =>
             Include((IEnumerable<TypeDefinition>) types);
-        
+
         /// <summary>
         /// Adds each type in the provided collection of types, and all their members and nested types, to the list
         /// of members to clone.
@@ -213,7 +213,7 @@ namespace AsmResolver.DotNet.Cloning
             _eventsToClone.Add(@event);
             return this;
         }
-        
+
         /// <summary>
         /// Clones all included members.
         /// </summary>
@@ -265,15 +265,15 @@ namespace AsmResolver.DotNet.Cloning
         private void DeepCopyType(MemberCloneContext context, TypeDefinition type)
         {
             var clonedType = (TypeDefinition) context.ClonedMembers[type];
-            
+
             // Copy base type.
             if (type.BaseType is {})
                 clonedType.BaseType = context.Importer.ImportType(type.BaseType);
-            
+
             // Copy interface implementations.
             foreach (var implementation in type.Interfaces)
                 clonedType.Interfaces.Add(CloneInterfaceImplementation(context, implementation));
-            
+
             // Copy method implementations.
             foreach (var implementation in type.MethodImplementations)
             {
@@ -282,9 +282,9 @@ namespace AsmResolver.DotNet.Cloning
                     context.Importer.ImportMethod(implementation.Body)
                 ));
             }
-            
-            // If the type is nested and the declaring type is cloned as well, we should add it to the cloned type. 
-            if (type.IsNested 
+
+            // If the type is nested and the declaring type is cloned as well, we should add it to the cloned type.
+            if (type.IsNested
                 && context.ClonedMembers.TryGetValue(type.DeclaringType, out var member)
                 && member is TypeDefinition clonedDeclaringType)
             {
@@ -309,7 +309,7 @@ namespace AsmResolver.DotNet.Cloning
         }
 
         private void CloneCustomAttributes(
-            MemberCloneContext context, 
+            MemberCloneContext context,
             IHasCustomAttribute sourceProvider,
             IHasCustomAttribute clonedProvider)
         {
@@ -330,10 +330,10 @@ namespace AsmResolver.DotNet.Cloning
             {
                 var clonedArgument = new CustomAttributeNamedArgument(
                     namedArgument.MemberType,
-                    namedArgument.MemberName, 
+                    namedArgument.MemberName,
                     namedArgument.ArgumentType,
                     CloneCustomAttributeArgument(context, namedArgument.Argument));
-                
+
                 clonedSignature.NamedArguments.Add(clonedArgument);
             }
 
@@ -347,7 +347,7 @@ namespace AsmResolver.DotNet.Cloning
         {
             var clonedArgument = new CustomAttributeArgument(context.Importer.ImportTypeSignature(argument.ArgumentType));
             clonedArgument.IsNullArray = argument.IsNullArray;
-            
+
             // Copy all elements.
             for (int i = 0; i < argument.Elements.Count; i++)
                 clonedArgument.Elements.Add(argument.Elements[i]);
@@ -365,15 +365,15 @@ namespace AsmResolver.DotNet.Cloning
         private Constant CloneConstant(MemberCloneContext context, Constant constant)
         {
             return constant != null
-                ? new Constant(constant.Type, 
-                    constant.Value is null 
+                ? new Constant(constant.Type,
+                    constant.Value is null
                     ? null
                     : new DataBlobSignature(constant.Value.Data))
                 : null;
         }
 
         private void CloneGenericParameters(
-            MemberCloneContext context, 
+            MemberCloneContext context,
             IHasGenericParameters sourceProvider,
             IHasGenericParameters clonedProvider)
         {
@@ -385,7 +385,7 @@ namespace AsmResolver.DotNet.Cloning
         {
             var clonedParameter = new GenericParameter(parameter.Name, parameter.Attributes);
 
-            clonedParameter.Number = parameter.Number;
+            //clonedParameter.Number = parameter.Number;
 
             foreach (var constraint in parameter.Constraints)
                 clonedParameter.Constraints.Add(CloneGenericParameterConstraint(context, constraint));
@@ -398,7 +398,7 @@ namespace AsmResolver.DotNet.Cloning
             GenericParameterConstraint constraint)
         {
             var clonedConstraint = new GenericParameterConstraint(context.Importer.ImportType(constraint.Constraint));
-            
+
             CloneCustomAttributes(context, constraint, clonedConstraint);
             return clonedConstraint;
         }
@@ -408,7 +408,7 @@ namespace AsmResolver.DotNet.Cloning
             return marshalDescriptor switch
             {
                 null => null,
-                
+
                 ComInterfaceMarshalDescriptor com => new ComInterfaceMarshalDescriptor(com.NativeType),
 
                 CustomMarshalDescriptor custom => new CustomMarshalDescriptor(
@@ -470,12 +470,12 @@ namespace AsmResolver.DotNet.Cloning
                     argument.MemberName,
                     context.Importer.ImportTypeSignature(argument.ArgumentType),
                     CloneCustomAttributeArgument(context, argument.Argument));
-                
+
                 result.NamedArguments.Add(newArgument);
             }
 
             return result;
         }
-        
+
     }
 }

--- a/src/AsmResolver.DotNet/GenericParameter.cs
+++ b/src/AsmResolver.DotNet/GenericParameter.cs
@@ -10,9 +10,9 @@ namespace AsmResolver.DotNet
     /// <summary>
     /// Represents a type parameter that a generic method or type in a .NET module defines.
     /// </summary>
-    public class GenericParameter : 
+    public class GenericParameter :
         MetadataMember,
-        INameProvider, 
+        INameProvider,
         IHasCustomAttribute,
         IModuleProvider,
         IOwnedCollectionElement<IHasGenericParameters>
@@ -54,7 +54,7 @@ namespace AsmResolver.DotNet
             Name = name;
             Attributes = attributes;
         }
-        
+
         /// <summary>
         /// Gets the member that defines this generic parameter.
         /// </summary>
@@ -78,7 +78,7 @@ namespace AsmResolver.DotNet
         }
 
         /// <summary>
-        /// Gets or sets additional attributes assigned to this generic parameter. 
+        /// Gets or sets additional attributes assigned to this generic parameter.
         /// </summary>
         public GenericParameterAttributes Attributes
         {
@@ -89,11 +89,7 @@ namespace AsmResolver.DotNet
         /// <summary>
         /// Gets the index of this parameter within the list of generic parameters that the owner defines.
         /// </summary>
-        public ushort Number
-        {
-            get;
-            internal set;
-        }
+        public ushort Number => (ushort)Owner.GenericParameters.IndexOf(this);
 
         /// <inheritdoc />
         public ModuleDefinition Module => Owner?.Module;
@@ -121,7 +117,7 @@ namespace AsmResolver.DotNet
                 return _customAttributes;
             }
         }
-        
+
         /// <summary>
         /// Obtains the name of the generic parameter.
         /// </summary>
@@ -130,7 +126,7 @@ namespace AsmResolver.DotNet
         /// This method is called upon initialization of the <see cref="Name"/> property.
         /// </remarks>
         protected virtual string GetName() => null;
-        
+
         /// <summary>
         /// Obtains the owner of the generic parameter.
         /// </summary>
@@ -147,7 +143,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="Constraints"/> property.
         /// </remarks>
-        protected virtual IList<GenericParameterConstraint> GetConstraints() => 
+        protected virtual IList<GenericParameterConstraint> GetConstraints() =>
             new OwnedCollection<GenericParameter, GenericParameterConstraint>(this);
 
         /// <summary>
@@ -157,7 +153,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="CustomAttributes"/> property.
         /// </remarks>
-        protected virtual IList<CustomAttribute> GetCustomAttributes() => 
+        protected virtual IList<CustomAttribute> GetCustomAttributes() =>
             new OwnedCollection<IHasCustomAttribute, CustomAttribute>(this);
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/Serialized/SerializedGenericParameter.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedGenericParameter.cs
@@ -31,7 +31,6 @@ namespace AsmResolver.DotNet.Serialized
             _row = row;
 
             Attributes = _row.Attributes;
-            //Number = row.Number;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/Serialized/SerializedGenericParameter.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedGenericParameter.cs
@@ -11,7 +11,7 @@ namespace AsmResolver.DotNet.Serialized
 {
     /// <summary>
     /// Represents a lazily initialized implementation of <see cref="GenericParameter"/>  that is read from a
-    /// .NET metadata image. 
+    /// .NET metadata image.
     /// </summary>
     public class SerializedGenericParameter : GenericParameter
     {
@@ -31,7 +31,7 @@ namespace AsmResolver.DotNet.Serialized
             _row = row;
 
             Attributes = _row.Attributes;
-            Number = row.Number;            
+            //Number = row.Number;
         }
 
         /// <inheritdoc />
@@ -45,7 +45,7 @@ namespace AsmResolver.DotNet.Serialized
             var encoder = _context.Image.DotNetDirectory.Metadata
                 .GetStream<TablesStream>()
                 .GetIndexEncoder(CodedIndex.TypeOrMethodDef);
-            
+
             var ownerToken = encoder.DecodeIndex(_row.Owner);
             return _context.ParentModule.TryLookupMember(ownerToken, out var member)
                 ? member as IHasGenericParameters
@@ -68,7 +68,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override IList<CustomAttribute> GetCustomAttributes() => 
+        protected override IList<CustomAttribute> GetCustomAttributes() =>
             _context.ParentModule.GetCustomAttributeCollection(this);
     }
 }


### PR DESCRIPTION
Before this change, if you add more than 1 GenericParameter to a method definition, all of them would be written with the same number.