### PR TITLE
Fix cloning ldarg operand

### DIFF
--- a/src/AsmResolver.DotNet/Cloning/MemberCloner.Methods.cs
+++ b/src/AsmResolver.DotNet/Cloning/MemberCloner.Methods.cs
@@ -194,7 +194,7 @@ namespace AsmResolver.DotNet.Cloning
 
                 case CilOperandType.InlineArgument:
                 case CilOperandType.ShortInlineArgument:
-                    clonedInstruction.Operand = clonedBody.Owner.Parameters[((Parameter)instruction.Operand).Index];
+                    clonedInstruction.Operand = clonedBody.Owner.Parameters.GetBySignatureIndex(((Parameter)instruction.Operand).MethodSignatureIndex);
                     break;
 
                 default:


### PR DESCRIPTION
Before it could happen that it can't find the parameter index of the ldarg operand in case of the method having no parameters