### PR TITLE
IFileService interfaces

### DIFF
--- a/docs/dotnet/basics.rst
+++ b/docs/dotnet/basics.rst
@@ -30,17 +30,17 @@ Opening a .NET module can be done through one of the `FromXXX` methods from the 
 
 .. code-block:: csharp
 
+    byte[] raw = ...
+    ModuleDefinition module = ModuleDefinition.FromBytes(raw);
+    
+.. code-block:: csharp
+
     ModuleDefinition module = ModuleDefinition.FromFile(@"C:\myfile.exe");
 
 .. code-block:: csharp
 
     PEFile peFile = ...
     ModuleDefinition module = ModuleDefinition.FromFile(peFile);
-
-.. code-block:: csharp
-
-    byte[] raw = ...
-    ModuleDefinition module = ModuleDefinition.FromBytes(raw);
 
 .. code-block:: csharp
 
@@ -51,6 +51,14 @@ Opening a .NET module can be done through one of the `FromXXX` methods from the 
 
     IPEImage peImage = ...
     ModuleDefinition module = ModuleDefinition.FromImage(peImage);
+
+
+If you want to read large files (+100MB), consider using memory mapped I/O instead:
+
+.. code-block:: csharp
+
+    using var service = new MemoryMappedFileService();
+    ModuleDefinition module = ModuleDefinition.FromFile(service.OpenFile(@"C:\myfile.exe"));
 
 
 Writing a .NET module
@@ -87,17 +95,17 @@ Opening (multi-module) .NET assemblies can be done in a very similar fashion as 
 
 .. code-block:: csharp
 
+    byte[] raw = ...
+    AssemblyDefinition assembly = AssemblyDefinition.FromBytes(raw);
+
+.. code-block:: csharp
+
     AssemblyDefinition assembly = AssemblyDefinition.FromFile(@"C:\myfile.exe");
 
 .. code-block:: csharp
 
     IPEFile peFile = ...
     AssemblyDefinition assembly = AssemblyDefinition.FromFile(peFile);
-
-.. code-block:: csharp
-
-    byte[] raw = ...
-    AssemblyDefinition assembly = AssemblyDefinition.FromBytes(raw);
 
 .. code-block:: csharp
 
@@ -108,6 +116,14 @@ Opening (multi-module) .NET assemblies can be done in a very similar fashion as 
 
     IPEImage peImage = ...
     AssemblyDefinition assembly = AssemblyDefinition.FromImage(peImage);
+
+    
+If you want to read large files (+100MB), consider using memory mapped I/O instead:
+
+.. code-block:: csharp
+
+    using var service = new MemoryMappedFileService();
+    AssemblyDefinition assembly = AssemblyDefinition.FromFile(service.OpenFile(@"C:\myfile.exe"));
 
 
 Writing a .NET assembly

--- a/docs/pefile/basics.rst
+++ b/docs/pefile/basics.rst
@@ -15,17 +15,18 @@ Opening a file can be done through one of the `FromXXX` methods:
 
 .. code-block:: csharp
 
-    var peFile = PEFile.FromFile(@"C:\myfile.exe");
-
-.. code-block:: csharp
-
     byte[] raw = ...
     var peFile = PEFile.FromBytes(raw);
+    
+.. code-block:: csharp
+
+    var peFile = PEFile.FromFile(@"C:\myfile.exe");
 
 .. code-block:: csharp
 
     BinaryStreamReader reader = ...
     var peFile = PEFile.FromReader(reader);
+
 
 By default, AsmResolver assumes the PE file is in its unmapped form. This is usually the case when files are read directly from the file system. For memory mapped PE files, use the overload of the ``FromReader`` method, which allows for specifying the memory layout of the input.
 
@@ -33,6 +34,14 @@ By default, AsmResolver assumes the PE file is in its unmapped form. This is usu
 
     BinaryStreamReader reader = ...
     var peFile = PEFile.FromReader(reader, PEMappingMode.Mapped);
+
+
+If you want to read large files (+100MB), consider using memory mapped I/O instead:
+
+.. code-block:: csharp
+
+    using var service = new MemoryMappedFileService();
+    var peFile = PEFile.FromFile(service.OpenFile(@"C:\myfile.exe"));
 
 
 Writing PE files

--- a/docs/pefile/headers.rst
+++ b/docs/pefile/headers.rst
@@ -1,5 +1,5 @@
-Inspecting the PE headers
-=========================
+PE headers
+==========
 
 After you obtained an instance of the ``PEFile`` class, it is possible to read and edit various properties in the DOS header, COFF file header and optional header. They each have a designated property:
 

--- a/docs/pefile/sections.rst
+++ b/docs/pefile/sections.rst
@@ -1,5 +1,5 @@
-Inspecting the PE sections
-==========================
+PE sections
+===========
 
 Sections can be read and modified by accessing the ``PEFile.Sections`` property, which is a collection of ``PESection`` objects.
 

--- a/docs/peimage/basics.rst
+++ b/docs/peimage/basics.rst
@@ -24,6 +24,11 @@ Opening an image can be done through one of the `FromXXX` methods from the ``PEI
 
 .. code-block:: csharp
 
+    byte[] raw = ...
+    IPEImage peImage = PEImage.FromBytes(raw);
+
+.. code-block:: csharp
+
     IPEImage peImage = PEImage.FromFile(@"C:\myfile.exe");
 
 .. code-block:: csharp
@@ -33,13 +38,17 @@ Opening an image can be done through one of the `FromXXX` methods from the ``PEI
 
 .. code-block:: csharp
 
-    byte[] raw = ...
-    IPEImage peImage = PEImage.FromBytes(raw);
+    BinaryStreamReader reader = ...
+    IPEImage peImage = PEImage.FromReader(reader);
+
+
+If you want to read large files (+100MB), consider using memory mapped I/O instead:
 
 .. code-block:: csharp
 
-    BinaryStreamReader reader = ...
-    IPEImage peImage = PEImage.FromReader(reader);
+    using var service = new MemoryMappedFileService();
+    IPEImage peImage = PEImage.FromFile(service.OpenFile(@"C:\myfile.exe"));
+
 
 
 Writing a PE image

--- a/src/AsmResolver.DotNet/AssemblyDefinition.cs
+++ b/src/AsmResolver.DotNet/AssemblyDefinition.cs
@@ -50,8 +50,15 @@ namespace AsmResolver.DotNet
         /// <param name="file">The portable executable file to load.</param>
         /// <returns>The module.</returns>
         /// <exception cref="BadImageFormatException">Occurs when the image does not contain a valid .NET metadata directory.</exception>
-        public static AssemblyDefinition FromFile(PEFile file) =>
-            FromImage(PEImage.FromFile(file));
+        public static AssemblyDefinition FromFile(PEFile file) => FromImage(PEImage.FromFile(file));
+
+        /// <summary>
+        /// Reads a .NET assembly from the provided input file.
+        /// </summary>
+        /// <param name="file">The portable executable file to load.</param>
+        /// <returns>The module.</returns>
+        /// <exception cref="BadImageFormatException">Occurs when the image does not contain a valid .NET metadata directory.</exception>
+        public static AssemblyDefinition FromFile(IInputFile file) => FromImage(PEImage.FromFile(file));
 
         /// <summary>
         /// Reads a .NET assembly from an input stream.

--- a/src/AsmResolver.DotNet/AssemblyResolverBase.cs
+++ b/src/AsmResolver.DotNet/AssemblyResolverBase.cs
@@ -2,6 +2,7 @@ using AsmResolver.DotNet.Signatures;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using AsmResolver.IO;
 
 namespace AsmResolver.DotNet
 {
@@ -18,6 +19,23 @@ namespace AsmResolver.DotNet
         };
 
         private readonly Dictionary<AssemblyDescriptor, AssemblyDefinition> _cache = new(new SignatureComparer());
+
+        /// <summary>
+        /// Initializes the base of an assembly resolver.
+        /// </summary>
+        /// <param name="fileService">The service to use for reading files from the disk.</param>
+        protected AssemblyResolverBase(IFileService fileService)
+        {
+            FileService = fileService ?? throw new ArgumentNullException(nameof(fileService));
+        }
+
+        /// <summary>
+        /// Gets the file service that is used for reading files from the disk.
+        /// </summary>
+        public IFileService FileService
+        {
+            get;
+        }
 
         /// <summary>
         /// Gets a collection of custom search directories that are probed upon resolving a reference
@@ -108,7 +126,7 @@ namespace AsmResolver.DotNet
         /// <returns>The assembly.</returns>
         protected virtual AssemblyDefinition LoadAssemblyFromFile(string path)
         {
-            return AssemblyDefinition.FromFile(path);
+            return AssemblyDefinition.FromFile(FileService.OpenFile(path));
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/Code/Cil/CilMethodBody.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilMethodBody.cs
@@ -156,7 +156,7 @@ namespace AsmResolver.DotNet.Code.Cil
             DynamicMethodHelper.ReadLocalVariables(result, method, localSig);
 
             // Read raw instructions.
-            var reader = ByteArrayInputFile.CreateReader(code);
+            var reader = ByteArrayDataSource.CreateReader(code);
             var disassembler = new CilDisassembler(reader, new DynamicCilOperandResolver(module, result, tokenList));
             result.Instructions.AddRange(disassembler.ReadInstructions());
 
@@ -229,7 +229,7 @@ namespace AsmResolver.DotNet.Code.Cil
             ICilOperandResolver operandResolver,
             CilRawMethodBody rawBody)
         {
-            var reader = ByteArrayInputFile.CreateReader(rawBody.Code);
+            var reader = ByteArrayDataSource.CreateReader(rawBody.Code);
             var disassembler = new CilDisassembler(reader, operandResolver);
             result.Instructions.AddRange(disassembler.ReadInstructions());
         }
@@ -241,7 +241,7 @@ namespace AsmResolver.DotNet.Code.Cil
                 var section = fatBody.ExtraSections[i];
                 if (section.IsEHTable)
                 {
-                    var reader = ByteArrayInputFile.CreateReader(section.Data);
+                    var reader = ByteArrayDataSource.CreateReader(section.Data);
                     uint size = section.IsFat
                         ? CilExceptionHandler.FatExceptionHandlerSize
                         : CilExceptionHandler.TinyExceptionHandlerSize;

--- a/src/AsmResolver.DotNet/Code/Cil/CilMethodBody.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilMethodBody.cs
@@ -156,7 +156,7 @@ namespace AsmResolver.DotNet.Code.Cil
             DynamicMethodHelper.ReadLocalVariables(result, method, localSig);
 
             // Read raw instructions.
-            var reader = ByteArrayReaderFactory.CreateReader(code);
+            var reader = ByteArrayInputFile.CreateReader(code);
             var disassembler = new CilDisassembler(reader, new DynamicCilOperandResolver(module, result, tokenList));
             result.Instructions.AddRange(disassembler.ReadInstructions());
 
@@ -229,7 +229,7 @@ namespace AsmResolver.DotNet.Code.Cil
             ICilOperandResolver operandResolver,
             CilRawMethodBody rawBody)
         {
-            var reader = ByteArrayReaderFactory.CreateReader(rawBody.Code);
+            var reader = ByteArrayInputFile.CreateReader(rawBody.Code);
             var disassembler = new CilDisassembler(reader, operandResolver);
             result.Instructions.AddRange(disassembler.ReadInstructions());
         }
@@ -241,7 +241,7 @@ namespace AsmResolver.DotNet.Code.Cil
                 var section = fatBody.ExtraSections[i];
                 if (section.IsEHTable)
                 {
-                    var reader = ByteArrayReaderFactory.CreateReader(section.Data);
+                    var reader = ByteArrayInputFile.CreateReader(section.Data);
                     uint size = section.IsFat
                         ? CilExceptionHandler.FatExceptionHandlerSize
                         : CilExceptionHandler.TinyExceptionHandlerSize;

--- a/src/AsmResolver.DotNet/Code/Cil/DynamicCilOperandResolver.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/DynamicCilOperandResolver.cs
@@ -84,7 +84,7 @@ namespace AsmResolver.DotNet.Code.Cil
                     break;
 
                 case TableIndex.StandAloneSig:
-                    var reader = ByteArrayReaderFactory.CreateReader((byte[]) _tokens[(int) token.Rid]);
+                    var reader = ByteArrayInputFile.CreateReader((byte[]) _tokens[(int) token.Rid]);
                     return CallingConventionSignature.FromReader(new BlobReadContext(_readerContext), ref reader);
             }
 

--- a/src/AsmResolver.DotNet/Code/Cil/DynamicCilOperandResolver.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/DynamicCilOperandResolver.cs
@@ -84,7 +84,7 @@ namespace AsmResolver.DotNet.Code.Cil
                     break;
 
                 case TableIndex.StandAloneSig:
-                    var reader = ByteArrayInputFile.CreateReader((byte[]) _tokens[(int) token.Rid]);
+                    var reader = ByteArrayDataSource.CreateReader((byte[]) _tokens[(int) token.Rid]);
                     return CallingConventionSignature.FromReader(new BlobReadContext(_readerContext), ref reader);
             }
 

--- a/src/AsmResolver.DotNet/DotNetCoreAssemblyResolver.cs
+++ b/src/AsmResolver.DotNet/DotNetCoreAssemblyResolver.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using AsmResolver.DotNet.Config.Json;
+using AsmResolver.IO;
 
 namespace AsmResolver.DotNet
 {
@@ -16,8 +17,9 @@ namespace AsmResolver.DotNet
         /// Creates a new .NET Core assembly resolver, by attempting to autodetect the current .NET or .NET Core
         /// installation directory.
         /// </summary>
+        /// <param name="runtimeVersion">The version of .NET to target.</param>
         public DotNetCoreAssemblyResolver(Version runtimeVersion)
-            : this(null, runtimeVersion, DotNetCorePathProvider.Default)
+            : this(UncachedFileService.Instance, null, runtimeVersion, DotNetCorePathProvider.Default)
         {
         }
 
@@ -25,28 +27,60 @@ namespace AsmResolver.DotNet
         /// Creates a new .NET Core assembly resolver, by attempting to autodetect the current .NET or .NET Core
         /// installation directory.
         /// </summary>
+        /// <param name="fileService">The service to use for reading files from the disk.</param>
+        /// <param name="runtimeVersion">The version of .NET to target.</param>
+        public DotNetCoreAssemblyResolver(IFileService fileService, Version runtimeVersion)
+            : this(fileService, null, runtimeVersion, DotNetCorePathProvider.Default)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new .NET Core assembly resolver, by attempting to autodetect the current .NET or .NET Core
+        /// installation directory.
+        /// </summary>
+        /// <param name="configuration">The runtime configuration as specified by the *.runtimeconfig.json file.</param>
+        /// <param name="fallbackVersion">The version of .NET to fallback on if the runtime configuration is insufficient.</param>
         public DotNetCoreAssemblyResolver(RuntimeConfiguration configuration, Version fallbackVersion)
-            : this(configuration, fallbackVersion, DotNetCorePathProvider.Default)
+            : this(UncachedFileService.Instance, configuration, fallbackVersion, DotNetCorePathProvider.Default)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new .NET Core assembly resolver, by attempting to autodetect the current .NET or .NET Core
+        /// installation directory.
+        /// </summary>
+        /// <param name="fileService">The service to use for reading files from the disk.</param>
+        /// <param name="configuration">The runtime configuration as specified by the *.runtimeconfig.json file.</param>
+        /// <param name="fallbackVersion">The version of .NET to fallback on if the runtime configuration is insufficient.</param>
+        public DotNetCoreAssemblyResolver(IFileService fileService, RuntimeConfiguration configuration, Version fallbackVersion)
+            : this(fileService, configuration, fallbackVersion, DotNetCorePathProvider.Default)
         {
         }
 
         /// <summary>
         /// Creates a new .NET Core assembly resolver.
         /// </summary>
+        /// <param name="fileService">The service to use for reading files from the disk.</param>
         /// <param name="configuration">The runtime configuration to use.</param>
         /// <param name="pathProvider">The installation directory of .NET Core.</param>
-        public DotNetCoreAssemblyResolver(RuntimeConfiguration configuration, DotNetCorePathProvider pathProvider)
-            : this(configuration, null, pathProvider)
+        public DotNetCoreAssemblyResolver(IFileService fileService, RuntimeConfiguration configuration, DotNetCorePathProvider pathProvider)
+            : this(fileService, configuration, null, pathProvider)
         {
         }
 
         /// <summary>
         /// Creates a new .NET Core assembly resolver.
         /// </summary>
+        /// <param name="fileService">The service to use for reading files from the disk.</param>
         /// <param name="configuration">The runtime configuration to use, or <c>null</c> if no configuration is available.</param>
         /// <param name="fallbackVersion">The version of .NET or .NET Core to use when no (valid) configuration is provided.</param>
         /// <param name="pathProvider">The installation directory of .NET Core.</param>
-        public DotNetCoreAssemblyResolver(RuntimeConfiguration configuration, Version fallbackVersion, DotNetCorePathProvider pathProvider)
+        public DotNetCoreAssemblyResolver(
+            IFileService fileService,
+            RuntimeConfiguration configuration,
+            Version fallbackVersion,
+            DotNetCorePathProvider pathProvider)
+            : base(fileService)
         {
             if (fallbackVersion is null)
                 throw new ArgumentNullException(nameof(fallbackVersion));

--- a/src/AsmResolver.DotNet/DotNetFrameworkAssemblyResolver.cs
+++ b/src/AsmResolver.DotNet/DotNetFrameworkAssemblyResolver.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using AsmResolver.IO;
 
 namespace AsmResolver.DotNet
 {
@@ -15,6 +16,16 @@ namespace AsmResolver.DotNet
         /// Creates a new default assembly resolver.
         /// </summary>
         public DotNetFrameworkAssemblyResolver()
+            : this(UncachedFileService.Instance)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new default assembly resolver.
+        /// </summary>
+        /// <param name="fileService">The service to use for reading files from the disk.</param>
+        public DotNetFrameworkAssemblyResolver(IFileService fileService)
+            : base(fileService)
         {
             DetectGacDirectories();
         }

--- a/src/AsmResolver.DotNet/DynamicMethodHelper.cs
+++ b/src/AsmResolver.DotNet/DynamicMethodHelper.cs
@@ -19,7 +19,7 @@ namespace AsmResolver.DotNet
             if (!(method.Module is SerializedModuleDefinition module))
                 throw new ArgumentException("Method body should reference a serialized module.");
 
-            var reader = ByteArrayInputFile.CreateReader(localSig);
+            var reader = ByteArrayDataSource.CreateReader(localSig);
             var localsSignature = (LocalVariablesSignature) CallingConventionSignature.FromReader(
                 new BlobReadContext(module.ReaderContext),
                 ref reader);

--- a/src/AsmResolver.DotNet/DynamicMethodHelper.cs
+++ b/src/AsmResolver.DotNet/DynamicMethodHelper.cs
@@ -19,7 +19,7 @@ namespace AsmResolver.DotNet
             if (!(method.Module is SerializedModuleDefinition module))
                 throw new ArgumentException("Method body should reference a serialized module.");
 
-            var reader = ByteArrayReaderFactory.CreateReader(localSig);
+            var reader = ByteArrayInputFile.CreateReader(localSig);
             var localsSignature = (LocalVariablesSignature) CallingConventionSignature.FromReader(
                 new BlobReadContext(module.ReaderContext),
                 ref reader);

--- a/src/AsmResolver.DotNet/ModuleDefinition.cs
+++ b/src/AsmResolver.DotNet/ModuleDefinition.cs
@@ -213,7 +213,7 @@ namespace AsmResolver.DotNet
             AssemblyReferences.Add(corLib);
 
             OriginalTargetRuntime = DetectTargetRuntime();
-            MetadataResolver = new DefaultMetadataResolver(CreateAssemblyResolver());
+            MetadataResolver = new DefaultMetadataResolver(CreateAssemblyResolver(UncachedFileService.Instance));
 
             TopLevelTypes.Add(new TypeDefinition(null, "<Module>", 0));
         }
@@ -969,7 +969,7 @@ namespace AsmResolver.DotNet
         /// Creates an assembly resolver based on the corlib reference.
         /// </summary>
         /// <returns>The resolver.</returns>
-        protected IAssemblyResolver CreateAssemblyResolver()
+        protected IAssemblyResolver CreateAssemblyResolver(IFileService fileService)
         {
             string fullPath = FilePath;
             (string directory, string name) = !string.IsNullOrEmpty(fullPath)
@@ -984,18 +984,18 @@ namespace AsmResolver.DotNet
                 case DotNetRuntimeInfo.NetFramework:
                 case DotNetRuntimeInfo.NetStandard
                     when string.IsNullOrEmpty(DotNetCorePathProvider.DefaultInstallationPath):
-                    resolver = new DotNetFrameworkAssemblyResolver();
+                    resolver = new DotNetFrameworkAssemblyResolver(fileService);
                     break;
                 case DotNetRuntimeInfo.NetStandard
                     when DotNetCorePathProvider.Default.TryGetLatestStandardCompatibleVersion(
                         runtime.Version, out var coreVersion):
-                    resolver = new DotNetCoreAssemblyResolver(coreVersion);
+                    resolver = new DotNetCoreAssemblyResolver(fileService, coreVersion);
                     break;
                 case DotNetRuntimeInfo.NetCoreApp:
-                    resolver = new DotNetCoreAssemblyResolver(runtime.Version);
+                    resolver = new DotNetCoreAssemblyResolver(fileService, runtime.Version);
                     break;
                 default:
-                    resolver = new DotNetFrameworkAssemblyResolver();
+                    resolver = new DotNetFrameworkAssemblyResolver(fileService);
                     break;
             }
 

--- a/src/AsmResolver.DotNet/Serialized/SerializedModuleDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedModuleDefinition.cs
@@ -75,7 +75,8 @@ namespace AsmResolver.DotNet.Serialized
             CorLibTypeFactory = CreateCorLibTypeFactory();
 
             OriginalTargetRuntime = DetectTargetRuntime();
-            MetadataResolver = new DefaultMetadataResolver(CreateAssemblyResolver());
+            MetadataResolver = new DefaultMetadataResolver(CreateAssemblyResolver(
+                readerParameters.PEReaderParameters.FileService));
 
             // Prepare lazy RID lists.
             _fieldLists = new LazyRidListRelation<TypeDefinitionRow>(metadata, TableIndex.TypeDef,

--- a/src/AsmResolver.DotNet/Signatures/DataBlobSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/DataBlobSignature.cs
@@ -46,7 +46,7 @@ namespace AsmResolver.DotNet.Signatures
         /// <returns>The deserialized literal.</returns>
         public object InterpretData(ElementType elementType)
         {
-            var reader = ByteArrayReaderFactory.CreateReader(Data);
+            var reader = ByteArrayInputFile.CreateReader(Data);
 
             return elementType switch
             {

--- a/src/AsmResolver.DotNet/Signatures/DataBlobSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/DataBlobSignature.cs
@@ -46,7 +46,7 @@ namespace AsmResolver.DotNet.Signatures
         /// <returns>The deserialized literal.</returns>
         public object InterpretData(ElementType elementType)
         {
-            var reader = ByteArrayInputFile.CreateReader(Data);
+            var reader = ByteArrayDataSource.CreateReader(Data);
 
             return elementType switch
             {

--- a/src/AsmResolver.PE.File/PEFile.cs
+++ b/src/AsmResolver.PE.File/PEFile.cs
@@ -108,7 +108,7 @@ namespace AsmResolver.PE.File
         /// <exception cref="BadImageFormatException">Occurs when the file does not follow the PE file format.</exception>
         public static PEFile FromFile(string path)
         {
-            var result = FromReader(ByteArrayReaderFactory.CreateReader(System.IO.File.ReadAllBytes(path)));
+            var result = FromReader(ByteArrayInputFile.CreateReader(System.IO.File.ReadAllBytes(path)));
             result.FilePath = path;
             return result;
         }
@@ -119,7 +119,7 @@ namespace AsmResolver.PE.File
         /// <param name="raw">The raw bytes representing the contents of the PE file to read.</param>
         /// <returns>The PE file that was read.</returns>
         /// <exception cref="BadImageFormatException">Occurs when the file does not follow the PE file format.</exception>
-        public static PEFile FromBytes(byte[] raw) => FromReader(ByteArrayReaderFactory.CreateReader(raw));
+        public static PEFile FromBytes(byte[] raw) => FromReader(ByteArrayInputFile.CreateReader(raw));
 
         /// <summary>
         /// Reads a PE file from the provided input stream.

--- a/src/AsmResolver.PE.File/PEFile.cs
+++ b/src/AsmResolver.PE.File/PEFile.cs
@@ -106,12 +106,7 @@ namespace AsmResolver.PE.File
         /// <param name="path">The file path to the PE file.</param>
         /// <returns>The PE file that was read.</returns>
         /// <exception cref="BadImageFormatException">Occurs when the file does not follow the PE file format.</exception>
-        public static PEFile FromFile(string path)
-        {
-            var result = FromReader(ByteArrayInputFile.CreateReader(System.IO.File.ReadAllBytes(path)));
-            result.FilePath = path;
-            return result;
-        }
+        public static PEFile FromFile(string path) => FromFile(UncachedFileService.Instance.OpenFile(path));
 
         /// <summary>
         /// Reads an unmapped PE file.
@@ -132,7 +127,7 @@ namespace AsmResolver.PE.File
         /// <param name="raw">The raw bytes representing the contents of the PE file to read.</param>
         /// <returns>The PE file that was read.</returns>
         /// <exception cref="BadImageFormatException">Occurs when the file does not follow the PE file format.</exception>
-        public static PEFile FromBytes(byte[] raw) => FromReader(ByteArrayInputFile.CreateReader(raw));
+        public static PEFile FromBytes(byte[] raw) => FromReader(ByteArrayDataSource.CreateReader(raw));
 
         /// <summary>
         /// Reads a PE file from the provided input stream.

--- a/src/AsmResolver.PE.File/PEFile.cs
+++ b/src/AsmResolver.PE.File/PEFile.cs
@@ -114,6 +114,19 @@ namespace AsmResolver.PE.File
         }
 
         /// <summary>
+        /// Reads an unmapped PE file.
+        /// </summary>
+        /// <param name="file">The file representing the PE.</param>
+        /// <returns>The PE file that was read.</returns>
+        /// <exception cref="BadImageFormatException">Occurs when the file does not follow the PE file format.</exception>
+        public static PEFile FromFile(IInputFile file)
+        {
+            var result = FromReader(file.CreateReader());
+            result.FilePath = file.FilePath;
+            return result;
+        }
+
+        /// <summary>
         /// Reads an unmapped PE file from memory.
         /// </summary>
         /// <param name="raw">The raw bytes representing the contents of the PE file to read.</param>

--- a/src/AsmResolver.PE/DotNet/Metadata/Blob/SerializedBlobStream.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Blob/SerializedBlobStream.cs
@@ -16,7 +16,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Blob
         /// <param name="name">The name of the stream.</param>
         /// <param name="rawData">The raw contents of the stream.</param>
         public SerializedBlobStream(string name, byte[] rawData)
-            : this(name, ByteArrayReaderFactory.CreateReader(rawData))
+            : this(name, ByteArrayInputFile.CreateReader(rawData))
         {
         }
 

--- a/src/AsmResolver.PE/DotNet/Metadata/Blob/SerializedBlobStream.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Blob/SerializedBlobStream.cs
@@ -16,7 +16,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Blob
         /// <param name="name">The name of the stream.</param>
         /// <param name="rawData">The raw contents of the stream.</param>
         public SerializedBlobStream(string name, byte[] rawData)
-            : this(name, ByteArrayInputFile.CreateReader(rawData))
+            : this(name, ByteArrayDataSource.CreateReader(rawData))
         {
         }
 

--- a/src/AsmResolver.PE/DotNet/Metadata/Guid/SerializedGuidStream.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Guid/SerializedGuidStream.cs
@@ -16,7 +16,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Guid
         /// <param name="name">The name of the stream.</param>
         /// <param name="rawData">The raw contents of the stream.</param>
         public SerializedGuidStream(string name, byte[] rawData)
-            : this(name, ByteArrayInputFile.CreateReader(rawData))
+            : this(name, ByteArrayDataSource.CreateReader(rawData))
         {
         }
 

--- a/src/AsmResolver.PE/DotNet/Metadata/Guid/SerializedGuidStream.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Guid/SerializedGuidStream.cs
@@ -16,7 +16,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Guid
         /// <param name="name">The name of the stream.</param>
         /// <param name="rawData">The raw contents of the stream.</param>
         public SerializedGuidStream(string name, byte[] rawData)
-            : this(name, ByteArrayReaderFactory.CreateReader(rawData))
+            : this(name, ByteArrayInputFile.CreateReader(rawData))
         {
         }
 

--- a/src/AsmResolver.PE/DotNet/Metadata/Strings/SerializedStringsStream.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Strings/SerializedStringsStream.cs
@@ -19,7 +19,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
         /// <param name="name">The name of the stream.</param>
         /// <param name="rawData">The raw contents of the stream.</param>
         public SerializedStringsStream(string name, byte[] rawData)
-            : this(name, ByteArrayInputFile.CreateReader(rawData))
+            : this(name, ByteArrayDataSource.CreateReader(rawData))
         {
         }
 

--- a/src/AsmResolver.PE/DotNet/Metadata/Strings/SerializedStringsStream.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Strings/SerializedStringsStream.cs
@@ -19,7 +19,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
         /// <param name="name">The name of the stream.</param>
         /// <param name="rawData">The raw contents of the stream.</param>
         public SerializedStringsStream(string name, byte[] rawData)
-            : this(name, ByteArrayReaderFactory.CreateReader(rawData))
+            : this(name, ByteArrayInputFile.CreateReader(rawData))
         {
         }
 

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/SerializedTableStream.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/SerializedTableStream.cs
@@ -27,7 +27,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables
         /// <param name="name">The name of the stream.</param>
         /// <param name="rawData">The raw contents of the stream.</param>
         public SerializedTableStream(PEReaderContext context, string name, byte[] rawData)
-            : this(context, name, ByteArrayInputFile.CreateReader(rawData))
+            : this(context, name, ByteArrayDataSource.CreateReader(rawData))
         {
         }
 

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/SerializedTableStream.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/SerializedTableStream.cs
@@ -27,7 +27,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables
         /// <param name="name">The name of the stream.</param>
         /// <param name="rawData">The raw contents of the stream.</param>
         public SerializedTableStream(PEReaderContext context, string name, byte[] rawData)
-            : this(context, name, ByteArrayReaderFactory.CreateReader(rawData))
+            : this(context, name, ByteArrayInputFile.CreateReader(rawData))
         {
         }
 

--- a/src/AsmResolver.PE/DotNet/Metadata/UserStrings/SerializedUserStringsStream.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/UserStrings/SerializedUserStringsStream.cs
@@ -19,7 +19,7 @@ namespace AsmResolver.PE.DotNet.Metadata.UserStrings
         /// <param name="name">The name of the stream.</param>
         /// <param name="rawData">The raw contents of the stream.</param>
         public SerializedUserStringsStream(string name, byte[] rawData)
-            : this(name, ByteArrayInputFile.CreateReader(rawData))
+            : this(name, ByteArrayDataSource.CreateReader(rawData))
         {
         }
 

--- a/src/AsmResolver.PE/DotNet/Metadata/UserStrings/SerializedUserStringsStream.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/UserStrings/SerializedUserStringsStream.cs
@@ -19,7 +19,7 @@ namespace AsmResolver.PE.DotNet.Metadata.UserStrings
         /// <param name="name">The name of the stream.</param>
         /// <param name="rawData">The raw contents of the stream.</param>
         public SerializedUserStringsStream(string name, byte[] rawData)
-            : this(name, ByteArrayReaderFactory.CreateReader(rawData))
+            : this(name, ByteArrayInputFile.CreateReader(rawData))
         {
         }
 

--- a/src/AsmResolver.PE/DotNet/StrongName/StrongNamePrivateKey.cs
+++ b/src/AsmResolver.PE/DotNet/StrongName/StrongNamePrivateKey.cs
@@ -22,7 +22,7 @@ namespace AsmResolver.PE.DotNet.StrongName
         /// <exception cref="NotSupportedException">Occurs when an invalid or unsupported algorithm is specified.</exception>
         public new static StrongNamePrivateKey FromFile(string path)
         {
-            var reader = ByteArrayInputFile.CreateReader(System.IO.File.ReadAllBytes(path));
+            var reader = ByteArrayDataSource.CreateReader(System.IO.File.ReadAllBytes(path));
             return FromReader(ref reader);
         }
 

--- a/src/AsmResolver.PE/DotNet/StrongName/StrongNamePrivateKey.cs
+++ b/src/AsmResolver.PE/DotNet/StrongName/StrongNamePrivateKey.cs
@@ -22,7 +22,7 @@ namespace AsmResolver.PE.DotNet.StrongName
         /// <exception cref="NotSupportedException">Occurs when an invalid or unsupported algorithm is specified.</exception>
         public new static StrongNamePrivateKey FromFile(string path)
         {
-            var reader = ByteArrayReaderFactory.CreateReader(System.IO.File.ReadAllBytes(path));
+            var reader = ByteArrayInputFile.CreateReader(System.IO.File.ReadAllBytes(path));
             return FromReader(ref reader);
         }
 

--- a/src/AsmResolver.PE/DotNet/StrongName/StrongNamePublicKey.cs
+++ b/src/AsmResolver.PE/DotNet/StrongName/StrongNamePublicKey.cs
@@ -24,7 +24,7 @@ namespace AsmResolver.PE.DotNet.StrongName
         /// <exception cref="NotSupportedException">Occurs when an invalid or unsupported algorithm is specified.</exception>
         public static StrongNamePublicKey FromFile(string path)
         {
-            var reader = ByteArrayInputFile.CreateReader(System.IO.File.ReadAllBytes(path));
+            var reader = ByteArrayDataSource.CreateReader(System.IO.File.ReadAllBytes(path));
             return FromReader(ref reader);
         }
 

--- a/src/AsmResolver.PE/DotNet/StrongName/StrongNamePublicKey.cs
+++ b/src/AsmResolver.PE/DotNet/StrongName/StrongNamePublicKey.cs
@@ -24,7 +24,7 @@ namespace AsmResolver.PE.DotNet.StrongName
         /// <exception cref="NotSupportedException">Occurs when an invalid or unsupported algorithm is specified.</exception>
         public static StrongNamePublicKey FromFile(string path)
         {
-            var reader = ByteArrayReaderFactory.CreateReader(System.IO.File.ReadAllBytes(path));
+            var reader = ByteArrayInputFile.CreateReader(System.IO.File.ReadAllBytes(path));
             return FromReader(ref reader);
         }
 

--- a/src/AsmResolver.PE/PEImage.cs
+++ b/src/AsmResolver.PE/PEImage.cs
@@ -43,7 +43,7 @@ namespace AsmResolver.PE
         /// <returns>The PE image that was opened.</returns>
         /// <exception cref="BadImageFormatException">Occurs when the file does not follow the PE file format.</exception>
         public static IPEImage FromFile(string filePath, PEReaderParameters readerParameters) =>
-            FromFile(PEFile.FromFile(filePath), readerParameters);
+            FromFile(PEFile.FromFile(readerParameters.FileService.OpenFile(filePath)), readerParameters);
 
         /// <summary>
         /// Opens a PE image from a buffer.
@@ -83,6 +83,15 @@ namespace AsmResolver.PE
         /// <exception cref="BadImageFormatException">Occurs when the file does not follow the PE file format.</exception>
         public static IPEImage FromReader(in BinaryStreamReader reader, PEMappingMode mode, PEReaderParameters readerParameters) =>
             FromFile(PEFile.FromReader(reader, mode), readerParameters);
+
+        /// <summary>
+        /// Opens a PE image from an input file object.
+        /// </summary>
+        /// <param name="inputFile">The file representing the PE.</param>
+        /// <returns>The PE image that was opened.</returns>
+        /// <exception cref="BadImageFormatException">Occurs when the file does not follow the PE file format.</exception>
+        public static IPEImage FromFile(IInputFile inputFile) =>
+            FromFile(PEFile.FromFile(inputFile), new PEReaderParameters());
 
         /// <summary>
         /// Opens a PE image from a PE file object.

--- a/src/AsmResolver.PE/PEReaderParameters.cs
+++ b/src/AsmResolver.PE/PEReaderParameters.cs
@@ -1,11 +1,12 @@
 using System;
+using AsmResolver.IO;
 using AsmResolver.PE.Debug;
 using AsmResolver.PE.DotNet.Metadata;
 
 namespace AsmResolver.PE
 {
     /// <summary>
-    /// Provides parameters for the reading process of a PE image. 
+    /// Provides parameters for the reading process of a PE image.
     /// </summary>
     public class PEReaderParameters
     {
@@ -54,5 +55,11 @@ namespace AsmResolver.PE
             get;
             set;
         }
+
+        public IFileService FileService
+        {
+            get;
+            set;
+        } = new ByteArrayFileService();
     }
 }

--- a/src/AsmResolver.PE/PEReaderParameters.cs
+++ b/src/AsmResolver.PE/PEReaderParameters.cs
@@ -56,10 +56,13 @@ namespace AsmResolver.PE
             set;
         }
 
+        /// <summary>
+        /// Gets the service to use for reading any additional files from the disk while reading the portable executable.
+        /// </summary>
         public IFileService FileService
         {
             get;
             set;
-        } = new ByteArrayFileService();
+        } = UncachedFileService.Instance;
     }
 }

--- a/src/AsmResolver/IO/ByteArrayDataSource.cs
+++ b/src/AsmResolver/IO/ByteArrayDataSource.cs
@@ -36,6 +36,14 @@ namespace AsmResolver.IO
         /// <inheritdoc />
         public ulong Length => (ulong) _data.Length;
 
+        /// <summary>
+        /// Constructs a new binary stream reader on the provided byte array.
+        /// </summary>
+        /// <param name="data">The byte array to read.</param>
+        /// <returns>The stream reader.</returns>
+        public static BinaryStreamReader CreateReader(byte[] data) =>
+            new(new ByteArrayDataSource(data), 0, 0, (uint) data.Length);
+
         /// <inheritdoc />
         public bool IsValidAddress(ulong address) => address - _baseAddress < (ulong) _data.Length;
 

--- a/src/AsmResolver/IO/ByteArrayFileService.cs
+++ b/src/AsmResolver/IO/ByteArrayFileService.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace AsmResolver.IO
+{
+    public class ByteArrayFileService : IFileService
+    {
+        private readonly Dictionary<string, ByteArrayInputFile> _files = new();
+
+        /// <inheritdoc />
+        public IEnumerable<string> GetOpenedFiles() => _files.Keys;
+
+        /// <inheritdoc />
+        public IInputFile OpenFile(string filePath)
+        {
+            if (!_files.TryGetValue(filePath, out var file))
+            {
+                file = new ByteArrayInputFile(filePath, File.ReadAllBytes(filePath), 0);
+                _files.Add(filePath, file);
+            }
+
+            return file;
+        }
+
+        /// <inheritdoc />
+        public void InvalidateFile(string filePath) => _files.Remove(filePath);
+
+        /// <inheritdoc />
+        void IDisposable.Dispose() => _files.Clear();
+    }
+}

--- a/src/AsmResolver/IO/ByteArrayFileService.cs
+++ b/src/AsmResolver/IO/ByteArrayFileService.cs
@@ -4,6 +4,11 @@ using System.IO;
 
 namespace AsmResolver.IO
 {
+    /// <summary>
+    /// Provides an implementation of a <see cref="IFileService"/> that uses instances of
+    /// <see cref="ByteArrayInputFile"/> to represent opened files, and keeps track of any of the instances
+    /// it creates.
+    /// </summary>
     public class ByteArrayFileService : IFileService
     {
         private readonly Dictionary<string, ByteArrayInputFile> _files = new();

--- a/src/AsmResolver/IO/ByteArrayFileService.cs
+++ b/src/AsmResolver/IO/ByteArrayFileService.cs
@@ -21,7 +21,7 @@ namespace AsmResolver.IO
         {
             if (!_files.TryGetValue(filePath, out var file))
             {
-                file = new ByteArrayInputFile(filePath, File.ReadAllBytes(filePath), 0);
+                file = new ByteArrayInputFile(filePath);
                 _files.Add(filePath, file);
             }
 

--- a/src/AsmResolver/IO/ByteArrayInputFile.cs
+++ b/src/AsmResolver/IO/ByteArrayInputFile.cs
@@ -20,6 +20,15 @@ namespace AsmResolver.IO
         }
 
         /// <summary>
+        /// Creates a new file for the provided raw contents.
+        /// </summary>
+        /// <param name="contents">The raw contents of the file.</param>
+        public ByteArrayInputFile(byte[] contents)
+            : this(null, contents, 0)
+        {
+        }
+
+        /// <summary>
         /// Creates a new file for the provided file path and raw contents.
         /// </summary>
         /// <param name="filePath">The file path.</param>

--- a/src/AsmResolver/IO/ByteArrayInputFile.cs
+++ b/src/AsmResolver/IO/ByteArrayInputFile.cs
@@ -5,7 +5,7 @@ namespace AsmResolver.IO
     /// <summary>
     /// Provides a mechanism to build binary stream readers from byte arrays.
     /// </summary>
-    public sealed class ByteArrayReaderFactory : IBinaryStreamReaderFactory
+    public sealed class ByteArrayInputFile : IInputFile
     {
         private readonly ByteArrayDataSource _dataSource;
 
@@ -14,13 +14,20 @@ namespace AsmResolver.IO
         /// </summary>
         /// <param name="data">The byte array to read from.</param>
         /// <param name="baseAddress">The base address to use.</param>
-        public ByteArrayReaderFactory(byte[] data, ulong baseAddress)
+        public ByteArrayInputFile(string filePath, byte[] data, ulong baseAddress)
         {
+            FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
             _dataSource = new ByteArrayDataSource(data, baseAddress);
         }
 
         /// <inheritdoc />
-        public uint MaxLength => (uint) _dataSource.Length;
+        public string FilePath
+        {
+            get;
+        }
+
+        /// <inheritdoc />
+        public uint Length => (uint) _dataSource.Length;
 
         /// <summary>
         /// Constructs a new binary stream reader on the provided byte array.

--- a/src/AsmResolver/IO/ByteArrayInputFile.cs
+++ b/src/AsmResolver/IO/ByteArrayInputFile.cs
@@ -49,14 +49,6 @@ namespace AsmResolver.IO
         /// <inheritdoc />
         public uint Length => (uint) _dataSource.Length;
 
-        /// <summary>
-        /// Constructs a new binary stream reader on the provided byte array.
-        /// </summary>
-        /// <param name="data">The byte array to read.</param>
-        /// <returns>The stream reader.</returns>
-        public static BinaryStreamReader CreateReader(byte[] data) =>
-            new(new ByteArrayDataSource(data), 0, 0, (uint) data.Length);
-
         /// <inheritdoc />
         public BinaryStreamReader CreateReader(ulong address, uint rva, uint length) =>
             new(_dataSource, address, rva, length);

--- a/src/AsmResolver/IO/ByteArrayInputFile.cs
+++ b/src/AsmResolver/IO/ByteArrayInputFile.cs
@@ -1,17 +1,28 @@
 using System;
+using System.IO;
 
 namespace AsmResolver.IO
 {
     /// <summary>
-    /// Provides a mechanism to build binary stream readers from byte arrays.
+    /// Represents a file for which the data is represented by a byte array.
     /// </summary>
     public sealed class ByteArrayInputFile : IInputFile
     {
         private readonly ByteArrayDataSource _dataSource;
 
         /// <summary>
-        /// Creates a new reader factory for the provided byte array.
+        /// Creates a new file for the provided file path.
         /// </summary>
+        /// <param name="filePath">The file path.</param>
+        public ByteArrayInputFile(string filePath)
+            : this(filePath, File.ReadAllBytes(filePath), 0)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new file for the provided file path and raw contents.
+        /// </summary>
+        /// <param name="filePath">The file path.</param>
         /// <param name="data">The byte array to read from.</param>
         /// <param name="baseAddress">The base address to use.</param>
         public ByteArrayInputFile(string filePath, byte[] data, ulong baseAddress)

--- a/src/AsmResolver/IO/ByteArrayInputFile.cs
+++ b/src/AsmResolver/IO/ByteArrayInputFile.cs
@@ -27,7 +27,7 @@ namespace AsmResolver.IO
         /// <param name="baseAddress">The base address to use.</param>
         public ByteArrayInputFile(string filePath, byte[] data, ulong baseAddress)
         {
-            FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+            FilePath = filePath;
             _dataSource = new ByteArrayDataSource(data, baseAddress);
         }
 

--- a/src/AsmResolver/IO/ByteArrayReaderFactory.cs
+++ b/src/AsmResolver/IO/ByteArrayReaderFactory.cs
@@ -19,6 +19,9 @@ namespace AsmResolver.IO
             _dataSource = new ByteArrayDataSource(data, baseAddress);
         }
 
+        /// <inheritdoc />
+        public uint MaxLength => (uint) _dataSource.Length;
+
         /// <summary>
         /// Constructs a new binary stream reader on the provided byte array.
         /// </summary>

--- a/src/AsmResolver/IO/IBinaryStreamReaderFactory.cs
+++ b/src/AsmResolver/IO/IBinaryStreamReaderFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 
 namespace AsmResolver.IO
 {
@@ -22,6 +23,8 @@ namespace AsmResolver.IO
         /// <param name="rva">The virtual address (relative to the image base) that is associated to the raw address.</param>
         /// <param name="length">The number of bytes to read.</param>
         /// <returns>The created reader.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Occurs if <paramref name="address"/> is not a valid address.</exception>
+        /// <exception cref="EndOfStreamException">Occurs if <paramref name="length"/> is too long.</exception>
         BinaryStreamReader CreateReader(ulong address, uint rva, uint length);
     }
 

--- a/src/AsmResolver/IO/IBinaryStreamReaderFactory.cs
+++ b/src/AsmResolver/IO/IBinaryStreamReaderFactory.cs
@@ -8,6 +8,14 @@ namespace AsmResolver.IO
     public interface IBinaryStreamReaderFactory : IDisposable
     {
         /// <summary>
+        /// Gets the maximum length a single binary stream reader produced by this factory can have.
+        /// </summary>
+        uint MaxLength
+        {
+            get;
+        }
+
+        /// <summary>
         /// Creates a new binary reader at the provided address.
         /// </summary>
         /// <param name="address">The raw address to start reading from.</param>
@@ -15,5 +23,11 @@ namespace AsmResolver.IO
         /// <param name="length">The number of bytes to read.</param>
         /// <returns>The created reader.</returns>
         BinaryStreamReader CreateReader(ulong address, uint rva, uint length);
+    }
+
+    public static class BinaryStreamReaderFactoryExtensions
+    {
+        public static BinaryStreamReader CreateReader(this IBinaryStreamReaderFactory factory)
+            => factory.CreateReader(0, 0, factory.MaxLength);
     }
 }

--- a/src/AsmResolver/IO/IBinaryStreamReaderFactory.cs
+++ b/src/AsmResolver/IO/IBinaryStreamReaderFactory.cs
@@ -25,8 +25,13 @@ namespace AsmResolver.IO
         BinaryStreamReader CreateReader(ulong address, uint rva, uint length);
     }
 
-    public static class BinaryStreamReaderFactoryExtensions
+    public static partial class IOExtensions
     {
+        /// <summary>
+        /// Creates a binary reader for the entire address space.
+        /// </summary>
+        /// <param name="factory">The factory to use.</param>
+        /// <returns>The constructed reader.</returns>
         public static BinaryStreamReader CreateReader(this IBinaryStreamReaderFactory factory)
             => factory.CreateReader(0, 0, factory.MaxLength);
     }

--- a/src/AsmResolver/IO/IBinaryStreamWriter.cs
+++ b/src/AsmResolver/IO/IBinaryStreamWriter.cs
@@ -95,9 +95,9 @@ namespace AsmResolver.IO
     }
 
     /// <summary>
-    /// Provides extension methods to implementations of the <see cref="IBinaryStreamWriter"/> interface.
+    /// Provides extension methods to various I/O interfaces in AsmResolver.
     /// </summary>
-    public static class BinaryStreamWriterExtensions
+    public static partial class IOExtensions
     {
         /// <summary>
         /// Writes a buffer of data to the stream.

--- a/src/AsmResolver/IO/IFileService.cs
+++ b/src/AsmResolver/IO/IFileService.cs
@@ -3,12 +3,33 @@ using System.Collections.Generic;
 
 namespace AsmResolver.IO
 {
+    /// <summary>
+    /// Provides members for opening and managing files for reading.
+    /// </summary>
+    /// <remarks>
+    /// The file service is the owner of any of the <see cref="IInputFile"/> objects it produces. Disposing an
+    /// instance of this interface results in all files opened by this service to be closed and disposed as well.
+    /// </remarks>
     public interface IFileService : IDisposable
     {
+        /// <summary>
+        /// Gets a collection of files currently opened by this file service.
+        /// </summary>
+        /// <returns>The paths of the files that were opened.</returns>
         IEnumerable<string> GetOpenedFiles();
 
+        /// <summary>
+        /// Opens a file at the provided file path.
+        /// </summary>
+        /// <param name="filePath">The path to the file to open.</param>
+        /// <returns>The opened file.</returns>
         IInputFile OpenFile(string filePath);
 
+        /// <summary>
+        /// If the provided file path was opened by this file service, closes the provided file and removes it from
+        /// the cache.
+        /// </summary>
+        /// <param name="filePath">The path of the file to close.</param>
         void InvalidateFile(string filePath);
     }
 }

--- a/src/AsmResolver/IO/IFileService.cs
+++ b/src/AsmResolver/IO/IFileService.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+
+namespace AsmResolver.IO
+{
+    public interface IFileService : IDisposable
+    {
+        IEnumerable<string> GetOpenedFiles();
+
+        IInputFile OpenFile(string filePath);
+
+        void InvalidateFile(string filePath);
+    }
+}

--- a/src/AsmResolver/IO/IInputFile.cs
+++ b/src/AsmResolver/IO/IInputFile.cs
@@ -6,12 +6,17 @@ namespace AsmResolver.IO
     /// <summary>
     /// Provides members for creating new binary streams.
     /// </summary>
-    public interface IBinaryStreamReaderFactory : IDisposable
+    public interface IInputFile : IDisposable
     {
+        string FilePath
+        {
+            get;
+        }
+
         /// <summary>
         /// Gets the maximum length a single binary stream reader produced by this factory can have.
         /// </summary>
-        uint MaxLength
+        uint Length
         {
             get;
         }
@@ -35,7 +40,7 @@ namespace AsmResolver.IO
         /// </summary>
         /// <param name="factory">The factory to use.</param>
         /// <returns>The constructed reader.</returns>
-        public static BinaryStreamReader CreateReader(this IBinaryStreamReaderFactory factory)
-            => factory.CreateReader(0, 0, factory.MaxLength);
+        public static BinaryStreamReader CreateReader(this IInputFile factory)
+            => factory.CreateReader(0, 0, factory.Length);
     }
 }

--- a/src/AsmResolver/IO/IInputFile.cs
+++ b/src/AsmResolver/IO/IInputFile.cs
@@ -4,7 +4,7 @@ using System.IO;
 namespace AsmResolver.IO
 {
     /// <summary>
-    /// Provides members for creating new binary streams.
+    /// Represents a file from which binary data can be read.
     /// </summary>
     public interface IInputFile : IDisposable
     {

--- a/src/AsmResolver/IO/IInputFile.cs
+++ b/src/AsmResolver/IO/IInputFile.cs
@@ -8,6 +8,9 @@ namespace AsmResolver.IO
     /// </summary>
     public interface IInputFile : IDisposable
     {
+        /// <summary>
+        /// Gets the path to the file on the disk, or null if this file was created from memory.
+        /// </summary>
         string FilePath
         {
             get;

--- a/src/AsmResolver/IO/MemoryMappedDataSource.cs
+++ b/src/AsmResolver/IO/MemoryMappedDataSource.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO.MemoryMappedFiles;
+
+namespace AsmResolver.IO
+{
+    /// <summary>
+    /// Represents a data source that obtains its data from a memory mapped file.
+    /// </summary>
+    public sealed class MemoryMappedDataSource : IDataSource, IDisposable
+    {
+        private readonly MemoryMappedViewAccessor _accessor;
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="MemoryMappedDataSource"/> class.
+        /// </summary>
+        /// <param name="accessor">The memory accessor to use.</param>
+        /// <param name="length">The length of the data.</param>
+        public MemoryMappedDataSource(MemoryMappedViewAccessor accessor, ulong length)
+        {
+            Length = length;
+            _accessor = accessor ?? throw new ArgumentNullException(nameof(accessor));
+        }
+
+        /// <inheritdoc />
+        public byte this[ulong address] => _accessor.ReadByte((long) address);
+
+        /// <inheritdoc />
+        public ulong Length
+        {
+            get;
+        }
+
+        /// <inheritdoc />
+        public bool IsValidAddress(ulong address) => address < Length;
+
+        /// <inheritdoc />
+        public int ReadBytes(ulong address, byte[] buffer, int index, int count) =>
+            _accessor.ReadArray((long) address, buffer, index, count);
+
+        /// <inheritdoc />
+        public void Dispose() => _accessor?.Dispose();
+    }
+}

--- a/src/AsmResolver/IO/MemoryMappedFileService.cs
+++ b/src/AsmResolver/IO/MemoryMappedFileService.cs
@@ -2,6 +2,10 @@ using System.Collections.Generic;
 
 namespace AsmResolver.IO
 {
+    /// <summary>
+    /// Provides an implementation of the <see cref="IFileService"/> interface, which maps any requested file into
+    /// memory, and keeps track of any of the instances it creates.
+    /// </summary>
     public class MemoryMappedFileService : IFileService
     {
         private readonly Dictionary<string, MemoryMappedInputFile> _files = new();

--- a/src/AsmResolver/IO/MemoryMappedFileService.cs
+++ b/src/AsmResolver/IO/MemoryMappedFileService.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+
+namespace AsmResolver.IO
+{
+    public class MemoryMappedFileService : IFileService
+    {
+        private readonly Dictionary<string, MemoryMappedInputFile> _files = new();
+
+        /// <inheritdoc />
+        public IEnumerable<string> GetOpenedFiles() => _files.Keys;
+
+        /// <inheritdoc />
+        public IInputFile OpenFile(string filePath)
+        {
+            if (!_files.TryGetValue(filePath, out var file))
+            {
+                file = new MemoryMappedInputFile(filePath);
+                _files.Add(filePath, file);
+            }
+
+            return file;
+        }
+
+        /// <inheritdoc />
+        public void InvalidateFile(string filePath)
+        {
+            if (_files.TryGetValue(filePath, out var file))
+            {
+                file.Dispose();
+                _files.Remove(filePath);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            foreach (var file in _files.Values)
+                file.Dispose();
+            _files.Clear();
+        }
+    }
+}

--- a/src/AsmResolver/IO/MemoryMappedInputFile.cs
+++ b/src/AsmResolver/IO/MemoryMappedInputFile.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.IO.MemoryMappedFiles;
 
@@ -6,7 +7,7 @@ namespace AsmResolver.IO
     /// <summary>
     /// Provides a factory for binary stream readers that operate on a memory mapped file.
     /// </summary>
-    public sealed class MemoryMappedReaderFactory : IBinaryStreamReaderFactory
+    public sealed class MemoryMappedInputFile : IInputFile
     {
         private readonly MemoryMappedFile _file;
         private readonly MemoryMappedDataSource _dataSource;
@@ -15,15 +16,22 @@ namespace AsmResolver.IO
         /// Creates a new reader factory for the provided file.
         /// </summary>
         /// <param name="filePath">The path to the file to read.</param>
-        public MemoryMappedReaderFactory(string filePath)
+        public MemoryMappedInputFile(string filePath)
         {
+            FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
             _file = MemoryMappedFile.CreateFromFile(filePath);
             long fileSize = new FileInfo(filePath).Length;
             _dataSource = new MemoryMappedDataSource(_file.CreateViewAccessor(0, fileSize), (ulong) fileSize);
         }
 
         /// <inheritdoc />
-        public uint MaxLength => (uint) _dataSource.Length;
+        public string FilePath
+        {
+            get;
+        }
+
+        /// <inheritdoc />
+        public uint Length => (uint) _dataSource.Length;
 
         /// <inheritdoc />
         public BinaryStreamReader CreateReader(ulong address, uint rva, uint length) =>

--- a/src/AsmResolver/IO/MemoryMappedInputFile.cs
+++ b/src/AsmResolver/IO/MemoryMappedInputFile.cs
@@ -5,7 +5,7 @@ using System.IO.MemoryMappedFiles;
 namespace AsmResolver.IO
 {
     /// <summary>
-    /// Provides a factory for binary stream readers that operate on a memory mapped file.
+    /// Represents an input file that is mapped in memory.
     /// </summary>
     public sealed class MemoryMappedInputFile : IInputFile
     {

--- a/src/AsmResolver/IO/MemoryMappedReaderFactory.cs
+++ b/src/AsmResolver/IO/MemoryMappedReaderFactory.cs
@@ -1,0 +1,39 @@
+using System.IO;
+using System.IO.MemoryMappedFiles;
+
+namespace AsmResolver.IO
+{
+    /// <summary>
+    /// Provides a factory for binary stream readers that operate on a memory mapped file.
+    /// </summary>
+    public sealed class MemoryMappedReaderFactory : IBinaryStreamReaderFactory
+    {
+        private readonly MemoryMappedFile _file;
+        private readonly MemoryMappedDataSource _dataSource;
+
+        /// <summary>
+        /// Creates a new reader factory for the provided file.
+        /// </summary>
+        /// <param name="filePath">The path to the file to read.</param>
+        public MemoryMappedReaderFactory(string filePath)
+        {
+            _file = MemoryMappedFile.CreateFromFile(filePath);
+            long fileSize = new FileInfo(filePath).Length;
+            _dataSource = new MemoryMappedDataSource(_file.CreateViewAccessor(0, fileSize), (ulong) fileSize);
+        }
+
+        /// <inheritdoc />
+        public uint MaxLength => (uint) _dataSource.Length;
+
+        /// <inheritdoc />
+        public BinaryStreamReader CreateReader(ulong address, uint rva, uint length) =>
+            new(_dataSource, address, rva, length);
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _file?.Dispose();
+            _dataSource?.Dispose();
+        }
+    }
+}

--- a/src/AsmResolver/IO/UncachedFileService.cs
+++ b/src/AsmResolver/IO/UncachedFileService.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace AsmResolver.IO
+{
+    public sealed class UncachedFileService : IFileService
+    {
+        public static UncachedFileService Instance
+        {
+            get;
+        } = new();
+
+        private UncachedFileService()
+        {
+        }
+
+        /// <inheritdoc />
+        IEnumerable<string> IFileService.GetOpenedFiles() => Enumerable.Empty<string>();
+
+        /// <inheritdoc />
+        public IInputFile OpenFile(string filePath) => new ByteArrayInputFile(filePath, File.ReadAllBytes(filePath), 0);
+
+        /// <inheritdoc />
+        void IFileService.InvalidateFile(string filePath)
+        {
+        }
+
+        /// <inheritdoc />
+        void IDisposable.Dispose()
+        {
+        }
+    }
+}

--- a/src/AsmResolver/IO/UncachedFileService.cs
+++ b/src/AsmResolver/IO/UncachedFileService.cs
@@ -5,8 +5,15 @@ using System.Linq;
 
 namespace AsmResolver.IO
 {
+    /// <summary>
+    /// Provides a basic singleton implementation of a <see cref="IFileService"/> that produces instances of the
+    /// <see cref="ByteArrayInputFile"/> class, and does no tracking and caching of any of the opened files.
+    /// </summary>
     public sealed class UncachedFileService : IFileService
     {
+        /// <summary>
+        /// Gets the singleton instance of the file service.
+        /// </summary>
         public static UncachedFileService Instance
         {
             get;
@@ -20,7 +27,7 @@ namespace AsmResolver.IO
         IEnumerable<string> IFileService.GetOpenedFiles() => Enumerable.Empty<string>();
 
         /// <inheritdoc />
-        public IInputFile OpenFile(string filePath) => new ByteArrayInputFile(filePath, File.ReadAllBytes(filePath), 0);
+        public IInputFile OpenFile(string filePath) => new ByteArrayInputFile(filePath);
 
         /// <inheritdoc />
         void IFileService.InvalidateFile(string filePath)

--- a/test/AsmResolver.DotNet.Tests/AssemblyDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/AssemblyDefinitionTest.cs
@@ -13,7 +13,7 @@ namespace AsmResolver.DotNet.Tests
         {
             using var stream = new MemoryStream();
             assembly.ManifestModule.Write(stream);
-            return AssemblyDefinition.FromReader(ByteArrayReaderFactory.CreateReader(stream.ToArray()));
+            return AssemblyDefinition.FromReader(ByteArrayInputFile.CreateReader(stream.ToArray()));
         }
 
         [Fact]

--- a/test/AsmResolver.DotNet.Tests/AssemblyDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/AssemblyDefinitionTest.cs
@@ -13,7 +13,7 @@ namespace AsmResolver.DotNet.Tests
         {
             using var stream = new MemoryStream();
             assembly.ManifestModule.Write(stream);
-            return AssemblyDefinition.FromReader(ByteArrayInputFile.CreateReader(stream.ToArray()));
+            return AssemblyDefinition.FromReader(ByteArrayDataSource.CreateReader(stream.ToArray()));
         }
 
         [Fact]

--- a/test/AsmResolver.DotNet.Tests/AssemblyResolverTest.cs
+++ b/test/AsmResolver.DotNet.Tests/AssemblyResolverTest.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using AsmResolver.DotNet.Config.Json;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.TestCases.NestedClasses;
+using AsmResolver.IO;
 using Xunit;
 
 namespace AsmResolver.DotNet.Tests
@@ -30,6 +31,24 @@ namespace AsmResolver.DotNet.Tests
             Assert.NotNull(assemblyDef);
             Assert.Equal(assemblyName.Name, assemblyDef.Name);
             Assert.NotNull(assemblyDef.ManifestModule.FilePath);
+        }
+
+        [Fact]
+        public void ResolveCorLibUsingFileService()
+        {
+            using var service = new ByteArrayFileService();
+
+            var assemblyName = typeof(object).Assembly.GetName();
+            var assemblyRef = new AssemblyReference(
+                assemblyName.Name,
+                assemblyName.Version,
+                false,
+                assemblyName.GetPublicKeyToken());
+
+            var resolver = new DotNetCoreAssemblyResolver(service, new Version(3, 1, 0));
+            Assert.Empty(service.GetOpenedFiles());
+            Assert.NotNull(resolver.Resolve(assemblyRef));
+            Assert.NotEmpty(service.GetOpenedFiles());
         }
 
         [Fact]

--- a/test/AsmResolver.DotNet.Tests/CustomAttributeTest.cs
+++ b/test/AsmResolver.DotNet.Tests/CustomAttributeTest.cs
@@ -37,7 +37,7 @@ namespace AsmResolver.DotNet.Tests
             using var stream = new MemoryStream();
             module.Write(stream);
 
-            module = ModuleDefinition.FromReader(ByteArrayReaderFactory.CreateReader(stream.ToArray()));
+            module = ModuleDefinition.FromReader(ByteArrayInputFile.CreateReader(stream.ToArray()));
 
             var type = module.TopLevelTypes.First(t => t.Name == nameof(CustomAttributesTestClass));
             Assert.All(type.CustomAttributes, a =>

--- a/test/AsmResolver.DotNet.Tests/CustomAttributeTest.cs
+++ b/test/AsmResolver.DotNet.Tests/CustomAttributeTest.cs
@@ -37,7 +37,7 @@ namespace AsmResolver.DotNet.Tests
             using var stream = new MemoryStream();
             module.Write(stream);
 
-            module = ModuleDefinition.FromReader(ByteArrayInputFile.CreateReader(stream.ToArray()));
+            module = ModuleDefinition.FromReader(ByteArrayDataSource.CreateReader(stream.ToArray()));
 
             var type = module.TopLevelTypes.First(t => t.Name == nameof(CustomAttributesTestClass));
             Assert.All(type.CustomAttributes, a =>

--- a/test/AsmResolver.DotNet.Tests/ModuleDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/ModuleDefinitionTest.cs
@@ -23,7 +23,7 @@ namespace AsmResolver.DotNet.Tests
         {
             using var stream = new MemoryStream();
             module.Write(stream);
-            return ModuleDefinition.FromReader(ByteArrayReaderFactory.CreateReader(stream.ToArray()));
+            return ModuleDefinition.FromReader(ByteArrayInputFile.CreateReader(stream.ToArray()));
         }
 
         [Fact]
@@ -242,7 +242,7 @@ namespace AsmResolver.DotNet.Tests
             // Write and rebuild.
             using var stream = new MemoryStream();
             module.Write(stream);
-            var newModule = ModuleDefinition.FromReader(ByteArrayReaderFactory.CreateReader(stream.ToArray()));
+            var newModule = ModuleDefinition.FromReader(ByteArrayInputFile.CreateReader(stream.ToArray()));
 
             // Assert contents.
             var newDirectory = (IResourceDirectory) newModule.NativeResourceDirectory.Entries

--- a/test/AsmResolver.DotNet.Tests/ModuleDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/ModuleDefinitionTest.cs
@@ -23,7 +23,7 @@ namespace AsmResolver.DotNet.Tests
         {
             using var stream = new MemoryStream();
             module.Write(stream);
-            return ModuleDefinition.FromReader(ByteArrayInputFile.CreateReader(stream.ToArray()));
+            return ModuleDefinition.FromReader(ByteArrayDataSource.CreateReader(stream.ToArray()));
         }
 
         [Fact]
@@ -242,7 +242,7 @@ namespace AsmResolver.DotNet.Tests
             // Write and rebuild.
             using var stream = new MemoryStream();
             module.Write(stream);
-            var newModule = ModuleDefinition.FromReader(ByteArrayInputFile.CreateReader(stream.ToArray()));
+            var newModule = ModuleDefinition.FromReader(ByteArrayDataSource.CreateReader(stream.ToArray()));
 
             // Assert contents.
             var newDirectory = (IResourceDirectory) newModule.NativeResourceDirectory.Entries

--- a/test/AsmResolver.DotNet.Tests/SecurityDeclarationTest.cs
+++ b/test/AsmResolver.DotNet.Tests/SecurityDeclarationTest.cs
@@ -16,7 +16,7 @@ namespace AsmResolver.DotNet.Tests
             {
                 var stream = new MemoryStream();
                 module.Write(stream);
-                module = ModuleDefinition.FromReader(ByteArrayInputFile.CreateReader(stream.ToArray()));
+                module = ModuleDefinition.FromReader(ByteArrayDataSource.CreateReader(stream.ToArray()));
             }
 
             var type = module.TopLevelTypes.First(t => t.Name == nameof(SecurityAttributes));

--- a/test/AsmResolver.DotNet.Tests/SecurityDeclarationTest.cs
+++ b/test/AsmResolver.DotNet.Tests/SecurityDeclarationTest.cs
@@ -16,7 +16,7 @@ namespace AsmResolver.DotNet.Tests
             {
                 var stream = new MemoryStream();
                 module.Write(stream);
-                module = ModuleDefinition.FromReader(ByteArrayReaderFactory.CreateReader(stream.ToArray()));
+                module = ModuleDefinition.FromReader(ByteArrayInputFile.CreateReader(stream.ToArray()));
             }
 
             var type = module.TopLevelTypes.First(t => t.Name == nameof(SecurityAttributes));

--- a/test/AsmResolver.DotNet.Tests/TypeDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/TypeDefinitionTest.cs
@@ -532,5 +532,19 @@ namespace AsmResolver.DotNet.Tests
             var corlibType = Assert.IsAssignableFrom<CorLibTypeSignature>(signature);
             Assert.Equal(ElementType.Object, corlibType.ElementType);
         }
+
+        [Fact]
+        public void InvalidMetadataLoopInBaseTypeShouldNotCrashIsValueType()
+        {
+            var module = new ModuleDefinition("Test");
+            var typeA = new TypeDefinition(null, "A", TypeAttributes.Public);
+            var typeB = new TypeDefinition(null, "B", TypeAttributes.Public, typeA);
+            typeA.BaseType = typeB;
+            module.TopLevelTypes.Add(typeA);
+            module.TopLevelTypes.Add(typeB);
+
+            Assert.False(typeB.IsValueType);
+            Assert.False(typeB.IsEnum);
+        }
     }
 }

--- a/test/AsmResolver.PE.Tests/DotNet/Metadata/FieldRvaDataReaderTest.cs
+++ b/test/AsmResolver.PE.Tests/DotNet/Metadata/FieldRvaDataReaderTest.cs
@@ -18,7 +18,7 @@ namespace AsmResolver.PE.Tests.DotNet.Metadata
                 .Body.CreateReader();
 
             var body = CilRawMethodBody.FromReader(ThrowErrorListener.Instance, ref reader);
-            var disassembler = new CilDisassembler(ByteArrayInputFile.CreateReader(body.Code));
+            var disassembler = new CilDisassembler(ByteArrayDataSource.CreateReader(body.Code));
 
             var initialValueFieldToken = MetadataToken.Zero;
 

--- a/test/AsmResolver.PE.Tests/DotNet/Metadata/FieldRvaDataReaderTest.cs
+++ b/test/AsmResolver.PE.Tests/DotNet/Metadata/FieldRvaDataReaderTest.cs
@@ -18,7 +18,7 @@ namespace AsmResolver.PE.Tests.DotNet.Metadata
                 .Body.CreateReader();
 
             var body = CilRawMethodBody.FromReader(ThrowErrorListener.Instance, ref reader);
-            var disassembler = new CilDisassembler(ByteArrayReaderFactory.CreateReader(body.Code));
+            var disassembler = new CilDisassembler(ByteArrayInputFile.CreateReader(body.Code));
 
             var initialValueFieldToken = MetadataToken.Zero;
 

--- a/test/AsmResolver.PE.Tests/DotNet/Metadata/MetadataTest.cs
+++ b/test/AsmResolver.PE.Tests/DotNet/Metadata/MetadataTest.cs
@@ -103,7 +103,7 @@ namespace AsmResolver.PE.Tests.DotNet.Metadata
             using var tempStream = new MemoryStream();
             metadata.Write(new BinaryStreamWriter(tempStream));
 
-            var reader = ByteArrayReaderFactory.CreateReader(tempStream.ToArray());
+            var reader = ByteArrayInputFile.CreateReader(tempStream.ToArray());
             var newMetadata = new SerializedMetadata(new PEReaderContext(peFile), ref reader);
 
             Assert.Equal(metadata.MajorVersion, newMetadata.MajorVersion);

--- a/test/AsmResolver.PE.Tests/DotNet/Metadata/MetadataTest.cs
+++ b/test/AsmResolver.PE.Tests/DotNet/Metadata/MetadataTest.cs
@@ -103,7 +103,7 @@ namespace AsmResolver.PE.Tests.DotNet.Metadata
             using var tempStream = new MemoryStream();
             metadata.Write(new BinaryStreamWriter(tempStream));
 
-            var reader = ByteArrayInputFile.CreateReader(tempStream.ToArray());
+            var reader = ByteArrayDataSource.CreateReader(tempStream.ToArray());
             var newMetadata = new SerializedMetadata(new PEReaderContext(peFile), ref reader);
 
             Assert.Equal(metadata.MajorVersion, newMetadata.MajorVersion);

--- a/test/AsmResolver.PE.Tests/DotNet/Metadata/Tables/Rows/RowTestUtils.cs
+++ b/test/AsmResolver.PE.Tests/DotNet/Metadata/Tables/Rows/RowTestUtils.cs
@@ -20,7 +20,7 @@ namespace AsmResolver.PE.Tests.DotNet.Metadata.Tables.Rows
 
             using var tempStream = new MemoryStream();
             expected.Write(new BinaryStreamWriter(tempStream), table.Layout);
-            var reader = ByteArrayReaderFactory.CreateReader(tempStream.ToArray());
+            var reader = ByteArrayInputFile.CreateReader(tempStream.ToArray());
             var newRow = readRow(ref reader, table.Layout);
 
             Assert.Equal(expected, newRow);
@@ -35,7 +35,7 @@ namespace AsmResolver.PE.Tests.DotNet.Metadata.Tables.Rows
 
             using var tempStream = new MemoryStream();
             expected.Write(new BinaryStreamWriter(tempStream), table.Layout);
-            var reader = ByteArrayReaderFactory.CreateReader(tempStream.ToArray());
+            var reader = ByteArrayInputFile.CreateReader(tempStream.ToArray());
             var newRow = readRow(new PEReaderContext(new PEFile()), ref reader, table.Layout);
 
             Assert.Equal(expected, newRow);

--- a/test/AsmResolver.PE.Tests/DotNet/Metadata/Tables/Rows/RowTestUtils.cs
+++ b/test/AsmResolver.PE.Tests/DotNet/Metadata/Tables/Rows/RowTestUtils.cs
@@ -20,7 +20,7 @@ namespace AsmResolver.PE.Tests.DotNet.Metadata.Tables.Rows
 
             using var tempStream = new MemoryStream();
             expected.Write(new BinaryStreamWriter(tempStream), table.Layout);
-            var reader = ByteArrayInputFile.CreateReader(tempStream.ToArray());
+            var reader = ByteArrayDataSource.CreateReader(tempStream.ToArray());
             var newRow = readRow(ref reader, table.Layout);
 
             Assert.Equal(expected, newRow);
@@ -35,7 +35,7 @@ namespace AsmResolver.PE.Tests.DotNet.Metadata.Tables.Rows
 
             using var tempStream = new MemoryStream();
             expected.Write(new BinaryStreamWriter(tempStream), table.Layout);
-            var reader = ByteArrayInputFile.CreateReader(tempStream.ToArray());
+            var reader = ByteArrayDataSource.CreateReader(tempStream.ToArray());
             var newRow = readRow(new PEReaderContext(new PEFile()), ref reader, table.Layout);
 
             Assert.Equal(expected, newRow);

--- a/test/AsmResolver.PE.Tests/DotNet/StrongName/StrongNamePublicKeyTest.cs
+++ b/test/AsmResolver.PE.Tests/DotNet/StrongName/StrongNamePublicKeyTest.cs
@@ -18,7 +18,7 @@ namespace AsmResolver.PE.Tests.DotNet.StrongName
             using var tempStream = new MemoryStream();
             publicKey.Write(new BinaryStreamWriter(tempStream));
 
-            var reader = ByteArrayReaderFactory.CreateReader(tempStream.ToArray());
+            var reader = ByteArrayInputFile.CreateReader(tempStream.ToArray());
             var newPublicKey = StrongNamePublicKey.FromReader(ref reader);
 
             Assert.Equal(publicKey.Modulus, newPublicKey.Modulus);

--- a/test/AsmResolver.PE.Tests/DotNet/StrongName/StrongNamePublicKeyTest.cs
+++ b/test/AsmResolver.PE.Tests/DotNet/StrongName/StrongNamePublicKeyTest.cs
@@ -18,7 +18,7 @@ namespace AsmResolver.PE.Tests.DotNet.StrongName
             using var tempStream = new MemoryStream();
             publicKey.Write(new BinaryStreamWriter(tempStream));
 
-            var reader = ByteArrayInputFile.CreateReader(tempStream.ToArray());
+            var reader = ByteArrayDataSource.CreateReader(tempStream.ToArray());
             var newPublicKey = StrongNamePublicKey.FromReader(ref reader);
 
             Assert.Equal(publicKey.Modulus, newPublicKey.Modulus);

--- a/test/AsmResolver.PE.Win32Resources.Tests/Version/VersionInfoResourceTest.cs
+++ b/test/AsmResolver.PE.Win32Resources.Tests/Version/VersionInfoResourceTest.cs
@@ -44,7 +44,7 @@ namespace AsmResolver.PE.Win32Resources.Tests.Version
             versionInfo.Write(new BinaryStreamWriter(tempStream));
 
             // Reload.
-            var infoReader = ByteArrayInputFile.CreateReader(tempStream.ToArray());
+            var infoReader = ByteArrayDataSource.CreateReader(tempStream.ToArray());
             var newVersionInfo = VersionInfoResource.FromReader(ref infoReader);
             var newFixedVersionInfo = newVersionInfo.FixedVersionInfo;
 
@@ -115,7 +115,7 @@ namespace AsmResolver.PE.Win32Resources.Tests.Version
             versionInfo.Write(new BinaryStreamWriter(tempStream));
 
             // Reload.
-            var infoReader = ByteArrayInputFile.CreateReader(tempStream.ToArray());
+            var infoReader = ByteArrayDataSource.CreateReader(tempStream.ToArray());
             var newVersionInfo = VersionInfoResource.FromReader(ref infoReader);
 
             // Verify.
@@ -150,7 +150,7 @@ namespace AsmResolver.PE.Win32Resources.Tests.Version
             versionInfo.Write(new BinaryStreamWriter(tempStream));
 
             // Reload.
-            var infoReader = ByteArrayInputFile.CreateReader(tempStream.ToArray());
+            var infoReader = ByteArrayDataSource.CreateReader(tempStream.ToArray());
             var newVersionInfo = VersionInfoResource.FromReader(ref infoReader);
 
             // Verify.

--- a/test/AsmResolver.PE.Win32Resources.Tests/Version/VersionInfoResourceTest.cs
+++ b/test/AsmResolver.PE.Win32Resources.Tests/Version/VersionInfoResourceTest.cs
@@ -44,7 +44,7 @@ namespace AsmResolver.PE.Win32Resources.Tests.Version
             versionInfo.Write(new BinaryStreamWriter(tempStream));
 
             // Reload.
-            var infoReader = ByteArrayReaderFactory.CreateReader(tempStream.ToArray());
+            var infoReader = ByteArrayInputFile.CreateReader(tempStream.ToArray());
             var newVersionInfo = VersionInfoResource.FromReader(ref infoReader);
             var newFixedVersionInfo = newVersionInfo.FixedVersionInfo;
 
@@ -115,7 +115,7 @@ namespace AsmResolver.PE.Win32Resources.Tests.Version
             versionInfo.Write(new BinaryStreamWriter(tempStream));
 
             // Reload.
-            var infoReader = ByteArrayReaderFactory.CreateReader(tempStream.ToArray());
+            var infoReader = ByteArrayInputFile.CreateReader(tempStream.ToArray());
             var newVersionInfo = VersionInfoResource.FromReader(ref infoReader);
 
             // Verify.
@@ -150,7 +150,7 @@ namespace AsmResolver.PE.Win32Resources.Tests.Version
             versionInfo.Write(new BinaryStreamWriter(tempStream));
 
             // Reload.
-            var infoReader = ByteArrayReaderFactory.CreateReader(tempStream.ToArray());
+            var infoReader = ByteArrayInputFile.CreateReader(tempStream.ToArray());
             var newVersionInfo = VersionInfoResource.FromReader(ref infoReader);
 
             // Verify.

--- a/test/AsmResolver.Tests/IO/BinaryStreamReaderTest.cs
+++ b/test/AsmResolver.Tests/IO/BinaryStreamReaderTest.cs
@@ -10,7 +10,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void EmptyArray()
         {
-            var reader = ByteArrayInputFile.CreateReader(new byte[0]);
+            var reader = ByteArrayDataSource.CreateReader(new byte[0]);
             Assert.Equal(0u, reader.Length);
 
             Assert.Throws<EndOfStreamException>(() => reader.ReadByte());
@@ -20,7 +20,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void ReadByte()
         {
-            var reader = ByteArrayInputFile.CreateReader(new byte[]
+            var reader = ByteArrayDataSource.CreateReader(new byte[]
             {
                 0x80,
                 0x80
@@ -36,7 +36,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void ReadInt16()
         {
-            var reader = ByteArrayInputFile.CreateReader(new byte[]
+            var reader = ByteArrayDataSource.CreateReader(new byte[]
             {
                 0x01, 0x80,
                 0x02, 0x80
@@ -51,7 +51,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void ReadInt32()
         {
-            var reader = ByteArrayInputFile.CreateReader(new byte[]
+            var reader = ByteArrayDataSource.CreateReader(new byte[]
             {
                 0x04, 0x03, 0x02, 0x81,
                 0x08, 0x07, 0x06, 0x85
@@ -67,7 +67,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void ReadInt64()
         {
-            var reader = ByteArrayInputFile.CreateReader(new byte[]
+            var reader = ByteArrayDataSource.CreateReader(new byte[]
             {
                 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x80,
                 0x0F, 0x0E, 0x0D, 0x0C, 0x0B, 0x0A, 0x09, 0x88,
@@ -82,7 +82,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void NewForkSubRange()
         {
-            var reader = ByteArrayInputFile.CreateReader(new byte[]
+            var reader = ByteArrayDataSource.CreateReader(new byte[]
             {
                 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
             });
@@ -97,7 +97,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void NewForkInvalidStart()
         {
-            var reader = ByteArrayInputFile.CreateReader(new byte[]
+            var reader = ByteArrayDataSource.CreateReader(new byte[]
             {
                 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
             });
@@ -108,7 +108,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void NewForkTooLong()
         {
-            var reader = ByteArrayInputFile.CreateReader(new byte[]
+            var reader = ByteArrayDataSource.CreateReader(new byte[]
             {
                 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
             });
@@ -119,7 +119,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void ForkReadsSameData()
         {
-            var reader = ByteArrayInputFile.CreateReader(new byte[]
+            var reader = ByteArrayDataSource.CreateReader(new byte[]
             {
                 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
             });
@@ -131,7 +131,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void ForkMovesIndependentOfOriginal()
         {
-            var reader = ByteArrayInputFile.CreateReader(new byte[]
+            var reader = ByteArrayDataSource.CreateReader(new byte[]
             {
                 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
             });
@@ -146,7 +146,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void ForkStartAtMiddle()
         {
-            var reader = ByteArrayInputFile.CreateReader(new byte[]
+            var reader = ByteArrayDataSource.CreateReader(new byte[]
             {
                 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
             });
@@ -158,7 +158,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void ForkOfFork()
         {
-            var reader = ByteArrayInputFile.CreateReader(new byte[]
+            var reader = ByteArrayDataSource.CreateReader(new byte[]
             {
                 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
             });

--- a/test/AsmResolver.Tests/IO/BinaryStreamReaderTest.cs
+++ b/test/AsmResolver.Tests/IO/BinaryStreamReaderTest.cs
@@ -10,7 +10,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void EmptyArray()
         {
-            var reader = ByteArrayReaderFactory.CreateReader(new byte[0]);
+            var reader = ByteArrayInputFile.CreateReader(new byte[0]);
             Assert.Equal(0u, reader.Length);
 
             Assert.Throws<EndOfStreamException>(() => reader.ReadByte());
@@ -20,7 +20,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void ReadByte()
         {
-            var reader = ByteArrayReaderFactory.CreateReader(new byte[]
+            var reader = ByteArrayInputFile.CreateReader(new byte[]
             {
                 0x80,
                 0x80
@@ -36,7 +36,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void ReadInt16()
         {
-            var reader = ByteArrayReaderFactory.CreateReader(new byte[]
+            var reader = ByteArrayInputFile.CreateReader(new byte[]
             {
                 0x01, 0x80,
                 0x02, 0x80
@@ -51,7 +51,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void ReadInt32()
         {
-            var reader = ByteArrayReaderFactory.CreateReader(new byte[]
+            var reader = ByteArrayInputFile.CreateReader(new byte[]
             {
                 0x04, 0x03, 0x02, 0x81,
                 0x08, 0x07, 0x06, 0x85
@@ -67,7 +67,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void ReadInt64()
         {
-            var reader = ByteArrayReaderFactory.CreateReader(new byte[]
+            var reader = ByteArrayInputFile.CreateReader(new byte[]
             {
                 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x80,
                 0x0F, 0x0E, 0x0D, 0x0C, 0x0B, 0x0A, 0x09, 0x88,
@@ -82,7 +82,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void NewForkSubRange()
         {
-            var reader = ByteArrayReaderFactory.CreateReader(new byte[]
+            var reader = ByteArrayInputFile.CreateReader(new byte[]
             {
                 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
             });
@@ -97,7 +97,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void NewForkInvalidStart()
         {
-            var reader = ByteArrayReaderFactory.CreateReader(new byte[]
+            var reader = ByteArrayInputFile.CreateReader(new byte[]
             {
                 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
             });
@@ -108,7 +108,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void NewForkTooLong()
         {
-            var reader = ByteArrayReaderFactory.CreateReader(new byte[]
+            var reader = ByteArrayInputFile.CreateReader(new byte[]
             {
                 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
             });
@@ -119,7 +119,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void ForkReadsSameData()
         {
-            var reader = ByteArrayReaderFactory.CreateReader(new byte[]
+            var reader = ByteArrayInputFile.CreateReader(new byte[]
             {
                 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
             });
@@ -131,7 +131,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void ForkMovesIndependentOfOriginal()
         {
-            var reader = ByteArrayReaderFactory.CreateReader(new byte[]
+            var reader = ByteArrayInputFile.CreateReader(new byte[]
             {
                 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
             });
@@ -146,7 +146,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void ForkStartAtMiddle()
         {
-            var reader = ByteArrayReaderFactory.CreateReader(new byte[]
+            var reader = ByteArrayInputFile.CreateReader(new byte[]
             {
                 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
             });
@@ -158,7 +158,7 @@ namespace AsmResolver.Tests.IO
         [Fact]
         public void ForkOfFork()
         {
-            var reader = ByteArrayReaderFactory.CreateReader(new byte[]
+            var reader = ByteArrayInputFile.CreateReader(new byte[]
             {
                 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
             });

--- a/test/AsmResolver.Tests/IO/MemoryMappedIOTest.cs
+++ b/test/AsmResolver.Tests/IO/MemoryMappedIOTest.cs
@@ -21,8 +21,8 @@ namespace AsmResolver.Tests.IO
             string tempPath = Path.Combine(_fixture.BasePath, "MemoryMappedIOTest_ReadShouldReturnFileContents.bin");
             File.WriteAllBytes(tempPath, contents);
 
-            using var factory = new MemoryMappedInputFile(tempPath);
-            var reader = factory.CreateReader();
+            using var service = new MemoryMappedFileService();
+            var reader = service.OpenFile(tempPath).CreateReader();
             Assert.Equal(contents, reader.ReadToEnd());
         }
 
@@ -33,8 +33,9 @@ namespace AsmResolver.Tests.IO
             string tempPath = Path.Combine(_fixture.BasePath, "MemoryMappedIOTest_ReadPastStreamShouldThrow.bin");
             File.WriteAllBytes(tempPath, contents);
 
-            using var factory = new MemoryMappedInputFile(tempPath);
-            Assert.Throws<EndOfStreamException>(() => factory.CreateReader(0, 0, (uint) (contents.Length + 1)));
+            using var service = new MemoryMappedFileService();
+            Assert.Throws<EndOfStreamException>(() =>
+                service.OpenFile(tempPath).CreateReader(0, 0, (uint) (contents.Length + 1)));
         }
     }
 }

--- a/test/AsmResolver.Tests/IO/MemoryMappedIOTest.cs
+++ b/test/AsmResolver.Tests/IO/MemoryMappedIOTest.cs
@@ -21,7 +21,7 @@ namespace AsmResolver.Tests.IO
             string tempPath = Path.Combine(_fixture.BasePath, "MemoryMappedIOTest_ReadShouldReturnFileContents.bin");
             File.WriteAllBytes(tempPath, contents);
 
-            using var factory = new MemoryMappedReaderFactory(tempPath);
+            using var factory = new MemoryMappedInputFile(tempPath);
             var reader = factory.CreateReader();
             Assert.Equal(contents, reader.ReadToEnd());
         }
@@ -33,7 +33,7 @@ namespace AsmResolver.Tests.IO
             string tempPath = Path.Combine(_fixture.BasePath, "MemoryMappedIOTest_ReadPastStreamShouldThrow.bin");
             File.WriteAllBytes(tempPath, contents);
 
-            using var factory = new MemoryMappedReaderFactory(tempPath);
+            using var factory = new MemoryMappedInputFile(tempPath);
             Assert.Throws<EndOfStreamException>(() => factory.CreateReader(0, 0, (uint) (contents.Length + 1)));
         }
     }

--- a/test/AsmResolver.Tests/IO/MemoryMappedIOTest.cs
+++ b/test/AsmResolver.Tests/IO/MemoryMappedIOTest.cs
@@ -1,0 +1,40 @@
+using System.IO;
+using AsmResolver.IO;
+using AsmResolver.Tests.Runners;
+using Xunit;
+
+namespace AsmResolver.Tests.IO
+{
+    public class MemoryMappedIOTest : IClassFixture<TemporaryDirectoryFixture>
+    {
+        private readonly TemporaryDirectoryFixture _fixture;
+
+        public MemoryMappedIOTest(TemporaryDirectoryFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public void ReadShouldReturnFileContents()
+        {
+            byte[] contents = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
+            string tempPath = Path.Combine(_fixture.BasePath, "MemoryMappedIOTest_ReadShouldReturnFileContents.bin");
+            File.WriteAllBytes(tempPath, contents);
+
+            using var factory = new MemoryMappedReaderFactory(tempPath);
+            var reader = factory.CreateReader();
+            Assert.Equal(contents, reader.ReadToEnd());
+        }
+
+        [Fact]
+        public void CreateReaderPastStreamShouldThrow()
+        {
+            byte[] contents = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
+            string tempPath = Path.Combine(_fixture.BasePath, "MemoryMappedIOTest_ReadPastStreamShouldThrow.bin");
+            File.WriteAllBytes(tempPath, contents);
+
+            using var factory = new MemoryMappedReaderFactory(tempPath);
+            Assert.Throws<EndOfStreamException>(() => factory.CreateReader(0, 0, (uint) (contents.Length + 1)));
+        }
+    }
+}


### PR DESCRIPTION
Adds `IFileService` that is used to abstract away the way files are opened and read from the disk. This allows for reading files using either simple byte arrays, or more advanced memory mapped files.

Closes #115.