### PR TITLE
UTF-8 strings

### DIFF
--- a/src/AsmResolver.DotNet/AssemblyDescriptor.cs
+++ b/src/AsmResolver.DotNet/AssemblyDescriptor.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
 using AsmResolver.Collections;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 

--- a/src/AsmResolver.DotNet/AssemblyResolverBase.cs
+++ b/src/AsmResolver.DotNet/AssemblyResolverBase.cs
@@ -1,7 +1,7 @@
-using AsmResolver.DotNet.Signatures;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using AsmResolver.DotNet.Signatures;
 using AsmResolver.IO;
 
 namespace AsmResolver.DotNet

--- a/src/AsmResolver.DotNet/Collections/Parameter.cs
+++ b/src/AsmResolver.DotNet/Collections/Parameter.cs
@@ -74,16 +74,16 @@ namespace AsmResolver.DotNet.Collections
         public ParameterDefinition? Definition => _parentCollection?.GetParameterDefinition(Sequence);
 
         /// <inheritdoc />
-        public string Name => Definition?.Name ?? GetArgumentName(MethodSignatureIndex);
+        public string Name => Definition?.Name ?? GetDummyArgumentName(MethodSignatureIndex);
 
         [SuppressMessage("ReSharper", "InconsistentlySynchronizedField")]
-        private static string GetArgumentName(int index)
+        private static string GetDummyArgumentName(int index)
         {
             if (index >= CachedArgNames.Count)
             {
                 lock (CachedArgNames)
                 {
-                    while (index > CachedArgNames.Count)
+                    while (index >= CachedArgNames.Count)
                         CachedArgNames.Add($"A_{CachedArgNames.Count.ToString()}");
                 }
             }

--- a/src/AsmResolver.DotNet/EventDefinition.cs
+++ b/src/AsmResolver.DotNet/EventDefinition.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.DotNet.Collections;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 

--- a/src/AsmResolver.DotNet/EventDefinition.cs
+++ b/src/AsmResolver.DotNet/EventDefinition.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.DotNet.Collections;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
@@ -17,7 +18,7 @@ namespace AsmResolver.DotNet
         IHasCustomAttribute,
         IOwnedCollectionElement<TypeDefinition>
     {
-        private readonly LazyVariable<string?> _name;
+        private readonly LazyVariable<Utf8String?> _name;
         private readonly LazyVariable<TypeDefinition?> _declaringType;
         private readonly LazyVariable<ITypeDefOrRef?> _eventType;
         private IList<MethodSemantics>? _semantics;
@@ -30,7 +31,7 @@ namespace AsmResolver.DotNet
         protected EventDefinition(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<string?>(GetName);
+            _name = new LazyVariable<Utf8String?>(() => GetName());
             _eventType = new LazyVariable<ITypeDefOrRef?>(GetEventType);
             _declaringType = new LazyVariable<TypeDefinition?>(GetDeclaringType);
         }
@@ -78,12 +79,19 @@ namespace AsmResolver.DotNet
                                 | (value ? EventAttributes.RtSpecialName : 0);
         }
 
-        /// <inheritdoc />
-        public string? Name
+        /// <summary>
+        /// Gets or sets the name of the event.
+        /// </summary>
+        /// <remarks>
+        /// This property corresponds to the Name column in the event table.
+        /// </remarks>
+        public Utf8String? Name
         {
             get => _name.Value;
             set => _name.Value = value;
         }
+
+        string? INameProvider.Name => Name;
 
         /// <inheritdoc />
         public string FullName => FullNameGenerator.GetEventFullName(Name, DeclaringType, EventType);
@@ -180,7 +188,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="Name"/> property.
         /// </remarks>
-        protected virtual string? GetName() => null;
+        protected virtual Utf8String? GetName() => null;
 
         /// <summary>
         /// Obtains the event type of the property definition.

--- a/src/AsmResolver.DotNet/ExportedType.cs
+++ b/src/AsmResolver.DotNet/ExportedType.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.DotNet.Signatures.Types;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
@@ -16,8 +17,8 @@ namespace AsmResolver.DotNet
         ITypeDescriptor,
         IOwnedCollectionElement<ModuleDefinition>
     {
-        private readonly LazyVariable<string?> _name;
-        private readonly LazyVariable<string?> _namespace;
+        private readonly LazyVariable<Utf8String?> _name;
+        private readonly LazyVariable<Utf8String?> _namespace;
         private readonly LazyVariable<IImplementation?> _implementation;
         private IList<CustomAttribute>? _customAttributes;
 
@@ -28,8 +29,8 @@ namespace AsmResolver.DotNet
         protected ExportedType(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<string?>(GetName);
-            _namespace = new LazyVariable<string?>(GetNamespace);
+            _name = new LazyVariable<Utf8String?>(() => GetName());
+            _namespace = new LazyVariable<Utf8String?>(() => GetNamespace());
             _implementation = new LazyVariable<IImplementation?>(GetImplementation);
         }
 
@@ -65,19 +66,33 @@ namespace AsmResolver.DotNet
             set;
         }
 
-        /// <inheritdoc />
-        public string? Name
+        /// <summary>
+        /// Gets or sets the name of the type.
+        /// </summary>
+        /// <remarks>
+        /// This property corresponds to the Name column in the exported type table.
+        /// </remarks>
+        public Utf8String? Name
         {
             get => _name.Value;
             set => _name.Value = value;
         }
 
-        /// <inheritdoc />
-        public string? Namespace
+        string? INameProvider.Name => Name;
+
+        /// <summary>
+        /// Gets or sets the namespace of the type.
+        /// </summary>
+        /// <remarks>
+        /// This property corresponds to the Namespace column in the exported type table.
+        /// </remarks>
+        public Utf8String? Namespace
         {
             get => _namespace.Value;
             set => _namespace.Value = value;
         }
+
+        string? ITypeDescriptor.Namespace => Namespace;
 
         /// <inheritdoc />
         public string FullName => this.GetTypeFullName();
@@ -146,7 +161,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="Namespace"/> property.
         /// </remarks>
-        protected virtual string? GetNamespace() => null;
+        protected virtual Utf8String? GetNamespace() => null;
 
         /// <summary>
         /// Obtains the name of the exported type.
@@ -155,7 +170,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="Name"/> property.
         /// </remarks>
-        protected virtual string? GetName() => null;
+        protected virtual Utf8String? GetName() => null;
 
         /// <summary>
         /// Obtains the implementation of the exported type.

--- a/src/AsmResolver.DotNet/ExportedType.cs
+++ b/src/AsmResolver.DotNet/ExportedType.cs
@@ -2,7 +2,6 @@
 using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.DotNet.Signatures.Types;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 

--- a/src/AsmResolver.DotNet/FieldDefinition.cs
+++ b/src/AsmResolver.DotNet/FieldDefinition.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Marshal;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
@@ -22,7 +23,7 @@ namespace AsmResolver.DotNet
         IHasFieldMarshal,
         IOwnedCollectionElement<TypeDefinition>
     {
-        private readonly LazyVariable<string?> _name;
+        private readonly LazyVariable<Utf8String?> _name;
         private readonly LazyVariable<FieldSignature?> _signature;
         private readonly LazyVariable<TypeDefinition?> _declaringType;
         private readonly LazyVariable<Constant?> _constant;
@@ -40,7 +41,7 @@ namespace AsmResolver.DotNet
         protected FieldDefinition(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<string?>(GetName);
+            _name = new LazyVariable<Utf8String?>(() => GetName());
             _signature = new LazyVariable<FieldSignature?>(GetSignature);
             _declaringType = new LazyVariable<TypeDefinition?>(GetDeclaringType);
             _constant = new LazyVariable<Constant?>(GetConstant);
@@ -69,12 +70,19 @@ namespace AsmResolver.DotNet
             Signature = signature;
         }
 
-        /// <inheritdoc />
-        public string? Name
+        /// <summary>
+        /// Gets or sets the name of the field.
+        /// </summary>
+        /// <remarks>
+        /// This property corresponds to the Name column in the field table.
+        /// </remarks>
+        public Utf8String? Name
         {
             get => _name.Value;
             set => _name.Value = value;
         }
+
+        string? INameProvider.Name => Name;
 
         /// <summary>
         /// Gets or sets the signature of the field. This includes the field type.
@@ -401,7 +409,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="Name"/> property.
         /// </remarks>
-        protected virtual string? GetName() => null;
+        protected virtual Utf8String? GetName() => null;
 
         /// <summary>
         /// Obtains the signature of the field definition.

--- a/src/AsmResolver.DotNet/FieldDefinition.cs
+++ b/src/AsmResolver.DotNet/FieldDefinition.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Marshal;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 

--- a/src/AsmResolver.DotNet/FileReference.cs
+++ b/src/AsmResolver.DotNet/FileReference.cs
@@ -27,7 +27,7 @@ namespace AsmResolver.DotNet
         protected FileReference(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(() => GetName());
+            _name = new LazyVariable<Utf8String?>(GetName);
             _hashValue = new LazyVariable<byte[]?>(GetHashValue);
         }
 

--- a/src/AsmResolver.DotNet/FileReference.cs
+++ b/src/AsmResolver.DotNet/FileReference.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using AsmResolver.Collections;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
@@ -15,7 +16,7 @@ namespace AsmResolver.DotNet
         IManagedEntrypoint,
         IOwnedCollectionElement<ModuleDefinition>
     {
-        private readonly LazyVariable<string?> _name;
+        private readonly LazyVariable<Utf8String?> _name;
         private readonly LazyVariable<byte[]?> _hashValue;
         private IList<CustomAttribute>? _customAttributes;
 
@@ -26,7 +27,7 @@ namespace AsmResolver.DotNet
         protected FileReference(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<string?>(GetName);
+            _name = new LazyVariable<Utf8String?>(() => GetName());
             _hashValue = new LazyVariable<byte[]?>(GetHashValue);
         }
 
@@ -70,12 +71,19 @@ namespace AsmResolver.DotNet
                                 | (value ? FileAttributes.ContainsNoMetadata : 0);
         }
 
-        /// <inheritdoc />
-        public string? Name
+        /// <summary>
+        /// Gets or sets the name of the file.
+        /// </summary>
+        /// <remarks>
+        /// This property corresponds to the Name column in the file table.
+        /// </remarks>
+        public Utf8String? Name
         {
             get => _name.Value;
             set => _name.Value = value;
         }
+
+        string? INameProvider.Name => Name;
 
         /// <inheritdoc />
         public string FullName => Name ?? NullName;
@@ -120,7 +128,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initializing the <see cref="Name"/> property.
         /// </remarks>
-        protected virtual string? GetName() => null;
+        protected virtual Utf8String? GetName() => null;
 
         /// <summary>
         /// Obtains the hash of the referenced file.

--- a/src/AsmResolver.DotNet/FileReference.cs
+++ b/src/AsmResolver.DotNet/FileReference.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using AsmResolver.Collections;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 

--- a/src/AsmResolver.DotNet/GenericParameter.cs
+++ b/src/AsmResolver.DotNet/GenericParameter.cs
@@ -29,7 +29,7 @@ namespace AsmResolver.DotNet
         protected GenericParameter(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(() => GetName());
+            _name = new LazyVariable<Utf8String?>(GetName);
             _owner = new LazyVariable<IHasGenericParameters?>(GetOwner);
         }
 

--- a/src/AsmResolver.DotNet/GenericParameter.cs
+++ b/src/AsmResolver.DotNet/GenericParameter.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using AsmResolver.Collections;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
@@ -16,7 +17,7 @@ namespace AsmResolver.DotNet
         IModuleProvider,
         IOwnedCollectionElement<IHasGenericParameters>
     {
-        private readonly LazyVariable<string?> _name;
+        private readonly LazyVariable<Utf8String?> _name;
         private readonly LazyVariable<IHasGenericParameters?> _owner;
         private IList<GenericParameterConstraint>? _constraints;
         private IList<CustomAttribute>? _customAttributes;
@@ -28,7 +29,7 @@ namespace AsmResolver.DotNet
         protected GenericParameter(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<string?>(GetName);
+            _name = new LazyVariable<Utf8String?>(() => GetName());
             _owner = new LazyVariable<IHasGenericParameters?>(GetOwner);
         }
 
@@ -69,12 +70,19 @@ namespace AsmResolver.DotNet
             set => Owner = value;
         }
 
-        /// <inheritdoc />
-        public string? Name
+        /// <summary>
+        /// Gets or sets the name of the generic parameter.
+        /// </summary>
+        /// <remarks>
+        /// This property corresponds to the Name column in the generic parameter table.
+        /// </remarks>
+        public Utf8String? Name
         {
             get => _name.Value;
             set => _name.Value = value;
         }
+
+        string? INameProvider.Name => Name;
 
         /// <summary>
         /// Gets or sets additional attributes assigned to this generic parameter.
@@ -124,7 +132,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="Name"/> property.
         /// </remarks>
-        protected virtual string? GetName() => null;
+        protected virtual Utf8String? GetName() => null;
 
         /// <summary>
         /// Obtains the owner of the generic parameter.

--- a/src/AsmResolver.DotNet/GenericParameter.cs
+++ b/src/AsmResolver.DotNet/GenericParameter.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using AsmResolver.Collections;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 

--- a/src/AsmResolver.DotNet/GenericParameterConstraint.cs
+++ b/src/AsmResolver.DotNet/GenericParameterConstraint.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using AsmResolver.Collections;

--- a/src/AsmResolver.DotNet/IHasFieldMarshal.cs
+++ b/src/AsmResolver.DotNet/IHasFieldMarshal.cs
@@ -1,4 +1,3 @@
-using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Marshal;
 
 namespace AsmResolver.DotNet

--- a/src/AsmResolver.DotNet/INameProvider.cs
+++ b/src/AsmResolver.DotNet/INameProvider.cs
@@ -1,5 +1,3 @@
-using AsmResolver.PE.DotNet.Metadata.Strings;
-
 namespace AsmResolver.DotNet
 {
     /// <summary>

--- a/src/AsmResolver.DotNet/INameProvider.cs
+++ b/src/AsmResolver.DotNet/INameProvider.cs
@@ -1,3 +1,5 @@
+using AsmResolver.PE.DotNet.Metadata.Strings;
+
 namespace AsmResolver.DotNet
 {
     /// <summary>

--- a/src/AsmResolver.DotNet/ITypeDefOrRef.cs
+++ b/src/AsmResolver.DotNet/ITypeDefOrRef.cs
@@ -1,5 +1,3 @@
-using AsmResolver.PE.DotNet.Metadata.Strings;
-
 namespace AsmResolver.DotNet
 {
     /// <summary>

--- a/src/AsmResolver.DotNet/ITypeDefOrRef.cs
+++ b/src/AsmResolver.DotNet/ITypeDefOrRef.cs
@@ -1,12 +1,28 @@
-using AsmResolver.DotNet.Signatures;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 
 namespace AsmResolver.DotNet
 {
     /// <summary>
-    /// Represents a type definition or reference that can be referenced by a TypeDefOrRef coded index. 
+    /// Represents a type definition or reference that can be referenced by a TypeDefOrRef coded index.
     /// </summary>
     public interface ITypeDefOrRef : ITypeDescriptor, IMemberRefParent, IHasCustomAttribute
     {
+        /// <summary>
+        /// Gets the name of the type.
+        /// </summary>
+        new Utf8String? Name
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Gets the namespace the type resides in.
+        /// </summary>
+        new Utf8String? Namespace
+        {
+            get;
+        }
+
         /// <summary>
         /// When this type is nested, gets the enclosing type.
         /// </summary>

--- a/src/AsmResolver.DotNet/ITypeDescriptor.cs
+++ b/src/AsmResolver.DotNet/ITypeDescriptor.cs
@@ -1,5 +1,6 @@
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Types;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 
 namespace AsmResolver.DotNet
 {

--- a/src/AsmResolver.DotNet/ITypeDescriptor.cs
+++ b/src/AsmResolver.DotNet/ITypeDescriptor.cs
@@ -1,6 +1,4 @@
-using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Types;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 
 namespace AsmResolver.DotNet
 {

--- a/src/AsmResolver.DotNet/ImplementationMap.cs
+++ b/src/AsmResolver.DotNet/ImplementationMap.cs
@@ -21,7 +21,7 @@ namespace AsmResolver.DotNet
         protected ImplementationMap(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(() => GetName());
+            _name = new LazyVariable<Utf8String?>(GetName);
             _scope = new LazyVariable<ModuleReference?>(GetScope);
             _memberForwarded = new LazyVariable<IMemberForwarded?>(GetMemberForwarded);
         }

--- a/src/AsmResolver.DotNet/ImplementationMap.cs
+++ b/src/AsmResolver.DotNet/ImplementationMap.cs
@@ -1,4 +1,3 @@
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 

--- a/src/AsmResolver.DotNet/ImplementationMap.cs
+++ b/src/AsmResolver.DotNet/ImplementationMap.cs
@@ -1,3 +1,4 @@
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
@@ -9,7 +10,7 @@ namespace AsmResolver.DotNet
     /// </summary>
     public class ImplementationMap : MetadataMember, IFullNameProvider
     {
-        private readonly LazyVariable<string?> _name;
+        private readonly LazyVariable<Utf8String?> _name;
         private readonly LazyVariable<ModuleReference?> _scope;
         private readonly LazyVariable<IMemberForwarded?> _memberForwarded;
 
@@ -20,7 +21,7 @@ namespace AsmResolver.DotNet
         protected ImplementationMap(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<string?>(GetName);
+            _name = new LazyVariable<Utf8String?>(() => GetName());
             _scope = new LazyVariable<ModuleReference?>(GetScope);
             _memberForwarded = new LazyVariable<IMemberForwarded?>(GetMemberForwarded);
         }
@@ -57,12 +58,19 @@ namespace AsmResolver.DotNet
             internal set => _memberForwarded.Value = value;
         }
 
-        /// <inheritdoc />
-        public string? Name
+        /// <summary>
+        /// Gets or sets the name of the map.
+        /// </summary>
+        /// <remarks>
+        /// This property corresponds to the Name column in the implementation map table.
+        /// </remarks>
+        public Utf8String? Name
         {
             get => _name.Value;
             set => _name.Value = value;
         }
+
+        string? INameProvider.Name => Name;
 
         /// <inheritdoc />
         public string FullName => Scope is null
@@ -85,7 +93,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="Name"/> property.
         /// </remarks>
-        protected virtual string? GetName() => null;
+        protected virtual Utf8String? GetName() => null;
 
         /// <summary>
         /// Obtains the scope that declares the imported member.

--- a/src/AsmResolver.DotNet/InvalidTypeDefOrRef.cs
+++ b/src/AsmResolver.DotNet/InvalidTypeDefOrRef.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using AsmResolver.DotNet.Signatures.Types;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
 namespace AsmResolver.DotNet

--- a/src/AsmResolver.DotNet/KnownCorLibs.cs
+++ b/src/AsmResolver.DotNet/KnownCorLibs.cs
@@ -147,7 +147,7 @@ namespace AsmResolver.DotNet
                 SystemPrivateCoreLib_v5_0_0_0
             };
 
-            KnownCorLibNames = new HashSet<string>(KnownCorLibReferences.Select(r => r.Name!));
+            KnownCorLibNames = new HashSet<string>(KnownCorLibReferences.Select(r => r.Name!.Value));
         }
     }
 }

--- a/src/AsmResolver.DotNet/ManifestResource.cs
+++ b/src/AsmResolver.DotNet/ManifestResource.cs
@@ -30,7 +30,7 @@ namespace AsmResolver.DotNet
         protected ManifestResource(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(() => GetName());
+            _name = new LazyVariable<Utf8String?>(GetName);
             _implementation = new LazyVariable<IImplementation?>(GetImplementation);
             _embeddedData = new LazyVariable<ISegment?>(GetEmbeddedDataSegment);
         }

--- a/src/AsmResolver.DotNet/ManifestResource.cs
+++ b/src/AsmResolver.DotNet/ManifestResource.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.IO;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
@@ -17,7 +18,7 @@ namespace AsmResolver.DotNet
         IHasCustomAttribute,
         IOwnedCollectionElement<ModuleDefinition>
     {
-        private readonly LazyVariable<string?> _name;
+        private readonly LazyVariable<Utf8String?> _name;
         private readonly LazyVariable<IImplementation?> _implementation;
         private readonly LazyVariable<ISegment?> _embeddedData;
         private IList<CustomAttribute>? _customAttributes;
@@ -29,7 +30,7 @@ namespace AsmResolver.DotNet
         protected ManifestResource(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<string?>(GetName);
+            _name = new LazyVariable<Utf8String?>(() => GetName());
             _implementation = new LazyVariable<IImplementation?>(GetImplementation);
             _embeddedData = new LazyVariable<ISegment?>(GetEmbeddedDataSegment);
         }
@@ -101,12 +102,19 @@ namespace AsmResolver.DotNet
             set => Attributes = value ? ManifestResourceAttributes.Private : ManifestResourceAttributes.Public;
         }
 
-        /// <inheritdoc />
-        public string? Name
+        /// <summary>
+        /// Gets or sets the name of the manifest resource.
+        /// </summary>
+        /// <remarks>
+        /// This property corresponds to the Name column in the manifest resource table.
+        /// </remarks>
+        public Utf8String? Name
         {
             get => _name.Value;
             set => _name.Value = value;
         }
+
+        string? INameProvider.Name => Name;
 
         /// <summary>
         /// Gets or sets the implementation indicating the file containing the resource data.
@@ -191,7 +199,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="Name"/> property.
         /// </remarks>
-        protected virtual string? GetName() => null;
+        protected virtual Utf8String? GetName() => null;
 
         /// <summary>
         /// Obtains the implementation of this resource.

--- a/src/AsmResolver.DotNet/ManifestResource.cs
+++ b/src/AsmResolver.DotNet/ManifestResource.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.IO;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 

--- a/src/AsmResolver.DotNet/MemberReference.cs
+++ b/src/AsmResolver.DotNet/MemberReference.cs
@@ -4,7 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.DotNet.Signatures;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
 namespace AsmResolver.DotNet

--- a/src/AsmResolver.DotNet/MemberReference.cs
+++ b/src/AsmResolver.DotNet/MemberReference.cs
@@ -27,7 +27,7 @@ namespace AsmResolver.DotNet
             : base(token)
         {
             _parent = new LazyVariable<IMemberRefParent?>(GetParent);
-            _name = new LazyVariable<Utf8String?>(() => GetName());
+            _name = new LazyVariable<Utf8String?>(GetName);
             _signature = new LazyVariable<CallingConventionSignature?>(GetSignature);
         }
 

--- a/src/AsmResolver.DotNet/MemberReference.cs
+++ b/src/AsmResolver.DotNet/MemberReference.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.DotNet.Signatures;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
 namespace AsmResolver.DotNet
@@ -14,7 +15,7 @@ namespace AsmResolver.DotNet
     public class MemberReference : MetadataMember, ICustomAttributeType, IFieldDescriptor
     {
         private readonly LazyVariable<IMemberRefParent?> _parent;
-        private readonly LazyVariable<string?> _name;
+        private readonly LazyVariable<Utf8String?> _name;
         private readonly LazyVariable<CallingConventionSignature?> _signature;
         private IList<CustomAttribute>? _customAttributes;
 
@@ -26,7 +27,7 @@ namespace AsmResolver.DotNet
             : base(token)
         {
             _parent = new LazyVariable<IMemberRefParent?>(GetParent);
-            _name = new LazyVariable<string?>(GetName);
+            _name = new LazyVariable<Utf8String?>(() => GetName());
             _signature = new LazyVariable<CallingConventionSignature?>(GetSignature);
         }
 
@@ -57,11 +58,17 @@ namespace AsmResolver.DotNet
         /// <summary>
         /// Gets or sets the name of the referenced member.
         /// </summary>
-        public string? Name
+        /// <remarks>
+        /// This property corresponds to the Name column in the member reference table.
+        /// </remarks>
+        public Utf8String? Name
         {
             get => _name.Value;
             set => _name.Value = value;
         }
+
+        /// <inheritdoc />
+        string? INameProvider.Name => Name;
 
         /// <summary>
         /// Gets or sets the signature of the referenced member.
@@ -187,7 +194,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="Name"/> property.
         /// </remarks>
-        protected virtual string? GetName() => null;
+        protected virtual Utf8String? GetName() => null;
 
         /// <summary>
         /// Obtains the signature of the member reference.

--- a/src/AsmResolver.DotNet/MetadataMember.cs
+++ b/src/AsmResolver.DotNet/MetadataMember.cs
@@ -1,4 +1,3 @@
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
 namespace AsmResolver.DotNet

--- a/src/AsmResolver.DotNet/MetadataMember.cs
+++ b/src/AsmResolver.DotNet/MetadataMember.cs
@@ -1,3 +1,4 @@
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
 namespace AsmResolver.DotNet
@@ -7,7 +8,7 @@ namespace AsmResolver.DotNet
     /// </summary>
     public abstract class MetadataMember : IMetadataMember
     {
-        internal const string NullName = "<<<NULL NAME>>>";
+        internal static readonly Utf8String NullName = "<<<NULL NAME>>>";
 
         /// <summary>
         /// Initializes the metadata member with a metadata token.

--- a/src/AsmResolver.DotNet/MethodDefinition.cs
+++ b/src/AsmResolver.DotNet/MethodDefinition.cs
@@ -3,12 +3,11 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using AsmResolver.Collections;
-using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Code;
 using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Code.Native;
 using AsmResolver.DotNet.Collections;
-using AsmResolver.PE.DotNet.Metadata.Strings;
+using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 

--- a/src/AsmResolver.DotNet/MethodDefinition.cs
+++ b/src/AsmResolver.DotNet/MethodDefinition.cs
@@ -8,6 +8,7 @@ using AsmResolver.DotNet.Code;
 using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Code.Native;
 using AsmResolver.DotNet.Collections;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
@@ -73,12 +74,19 @@ namespace AsmResolver.DotNet
             Signature = signature;
         }
 
-        /// <inheritdoc />
-        public string? Name
+        /// <summary>
+        /// Gets or sets the name of the method definition.
+        /// </summary>
+        /// <remarks>
+        /// This property corresponds to the Name column in the method definition table.
+        /// </remarks>
+        public Utf8String? Name
         {
             get => _name.Value;
             set => _name.Value = value;
         }
+
+        string? INameProvider.Name => Name;
 
         /// <summary>
         /// Gets or sets the signature of the method This includes the return type, as well as the types of the
@@ -668,7 +676,7 @@ namespace AsmResolver.DotNet
         /// <summary>
         /// Gets a value indicating whether the method is a (class) constructor.
         /// </summary>
-        public bool IsConstructor => IsSpecialName && IsRuntimeSpecialName && Name is ".cctor" or ".ctor";
+        public bool IsConstructor => IsSpecialName && IsRuntimeSpecialName && Name?.Value is ".cctor" or ".ctor";
 
         MethodDefinition IMethodDescriptor.Resolve() => this;
 

--- a/src/AsmResolver.DotNet/MethodSpecification.cs
+++ b/src/AsmResolver.DotNet/MethodSpecification.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Types;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
 namespace AsmResolver.DotNet
@@ -60,8 +61,13 @@ namespace AsmResolver.DotNet
             set => _signature.Value = value;
         }
 
-        /// <inheritdoc />
-        public string Name => Method?.Name ?? NullName;
+
+        /// <summary>
+        /// Gets or sets the name of the method specification.
+        /// </summary>
+        public Utf8String Name => Method?.Name ?? NullName;
+
+        string? INameProvider.Name => Name;
 
         /// <inheritdoc />
         public string FullName => FullNameGenerator.GetMethodFullName(

--- a/src/AsmResolver.DotNet/MethodSpecification.cs
+++ b/src/AsmResolver.DotNet/MethodSpecification.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Types;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
 namespace AsmResolver.DotNet

--- a/src/AsmResolver.DotNet/ModuleDefinition.cs
+++ b/src/AsmResolver.DotNet/ModuleDefinition.cs
@@ -14,6 +14,7 @@ using AsmResolver.PE.Builder;
 using AsmResolver.PE.Debug;
 using AsmResolver.PE.DotNet;
 using AsmResolver.PE.DotNet.Builder;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.File;
 using AsmResolver.PE.File.Headers;
@@ -31,7 +32,7 @@ namespace AsmResolver.DotNet
         IHasCustomAttribute,
         IOwnedCollectionElement<AssemblyDefinition>
     {
-        private readonly LazyVariable<string?> _name;
+        private readonly LazyVariable<Utf8String?> _name;
         private readonly LazyVariable<Guid> _mvid;
         private readonly LazyVariable<Guid> _encId;
         private readonly LazyVariable<Guid> _encBaseId;
@@ -215,7 +216,7 @@ namespace AsmResolver.DotNet
         protected ModuleDefinition(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<string?>(GetName);
+            _name = new LazyVariable<Utf8String?>(() => GetName());
             _mvid = new LazyVariable<Guid>(GetMvid);
             _encId = new LazyVariable<Guid>(GetEncId);
             _encBaseId = new LazyVariable<Guid>(GetEncBaseId);
@@ -319,11 +320,13 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This property corresponds to the Name column in the module definition table.
         /// </remarks>
-        public string? Name
+        public Utf8String? Name
         {
             get => _name.Value;
             set => _name.Value = value;
         }
+
+        string? INameProvider.Name => Name;
 
         /// <summary>
         /// Gets or sets the generation number of the module.
@@ -861,7 +864,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="Name"/> property.
         /// </remarks>
-        protected virtual string? GetName() => null;
+        protected virtual Utf8String? GetName() => null;
 
         /// <summary>
         /// Obtains the MVID of the module definition.

--- a/src/AsmResolver.DotNet/ModuleDefinition.cs
+++ b/src/AsmResolver.DotNet/ModuleDefinition.cs
@@ -216,11 +216,11 @@ namespace AsmResolver.DotNet
         protected ModuleDefinition(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(() => GetName());
+            _name = new LazyVariable<Utf8String?>(GetName);
             _mvid = new LazyVariable<Guid>(GetMvid);
             _encId = new LazyVariable<Guid>(GetEncId);
             _encBaseId = new LazyVariable<Guid>(GetEncBaseId);
-            _managedEntrypoint = new LazyVariable<IManagedEntrypoint?>(() => GetManagedEntrypoint());
+            _managedEntrypoint = new LazyVariable<IManagedEntrypoint?>(GetManagedEntrypoint);
             _runtimeVersion = new LazyVariable<string>(GetRuntimeVersion);
             _nativeResources = new LazyVariable<IResourceDirectory?>(GetNativeResources);
             Attributes = DotNetDirectoryFlags.ILOnly;

--- a/src/AsmResolver.DotNet/ModuleDefinition.cs
+++ b/src/AsmResolver.DotNet/ModuleDefinition.cs
@@ -14,7 +14,6 @@ using AsmResolver.PE.Builder;
 using AsmResolver.PE.Debug;
 using AsmResolver.PE.DotNet;
 using AsmResolver.PE.DotNet.Builder;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.File;
 using AsmResolver.PE.File.Headers;

--- a/src/AsmResolver.DotNet/ModuleReference.cs
+++ b/src/AsmResolver.DotNet/ModuleReference.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using AsmResolver.Collections;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
 namespace AsmResolver.DotNet
@@ -15,7 +16,7 @@ namespace AsmResolver.DotNet
         IHasCustomAttribute,
         IOwnedCollectionElement<ModuleDefinition>
     {
-        private readonly LazyVariable<string?> _name;
+        private readonly LazyVariable<Utf8String?> _name;
         private IList<CustomAttribute>? _customAttributes;
 
         /// <summary>
@@ -25,7 +26,7 @@ namespace AsmResolver.DotNet
         protected ModuleReference(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<string?>(GetName);
+            _name = new LazyVariable<Utf8String?>(() => GetName());
         }
 
         /// <summary>
@@ -38,12 +39,19 @@ namespace AsmResolver.DotNet
             Name = name;
         }
 
-        /// <inheritdoc />
-        public string? Name
+        /// <summary>
+        /// Gets or sets the name of the module.
+        /// </summary>
+        /// <remarks>
+        /// This property corresponds to the Name column in the module definition table.
+        /// </remarks>
+        public Utf8String? Name
         {
             get => _name.Value;
             set => _name.Value = value;
         }
+
+        string? INameProvider.Name => Name;
 
         /// <inheritdoc />
         public ModuleDefinition? Module
@@ -76,7 +84,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="Name"/> property.
         /// </remarks>
-        protected virtual string? GetName() => null;
+        protected virtual Utf8String? GetName() => null;
 
         AssemblyDescriptor? IResolutionScope.GetAssembly() => Module?.Assembly;
 

--- a/src/AsmResolver.DotNet/ModuleReference.cs
+++ b/src/AsmResolver.DotNet/ModuleReference.cs
@@ -26,7 +26,7 @@ namespace AsmResolver.DotNet
         protected ModuleReference(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(() => GetName());
+            _name = new LazyVariable<Utf8String?>(GetName);
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/ModuleReference.cs
+++ b/src/AsmResolver.DotNet/ModuleReference.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using AsmResolver.Collections;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
 namespace AsmResolver.DotNet

--- a/src/AsmResolver.DotNet/ParameterDefinition.cs
+++ b/src/AsmResolver.DotNet/ParameterDefinition.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.DotNet.Signatures.Marshal;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
@@ -22,7 +23,7 @@ namespace AsmResolver.DotNet
         IHasFieldMarshal,
         IOwnedCollectionElement<MethodDefinition>
     {
-        private readonly LazyVariable<string?> _name;
+        private readonly LazyVariable<Utf8String?> _name;
         private readonly LazyVariable<MethodDefinition?> _method;
         private readonly LazyVariable<Constant?> _constant;
         private readonly LazyVariable<MarshalDescriptor?> _marshalDescriptor;
@@ -35,7 +36,7 @@ namespace AsmResolver.DotNet
         protected ParameterDefinition(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<string?>(GetName);
+            _name = new LazyVariable<Utf8String?>(() => GetName());
             _method = new LazyVariable<MethodDefinition?>(GetMethod);
             _constant = new LazyVariable<Constant?>(GetConstant);
             _marshalDescriptor = new LazyVariable<MarshalDescriptor?>(GetMarshalDescriptor);
@@ -65,12 +66,19 @@ namespace AsmResolver.DotNet
             Attributes = attributes;
         }
 
-        /// <inheritdoc />
-        public string? Name
+        /// <summary>
+        /// Gets or sets the name of the parameter.
+        /// </summary>
+        /// <remarks>
+        /// This property corresponds to the Name column in the parameter definition table.
+        /// </remarks>
+        public Utf8String? Name
         {
             get => _name.Value;
             set => _name.Value = value;
         }
+
+        string? INameProvider.Name => Name;
 
         /// <summary>
         /// Gets or sets the index for which this parameter definition provides information for.
@@ -210,7 +218,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="Name"/> property.
         /// </remarks>
-        protected virtual string? GetName() => null;
+        protected virtual Utf8String? GetName() => null;
 
         /// <summary>
         /// Obtains the method that owns the parameter.

--- a/src/AsmResolver.DotNet/ParameterDefinition.cs
+++ b/src/AsmResolver.DotNet/ParameterDefinition.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.DotNet.Signatures.Marshal;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 

--- a/src/AsmResolver.DotNet/ParameterDefinition.cs
+++ b/src/AsmResolver.DotNet/ParameterDefinition.cs
@@ -36,7 +36,7 @@ namespace AsmResolver.DotNet
         protected ParameterDefinition(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(() => GetName());
+            _name = new LazyVariable<Utf8String?>(GetName);
             _method = new LazyVariable<MethodDefinition?>(GetMethod);
             _constant = new LazyVariable<Constant?>(GetConstant);
             _marshalDescriptor = new LazyVariable<MarshalDescriptor?>(GetMarshalDescriptor);

--- a/src/AsmResolver.DotNet/PropertyDefinition.cs
+++ b/src/AsmResolver.DotNet/PropertyDefinition.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Collections;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
@@ -19,7 +20,7 @@ namespace AsmResolver.DotNet
         IHasConstant,
         IOwnedCollectionElement<TypeDefinition>
     {
-        private readonly LazyVariable<string?> _name;
+        private readonly LazyVariable<Utf8String?> _name;
         private readonly LazyVariable<TypeDefinition?> _declaringType;
         private readonly LazyVariable<PropertySignature?> _signature;
         private readonly LazyVariable<Constant?> _constant;
@@ -33,7 +34,7 @@ namespace AsmResolver.DotNet
         protected PropertyDefinition(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<string?>(GetName);
+            _name = new LazyVariable<Utf8String?>(() => GetName());
             _signature = new LazyVariable<PropertySignature?>(GetSignature);
             _declaringType = new LazyVariable<TypeDefinition?>(GetDeclaringType);
             _constant = new LazyVariable<Constant?>(GetConstant);
@@ -93,12 +94,19 @@ namespace AsmResolver.DotNet
                                 | (value ? PropertyAttributes.HasDefault : 0);
         }
 
-        /// <inheritdoc />
-        public string? Name
+        /// <summary>
+        /// Gets or sets the name of the property.
+        /// </summary>
+        /// <remarks>
+        /// This property corresponds to the Name column in the property definition table.
+        /// </remarks>
+        public Utf8String? Name
         {
             get => _name.Value;
             set => _name.Value = value;
         }
+
+        string? INameProvider.Name => Name;
 
         /// <inheritdoc />
         public string FullName => FullNameGenerator.GetPropertyFullName(Name, DeclaringType, Signature);
@@ -187,7 +195,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="Name"/> property.
         /// </remarks>
-        protected virtual string? GetName() => null;
+        protected virtual Utf8String? GetName() => null;
 
         /// <summary>
         /// Obtains the signature of the property definition.

--- a/src/AsmResolver.DotNet/PropertyDefinition.cs
+++ b/src/AsmResolver.DotNet/PropertyDefinition.cs
@@ -2,9 +2,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using AsmResolver.Collections;
-using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Collections;
-using AsmResolver.PE.DotNet.Metadata.Strings;
+using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 

--- a/src/AsmResolver.DotNet/PropertyDefinition.cs
+++ b/src/AsmResolver.DotNet/PropertyDefinition.cs
@@ -34,7 +34,7 @@ namespace AsmResolver.DotNet
         protected PropertyDefinition(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(() => GetName());
+            _name = new LazyVariable<Utf8String?>(GetName);
             _signature = new LazyVariable<PropertySignature?>(GetSignature);
             _declaringType = new LazyVariable<TypeDefinition?>(GetDeclaringType);
             _constant = new LazyVariable<Constant?>(GetConstant);

--- a/src/AsmResolver.DotNet/ReferenceImporter.cs
+++ b/src/AsmResolver.DotNet/ReferenceImporter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using AsmResolver.DotNet.Signatures;

--- a/src/AsmResolver.DotNet/ReferenceImporter.cs
+++ b/src/AsmResolver.DotNet/ReferenceImporter.cs
@@ -12,7 +12,7 @@ namespace AsmResolver.DotNet
     /// </summary>
     public class ReferenceImporter : ITypeSignatureVisitor<TypeSignature>
     {
-        private readonly SignatureComparer _comparer = new SignatureComparer();
+        private readonly SignatureComparer _comparer = new();
 
         /// <summary>
         /// Creates a new reference importer.

--- a/src/AsmResolver.DotNet/ReflectionAssemblyDescriptor.cs
+++ b/src/AsmResolver.DotNet/ReflectionAssemblyDescriptor.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
 namespace AsmResolver.DotNet
@@ -26,22 +27,18 @@ namespace AsmResolver.DotNet
         }
 
         /// <inheritdoc />
-        protected override string? GetName() =>
-            _assemblyName.Name;
+        protected override Utf8String? GetName() => _assemblyName.Name;
 
         /// <inheritdoc />
-        protected override string GetCulture() =>
-            _assemblyName.CultureName;
+        protected override Utf8String? GetCulture() => _assemblyName.CultureName;
 
         /// <inheritdoc />
         public override bool IsCorLib => Name is not null && KnownCorLibs.KnownCorLibNames.Contains(Name);
 
         /// <inheritdoc />
-        public override byte[]? GetPublicKeyToken() =>
-            _assemblyName.GetPublicKeyToken();
+        public override byte[]? GetPublicKeyToken() => _assemblyName.GetPublicKeyToken();
 
         /// <inheritdoc />
-        public override AssemblyDefinition? Resolve() =>
-            _parentModule.MetadataResolver.AssemblyResolver.Resolve(this);
+        public override AssemblyDefinition? Resolve() => _parentModule.MetadataResolver.AssemblyResolver.Resolve(this);
     }
 }

--- a/src/AsmResolver.DotNet/ReflectionAssemblyDescriptor.cs
+++ b/src/AsmResolver.DotNet/ReflectionAssemblyDescriptor.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
 namespace AsmResolver.DotNet

--- a/src/AsmResolver.DotNet/Serialized/SerializedAssemblyDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedAssemblyDefinition.cs
@@ -44,7 +44,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetName()
+        protected override Utf8String? GetName()
         {
             return _context.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.Name)
@@ -52,7 +52,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetCulture()
+        protected override Utf8String? GetCulture()
         {
             return _context.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.Culture)

--- a/src/AsmResolver.DotNet/Serialized/SerializedAssemblyReference.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedAssemblyReference.cs
@@ -34,7 +34,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetName()
+        protected override Utf8String? GetName()
         {
             return _context.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.Name)
@@ -42,7 +42,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetCulture()
+        protected override Utf8String? GetCulture()
         {
             return _context.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.Culture)

--- a/src/AsmResolver.DotNet/Serialized/SerializedEventDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedEventDefinition.cs
@@ -34,7 +34,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetName()
+        protected override Utf8String? GetName()
         {
             return _context.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.Name)

--- a/src/AsmResolver.DotNet/Serialized/SerializedExportedType.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedExportedType.cs
@@ -34,7 +34,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetName()
+        protected override Utf8String? GetName()
         {
             return _context.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.Name)
@@ -42,7 +42,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetNamespace()
+        protected override Utf8String? GetNamespace()
         {
             return _context.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.Namespace)

--- a/src/AsmResolver.DotNet/Serialized/SerializedFieldDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedFieldDefinition.cs
@@ -35,7 +35,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetName()
+        protected override Utf8String? GetName()
         {
             return _context.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.Name)

--- a/src/AsmResolver.DotNet/Serialized/SerializedFileReference.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedFileReference.cs
@@ -35,7 +35,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetName()
+        protected override Utf8String? GetName()
         {
             return _context.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.Name)

--- a/src/AsmResolver.DotNet/Serialized/SerializedGenericParameter.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedGenericParameter.cs
@@ -34,7 +34,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetName()
+        protected override Utf8String? GetName()
         {
             return _context.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.Name)

--- a/src/AsmResolver.DotNet/Serialized/SerializedImplementationMap.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedImplementationMap.cs
@@ -43,7 +43,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetName()
+        protected override Utf8String? GetName()
         {
             return _context.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.ImportName)

--- a/src/AsmResolver.DotNet/Serialized/SerializedManifestResource.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedManifestResource.cs
@@ -34,7 +34,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetName()
+        protected override Utf8String? GetName()
         {
             return _context.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.Name)

--- a/src/AsmResolver.DotNet/Serialized/SerializedMemberReference.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedMemberReference.cs
@@ -49,7 +49,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetName()
+        protected override Utf8String? GetName()
         {
             return _context.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.Name)

--- a/src/AsmResolver.DotNet/Serialized/SerializedModuleDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedModuleDefinition.cs
@@ -168,7 +168,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetName()
+        protected override Utf8String? GetName()
         {
             return ReaderContext.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.Name)

--- a/src/AsmResolver.DotNet/Serialized/SerializedModuleReference.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedModuleReference.cs
@@ -33,7 +33,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetName()
+        protected override Utf8String? GetName()
         {
             return _context.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.Name)

--- a/src/AsmResolver.DotNet/Serialized/SerializedParameterDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedParameterDefinition.cs
@@ -36,7 +36,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetName()
+        protected override Utf8String? GetName()
         {
             return _context.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.Name)

--- a/src/AsmResolver.DotNet/Serialized/SerializedPropertyDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedPropertyDefinition.cs
@@ -35,7 +35,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetName()
+        protected override Utf8String? GetName()
         {
             return _context.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.Name)

--- a/src/AsmResolver.DotNet/Serialized/SerializedTypeDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedTypeDefinition.cs
@@ -35,7 +35,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetNamespace()
+        protected override Utf8String? GetNamespace()
         {
             return _context.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.Namespace)
@@ -43,7 +43,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetName()
+        protected override Utf8String? GetName()
         {
             return _context.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.Name)

--- a/src/AsmResolver.DotNet/Serialized/SerializedTypeReference.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedTypeReference.cs
@@ -32,7 +32,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetNamespace()
+        protected override Utf8String? GetNamespace()
         {
             return _context.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.Namespace)
@@ -40,7 +40,7 @@ namespace AsmResolver.DotNet.Serialized
         }
 
         /// <inheritdoc />
-        protected override string? GetName()
+        protected override Utf8String? GetName()
         {
             return _context.Metadata.TryGetStream<StringsStream>(out var stringsStream)
                 ? stringsStream.GetStringByIndex(_row.Name)

--- a/src/AsmResolver.DotNet/Signatures/CustomAttributeArgumentWriter.cs
+++ b/src/AsmResolver.DotNet/Signatures/CustomAttributeArgumentWriter.cs
@@ -55,7 +55,7 @@ namespace AsmResolver.DotNet.Signatures
             switch (argumentType.ElementType)
             {
                 case ElementType.String:
-                    writer.WriteSerString(null);
+                    writer.WriteSerString(default(Utf8String));
                     break;
 
                 case ElementType.Object:
@@ -138,8 +138,12 @@ namespace AsmResolver.DotNet.Signatures
                     writer.WriteDouble((double) element);
                     break;
 
-                case ElementType.String:
-                    writer.WriteSerString(element as string);
+                case ElementType.String when element is string s:
+                    writer.WriteSerString(s);
+                    break;
+
+                case ElementType.String when element is Utf8String s:
+                    writer.WriteSerString(s);
                     break;
 
                 case ElementType.Object:

--- a/src/AsmResolver.DotNet/Signatures/CustomAttributeNamedArgument.cs
+++ b/src/AsmResolver.DotNet/Signatures/CustomAttributeNamedArgument.cs
@@ -19,7 +19,7 @@ namespace AsmResolver.DotNet.Signatures
         /// <param name="memberName">The name of the referenced member.</param>
         /// <param name="argumentType">The type of the argument to store.</param>
         /// <param name="argument">The argument value.</param>
-        public CustomAttributeNamedArgument(CustomAttributeArgumentMemberType memberType, string? memberName, TypeSignature argumentType, CustomAttributeArgument argument)
+        public CustomAttributeNamedArgument(CustomAttributeArgumentMemberType memberType, Utf8String? memberName, TypeSignature argumentType, CustomAttributeArgument argument)
         {
             MemberType = memberType;
             MemberName = memberName;
@@ -39,7 +39,7 @@ namespace AsmResolver.DotNet.Signatures
         /// <summary>
         /// Gets or sets the name of the referenced member.
         /// </summary>
-        public string? MemberName
+        public Utf8String? MemberName
         {
             get;
             set;
@@ -73,7 +73,7 @@ namespace AsmResolver.DotNet.Signatures
         {
             var memberType = (CustomAttributeArgumentMemberType) reader.ReadByte();
             var argumentType = TypeSignature.ReadFieldOrPropType(context, ref reader);
-            string? memberName = reader.ReadSerString();
+            var memberName = reader.ReadSerString();
             var argument = CustomAttributeArgument.FromReader(context, argumentType, ref reader);
 
             return new CustomAttributeNamedArgument(memberType, memberName, argumentType, argument);

--- a/src/AsmResolver.DotNet/Signatures/Marshal/CustomMarshalDescriptor.cs
+++ b/src/AsmResolver.DotNet/Signatures/Marshal/CustomMarshalDescriptor.cs
@@ -18,9 +18,9 @@ namespace AsmResolver.DotNet.Signatures.Marshal
         public new static CustomMarshalDescriptor FromReader(ModuleDefinition parentModule, ref BinaryStreamReader reader)
         {
             string? guid = reader.ReadSerString();
-            string? nativeTypeName = reader.ReadSerString();
+            var nativeTypeName = reader.ReadSerString();
             string? marshalTypeName = reader.ReadSerString();
-            string? cookie = reader.ReadSerString();
+            var cookie = reader.ReadSerString();
 
             return new CustomMarshalDescriptor(guid, nativeTypeName,
                 marshalTypeName is null ? null : TypeNameParser.Parse(parentModule, marshalTypeName), cookie);
@@ -33,7 +33,7 @@ namespace AsmResolver.DotNet.Signatures.Marshal
         /// <param name="nativeTypeName"></param>
         /// <param name="marshalType"></param>
         /// <param name="cookie"></param>
-        public CustomMarshalDescriptor(string? guid, string? nativeTypeName, TypeSignature? marshalType, string? cookie)
+        public CustomMarshalDescriptor(string? guid, Utf8String? nativeTypeName, TypeSignature? marshalType, Utf8String? cookie)
         {
             Guid = guid;
             NativeTypeName = nativeTypeName;
@@ -62,7 +62,7 @@ namespace AsmResolver.DotNet.Signatures.Marshal
         /// <remarks>
         /// This field is ignored by the CLR.
         /// </remarks>
-        public string? NativeTypeName
+        public Utf8String? NativeTypeName
         {
             get;
             set;
@@ -80,7 +80,7 @@ namespace AsmResolver.DotNet.Signatures.Marshal
         /// <summary>
         /// Gets or sets an additional value to be passed onto the custom marshaller.
         /// </summary>
-        public string? Cookie
+        public Utf8String? Cookie
         {
             get;
             set;
@@ -93,9 +93,9 @@ namespace AsmResolver.DotNet.Signatures.Marshal
 
             writer.WriteByte((byte) NativeType);
             writer.WriteSerString(Guid ?? string.Empty);
-            writer.WriteSerString(NativeTypeName ?? string.Empty);
+            writer.WriteSerString(NativeTypeName ?? Utf8String.Empty);
             writer.WriteSerString(MarshalType is null ? string.Empty : TypeNameBuilder.GetAssemblyQualifiedName(MarshalType));
-            writer.WriteSerString(Cookie ?? string.Empty);
+            writer.WriteSerString(Cookie ?? Utf8String.Empty);
         }
     }
 }

--- a/src/AsmResolver.DotNet/Signatures/SignatureComparer.MemberReferences.cs
+++ b/src/AsmResolver.DotNet/Signatures/SignatureComparer.MemberReferences.cs
@@ -56,7 +56,7 @@ namespace AsmResolver.DotNet.Signatures
         {
             unchecked
             {
-                int hashCode = obj.Name == null ? 0 : obj.Name.GetHashCode();
+                int hashCode = obj.Name is null ? 0 : obj.Name.GetHashCode();
                 hashCode = (hashCode * 397) ^ (obj.DeclaringType is not null ? GetHashCode(obj.DeclaringType) : 0);
                 hashCode = (hashCode * 397) ^ (obj.Signature is not null ? GetHashCode(obj.Signature) : 0);
                 return hashCode;
@@ -81,7 +81,7 @@ namespace AsmResolver.DotNet.Signatures
         {
             unchecked
             {
-                int hashCode = obj.Name == null ? 0 : obj.Name.GetHashCode();
+                int hashCode = obj.Name is null ? 0 : obj.Name.GetHashCode();
                 hashCode = (hashCode * 397) ^ (obj.DeclaringType is not null ? GetHashCode(obj.DeclaringType) : 0);
                 hashCode = (hashCode * 397) ^ (obj.Signature is not null ? GetHashCode(obj.Signature) : 0);
                 return hashCode;

--- a/src/AsmResolver.DotNet/Signatures/SignatureComparer.ResolutionScope.cs
+++ b/src/AsmResolver.DotNet/Signatures/SignatureComparer.ResolutionScope.cs
@@ -94,13 +94,13 @@ namespace AsmResolver.DotNet.Signatures
         {
             unchecked
             {
-                int hashCode = (obj.Name != null ? obj.Name.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (obj.Culture != null ? obj.Culture.GetHashCode() : 0);
+                int hashCode = obj.Name is null ? 0 : obj.Name.GetHashCode();
+                hashCode = (hashCode * 397) ^ (obj.Culture is not null ? obj.Culture.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (int) TableIndex.AssemblyRef;
-                hashCode = (hashCode * 397) ^ (obj.Version != null ? obj.Version.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ obj.Version.GetHashCode();
                 hashCode = (hashCode * 397) ^ (int) obj.Attributes;
                 var publicKeyToken = obj.GetPublicKeyToken();
-                hashCode = (hashCode * 397) ^ (publicKeyToken != null ? GetHashCode(publicKeyToken) : 0);
+                hashCode = (hashCode * 397) ^ (publicKeyToken is not null ? GetHashCode(publicKeyToken) : 0);
                 return hashCode;
             }
         }

--- a/src/AsmResolver.DotNet/Signatures/SignatureComparer.TypeDefOrRef.cs
+++ b/src/AsmResolver.DotNet/Signatures/SignatureComparer.TypeDefOrRef.cs
@@ -34,9 +34,9 @@ namespace AsmResolver.DotNet.Signatures
         {
             unchecked
             {
-                int hashCode = obj.Name != null ? obj.Name.GetHashCode() : 0;
-                hashCode = (hashCode * 397) ^ (obj.Namespace != null ? obj.Namespace.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (obj.DeclaringType != null ? GetHashCode(obj.DeclaringType) : 0);
+                int hashCode = obj.Name is null ? 0 : obj.Name.GetHashCode();
+                hashCode = (hashCode * 397) ^ (obj.Namespace is null ? 0 : obj.Namespace.GetHashCode());
+                hashCode = (hashCode * 397) ^ (obj.DeclaringType is null ? 0 : GetHashCode(obj.DeclaringType));
                 return hashCode;
             }
         }

--- a/src/AsmResolver.DotNet/Signatures/SignatureComparer.TypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/SignatureComparer.TypeSignature.cs
@@ -190,9 +190,9 @@ namespace AsmResolver.DotNet.Signatures
             unchecked
             {
                 int hashCode = (int) obj.ElementType << ElementTypeOffset;
-                hashCode = (hashCode * 397) ^ obj.Name.GetHashCode();
-                hashCode = (hashCode * 397) ^ (obj.Namespace != null ? obj.Namespace.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (obj.Scope != null ? GetHashCode(obj.Scope) : 0);
+                hashCode = (hashCode * 397) ^ (obj.Name is null ? 0 : obj.Name.GetHashCode());
+                hashCode = (hashCode * 397) ^ (obj.Namespace is null ? 0 : obj.Namespace.GetHashCode());
+                hashCode = (hashCode * 397) ^ (obj.Scope is null ? 0 : GetHashCode(obj.Scope));
                 return hashCode;
             }
         }

--- a/src/AsmResolver.DotNet/Signatures/Types/ArrayTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/ArrayTypeSignature.cs
@@ -56,7 +56,7 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override ElementType ElementType => ElementType.Array;
 
         /// <inheritdoc />
-        public override string? Name => (BaseType.Name ?? NullTypeToString) + GetDimensionsString();
+        public override string Name => $"{BaseType.Name ?? NullTypeToString}{GetDimensionsString()}";
 
         /// <inheritdoc />
         public override bool IsValueType => false;

--- a/src/AsmResolver.DotNet/Signatures/Types/ByReferenceTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/ByReferenceTypeSignature.cs
@@ -20,7 +20,7 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override ElementType ElementType => ElementType.ByRef;
 
         /// <inheritdoc />
-        public override string? Name => $"{BaseType.Name ?? NullTypeToString}&";
+        public override string Name => $"{BaseType.Name ?? NullTypeToString}&";
 
         /// <inheritdoc />
         public override bool IsValueType => false;

--- a/src/AsmResolver.DotNet/Signatures/Types/CorLibTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/CorLibTypeSignature.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
 namespace AsmResolver.DotNet.Signatures.Types

--- a/src/AsmResolver.DotNet/Signatures/Types/CorLibTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/CorLibTypeSignature.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
 namespace AsmResolver.DotNet.Signatures.Types

--- a/src/AsmResolver.DotNet/Signatures/Types/CustomModifierTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/CustomModifierTypeSignature.cs
@@ -1,4 +1,3 @@
-using System;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
 namespace AsmResolver.DotNet.Signatures.Types
@@ -52,14 +51,14 @@ namespace AsmResolver.DotNet.Signatures.Types
         }
 
         /// <inheritdoc />
-        public override string? Name
+        public override string Name
         {
             get
             {
                 string modifierString = IsRequired ? "modreq(" : "modopt(";
 
-                string baseType = BaseType?.Name ?? NullTypeToString;
-                string modifier = ModifierType?.FullName ?? NullTypeToString;
+                string baseType = BaseType.Name ?? NullTypeToString;
+                string modifier = ModifierType.FullName;
                 return $"{baseType} {modifierString}{modifier})";
             }
         }

--- a/src/AsmResolver.DotNet/Signatures/Types/GenericInstanceTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/GenericInstanceTypeSignature.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using AsmResolver.IO;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
 namespace AsmResolver.DotNet.Signatures.Types

--- a/src/AsmResolver.DotNet/Signatures/Types/GenericInstanceTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/GenericInstanceTypeSignature.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using AsmResolver.IO;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
 namespace AsmResolver.DotNet.Signatures.Types

--- a/src/AsmResolver.DotNet/Signatures/Types/GenericParameterSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/GenericParameterSignature.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using AsmResolver.IO;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
 namespace AsmResolver.DotNet.Signatures.Types

--- a/src/AsmResolver.DotNet/Signatures/Types/GenericParameterSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/GenericParameterSignature.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using AsmResolver.IO;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
 namespace AsmResolver.DotNet.Signatures.Types
@@ -63,7 +64,7 @@ namespace AsmResolver.DotNet.Signatures.Types
         }
 
         /// <inheritdoc />
-        public override string? Name => ParameterType switch
+        public override string Name => ParameterType switch
         {
             GenericParameterType.Type => $"!{Index}",
             GenericParameterType.Method => $"!!{Index}",

--- a/src/AsmResolver.DotNet/Signatures/Types/Parsing/TypeNameParser.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/Parsing/TypeNameParser.cs
@@ -349,7 +349,7 @@ namespace AsmResolver.DotNet.Signatures.Types.Parsing
 
                     case "culture":
                         assemblyRef.Culture = ParseCulture();
-                        if (assemblyRef.Culture.Equals("neutral", StringComparison.OrdinalIgnoreCase))
+                        if (assemblyRef.Culture.Equals("neutral"))
                             assemblyRef.Culture = null;
                         break;
 

--- a/src/AsmResolver.DotNet/Signatures/Types/PointerTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/PointerTypeSignature.cs
@@ -20,7 +20,7 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override ElementType ElementType => ElementType.Ptr;
 
         /// <inheritdoc />
-        public override string Name => $"{BaseType?.Name ?? NullTypeToString}*";
+        public override string? Name => $"{BaseType?.Name ?? NullTypeToString}*";
 
         /// <inheritdoc />
         public override bool IsValueType => false;

--- a/src/AsmResolver.DotNet/Signatures/Types/SentinelTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/SentinelTypeSignature.cs
@@ -1,5 +1,4 @@
 using System;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
 namespace AsmResolver.DotNet.Signatures.Types

--- a/src/AsmResolver.DotNet/Signatures/Types/SentinelTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/SentinelTypeSignature.cs
@@ -1,4 +1,5 @@
 using System;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
 namespace AsmResolver.DotNet.Signatures.Types

--- a/src/AsmResolver.DotNet/Signatures/Types/SzArrayTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/SzArrayTypeSignature.cs
@@ -20,7 +20,7 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override ElementType ElementType => ElementType.SzArray;
 
         /// <inheritdoc />
-        public override string Name => $"{BaseType?.Name ?? NullTypeToString}[]";
+        public override string Name => $"{BaseType.Name ?? NullTypeToString}[]";
 
         /// <inheritdoc />
         public override bool IsValueType => false;

--- a/src/AsmResolver.DotNet/Signatures/Types/TypeSpecificationSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/TypeSpecificationSignature.cs
@@ -1,6 +1,3 @@
-using System;
-using AsmResolver.DotNet.Builder;
-
 namespace AsmResolver.DotNet.Signatures.Types
 {
     /// <summary>
@@ -27,7 +24,7 @@ namespace AsmResolver.DotNet.Signatures.Types
         }
 
         /// <inheritdoc />
-        public override string? Namespace => BaseType?.Namespace;
+        public override string? Namespace => BaseType.Namespace;
 
         /// <inheritdoc />
         public override IResolutionScope? Scope => BaseType.Scope;

--- a/src/AsmResolver.DotNet/TokenAllocator.cs
+++ b/src/AsmResolver.DotNet/TokenAllocator.cs
@@ -1,7 +1,7 @@
-﻿using AsmResolver.PE.DotNet;
-using AsmResolver.PE.DotNet.Metadata.Tables;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using AsmResolver.PE.DotNet;
+using AsmResolver.PE.DotNet.Metadata.Tables;
 
 namespace AsmResolver.DotNet
 {

--- a/src/AsmResolver.DotNet/TypeDefinition.cs
+++ b/src/AsmResolver.DotNet/TypeDefinition.cs
@@ -8,6 +8,7 @@ using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Types;
 using AsmResolver.PE.DotNet.Cil;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
@@ -25,8 +26,8 @@ namespace AsmResolver.DotNet
         IOwnedCollectionElement<ModuleDefinition>,
         IOwnedCollectionElement<TypeDefinition>
     {
-        private readonly LazyVariable<string?> _namespace;
-        private readonly LazyVariable<string?> _name;
+        private readonly LazyVariable<Utf8String?> _namespace;
+        private readonly LazyVariable<Utf8String?> _name;
         private readonly LazyVariable<ITypeDefOrRef?> _baseType;
         private readonly LazyVariable<TypeDefinition?> _declaringType;
         private readonly LazyVariable<ClassLayout?> _classLayout;
@@ -49,8 +50,8 @@ namespace AsmResolver.DotNet
         protected TypeDefinition(MetadataToken token)
             : base(token)
         {
-            _namespace = new LazyVariable<string?>(GetNamespace);
-            _name = new LazyVariable<string?>(GetName);
+            _namespace = new LazyVariable<Utf8String?>(() => GetNamespace());
+            _name = new LazyVariable<Utf8String?>(() => GetName());
             _baseType = new LazyVariable<ITypeDefOrRef?>(GetBaseType);
             _declaringType = new LazyVariable<TypeDefinition?>(GetDeclaringType);
             _classLayout = new LazyVariable<ClassLayout?>(GetClassLayout);
@@ -86,20 +87,30 @@ namespace AsmResolver.DotNet
         /// <summary>
         /// Gets or sets the namespace the type resides in.
         /// </summary>
-        public string? Namespace
+        /// <remarks>
+        /// This property corresponds to the Namespace column in the type definition table.
+        /// </remarks>
+        public Utf8String? Namespace
         {
             get => _namespace.Value;
             set => _namespace.Value = value;
         }
 
+        string? ITypeDescriptor.Namespace => Namespace;
+
         /// <summary>
         /// Gets or sets the name of the type.
         /// </summary>
-        public string? Name
+        /// <remarks>
+        /// This property corresponds to the Name column in the type definition table.
+        /// </remarks>
+        public Utf8String? Name
         {
             get => _name.Value;
             set => _name.Value = value;
         }
+
+        string? INameProvider.Name => Name;
 
         /// <summary>
         /// Gets the full name (including namespace or declaring type full name) of the type.
@@ -801,7 +812,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="Namespace"/> property.
         /// </remarks>
-        protected virtual string? GetNamespace() => null;
+        protected virtual Utf8String? GetNamespace() => null;
 
         /// <summary>
         /// Obtains the name of the type definition.
@@ -810,7 +821,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="Name"/> property.
         /// </remarks>
-        protected virtual string? GetName() => null;
+        protected virtual Utf8String? GetName() => null;
 
         /// <summary>
         /// Obtains the base type of the type definition.

--- a/src/AsmResolver.DotNet/TypeDefinition.cs
+++ b/src/AsmResolver.DotNet/TypeDefinition.cs
@@ -50,8 +50,8 @@ namespace AsmResolver.DotNet
         protected TypeDefinition(MetadataToken token)
             : base(token)
         {
-            _namespace = new LazyVariable<Utf8String?>(() => GetNamespace());
-            _name = new LazyVariable<Utf8String?>(() => GetName());
+            _namespace = new LazyVariable<Utf8String?>(GetNamespace);
+            _name = new LazyVariable<Utf8String?>(GetName);
             _baseType = new LazyVariable<ITypeDefOrRef?>(GetBaseType);
             _declaringType = new LazyVariable<TypeDefinition?>(GetDeclaringType);
             _classLayout = new LazyVariable<ClassLayout?>(GetClassLayout);

--- a/src/AsmResolver.DotNet/TypeDefinition.cs
+++ b/src/AsmResolver.DotNet/TypeDefinition.cs
@@ -8,7 +8,6 @@ using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Types;
 using AsmResolver.PE.DotNet.Cil;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 

--- a/src/AsmResolver.DotNet/TypeReference.cs
+++ b/src/AsmResolver.DotNet/TypeReference.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.DotNet.Signatures.Types;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
 namespace AsmResolver.DotNet
@@ -14,8 +15,8 @@ namespace AsmResolver.DotNet
         ITypeDefOrRef,
         IResolutionScope
     {
-        private readonly LazyVariable<string?> _name;
-        private readonly LazyVariable<string?> _namespace;
+        private readonly LazyVariable<Utf8String?> _name;
+        private readonly LazyVariable<Utf8String?> _namespace;
         private readonly LazyVariable<IResolutionScope?> _scope;
         private IList<CustomAttribute>? _customAttributes;
 
@@ -26,8 +27,8 @@ namespace AsmResolver.DotNet
         protected TypeReference(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<string?>(GetName);
-            _namespace = new LazyVariable<string?>(GetNamespace);
+            _name = new LazyVariable<Utf8String?>(() => GetName());
+            _namespace = new LazyVariable<Utf8String?>(() => GetNamespace());
             _scope = new LazyVariable<IResolutionScope?>(GetScope);
         }
 
@@ -62,22 +63,32 @@ namespace AsmResolver.DotNet
         }
 
         /// <summary>
-        /// Gets or sets the name of the type that this object is referencing.
+        /// Gets or sets the name of the referenced type.
         /// </summary>
-        public string? Name
+        /// <remarks>
+        /// This property corresponds to the Name column in the type reference table.
+        /// </remarks>
+        public Utf8String? Name
         {
             get => _name.Value;
             set => _name.Value = value;
         }
 
+        string? INameProvider.Name => Name;
+
         /// <summary>
         /// Gets or sets the namespace the type is residing in.
         /// </summary>
-        public string? Namespace
+        /// <remarks>
+        /// This property corresponds to the Namespace column in the type definition table.
+        /// </remarks>
+        public Utf8String? Namespace
         {
             get => _namespace.Value;
             set => _namespace.Value = value;
         }
+
+        string? ITypeDescriptor.Namespace => Namespace;
 
         /// <inheritdoc />
         public string FullName => this.GetTypeFullName();
@@ -138,7 +149,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="Name"/> property.
         /// </remarks>
-        protected virtual string? GetName() => null;
+        protected virtual Utf8String? GetName() => null;
 
         /// <summary>
         /// Obtains the namespace of the type reference.
@@ -147,7 +158,7 @@ namespace AsmResolver.DotNet
         /// <remarks>
         /// This method is called upon initialization of the <see cref="Namespace"/> property.
         /// </remarks>
-        protected virtual string? GetNamespace() => null;
+        protected virtual Utf8String? GetNamespace() => null;
 
         /// <summary>
         /// Obtains the scope of the type reference.

--- a/src/AsmResolver.DotNet/TypeReference.cs
+++ b/src/AsmResolver.DotNet/TypeReference.cs
@@ -27,8 +27,8 @@ namespace AsmResolver.DotNet
         protected TypeReference(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(() => GetName());
-            _namespace = new LazyVariable<Utf8String?>(() => GetNamespace());
+            _name = new LazyVariable<Utf8String?>(GetName);
+            _namespace = new LazyVariable<Utf8String?>(GetNamespace);
             _scope = new LazyVariable<IResolutionScope?>(GetScope);
         }
 

--- a/src/AsmResolver.DotNet/TypeReference.cs
+++ b/src/AsmResolver.DotNet/TypeReference.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.DotNet.Signatures.Types;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
 namespace AsmResolver.DotNet

--- a/src/AsmResolver.DotNet/TypeSpecification.cs
+++ b/src/AsmResolver.DotNet/TypeSpecification.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.DotNet.Signatures.Types;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
 namespace AsmResolver.DotNet

--- a/src/AsmResolver.DotNet/TypeSpecification.cs
+++ b/src/AsmResolver.DotNet/TypeSpecification.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.DotNet.Signatures.Types;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
 namespace AsmResolver.DotNet
@@ -46,11 +47,19 @@ namespace AsmResolver.DotNet
             set => _signature.Value = value;
         }
 
-        /// <inheritdoc />
-        public string Name => Signature?.Name ?? TypeSignature.NullTypeToString;
+        /// <summary>
+        /// Gets or sets the name of the referenced type.
+        /// </summary>
+        public Utf8String Name => Signature?.Name ?? TypeSignature.NullTypeToString;
 
-        /// <inheritdoc />
-        public string? Namespace => Signature?.Namespace;
+        string INameProvider.Name => Name;
+
+        /// <summary>
+        /// Gets or sets the namespace the type is residing in.
+        /// </summary>
+        public Utf8String? Namespace => Signature?.Namespace;
+
+        string? ITypeDescriptor.Namespace => Namespace;
 
         /// <inheritdoc />
         public string FullName => this.GetTypeFullName();

--- a/src/AsmResolver.PE/DotNet/Metadata/Strings/SerializedStringsStream.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Strings/SerializedStringsStream.cs
@@ -9,7 +9,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
     /// </summary>
     public class SerializedStringsStream : StringsStream
     {
-        private readonly Dictionary<uint, string> _cachedStrings = new();
+        private readonly Dictionary<uint, Utf8String> _cachedStrings = new();
         private readonly BinaryStreamReader _reader;
 
         /// <summary>
@@ -48,16 +48,30 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
         public override void Write(IBinaryStreamWriter writer) => _reader.Fork().WriteToOutput(writer);
 
         /// <inheritdoc />
-        public override string? GetStringByIndex(uint index)
+        public override Utf8String? GetStringByIndex(uint index)
         {
             if (index == 0)
                 return null;
 
-            if (!_cachedStrings.TryGetValue(index, out string value) && index < _reader.Length)
+            if (!_cachedStrings.TryGetValue(index, out var value) && index < _reader.Length)
             {
                 var stringsReader = _reader.ForkRelative(index);
-                var data = stringsReader.ReadBytesUntil(0);
-                value = Encoding.UTF8.GetString(data, 0, data.Length - 1);
+                byte[] rawData = stringsReader.ReadBytesUntil(0);
+
+                if (rawData.Length == 0)
+                {
+                    value = Utf8String.Empty;
+                }
+                else
+                {
+                    // Trim off null terminator byte if its present.
+                    int actualLength = rawData.Length;
+                    if (rawData[actualLength - 1] == 0)
+                        actualLength--;
+
+                    value = new Utf8String(rawData, 0, actualLength);
+                }
+
                 _cachedStrings[index] = value;
             }
 

--- a/src/AsmResolver.PE/DotNet/Metadata/Strings/StringsStream.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Strings/StringsStream.cs
@@ -37,6 +37,6 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
         /// </summary>
         /// <param name="index">The offset into the heap to start reading.</param>
         /// <returns>The string, or <c>null</c> if the index was invalid.</returns>
-        public abstract string? GetStringByIndex(uint index);
+        public abstract Utf8String? GetStringByIndex(uint index);
     }
 }

--- a/src/AsmResolver.PE/DotNet/Metadata/Strings/Utf8String.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Strings/Utf8String.cs
@@ -171,7 +171,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
         public bool Equals(string other) => Value.Equals(other);
 
         /// <inheritdoc />
-        public int CompareTo(Utf8String other) => string.Compare(Value, other.Value, StringComparison.Ordinal);
+        public int CompareTo(Utf8String other) => ByteArrayEqualityComparer.Instance.Compare(_data, other._data);
 
         /// <inheritdoc />
         /// <remarks>

--- a/src/AsmResolver.PE/DotNet/Metadata/Strings/Utf8String.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Strings/Utf8String.cs
@@ -1,0 +1,317 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+
+namespace AsmResolver.PE.DotNet.Metadata.Strings
+{
+    /// <summary>
+    /// Represents an immutable UTF-8 encoded string stored in the #Strings stream of a .NET image.
+    /// This class supports preserving invalid UTF-8 code sequences.
+    /// </summary>
+    public sealed class Utf8String : IEquatable<string>, IEquatable<byte[]>, IComparable<Utf8String>
+    {
+        /// <summary>
+        /// Represents the empty UTF-8 string.
+        /// </summary>
+        public static readonly Utf8String Empty = new(Array.Empty<byte>());
+
+        private readonly byte[] _data;
+        private string? _cachedString;
+
+        /// <summary>
+        /// Creates a new UTF-8 string from the provided raw data.
+        /// </summary>
+        /// <param name="data">The raw UTF-8 data.</param>
+        public Utf8String(byte[] data)
+        {
+            // Copy data to enforce immutability.
+            _data = new byte[data.Length];
+            Buffer.BlockCopy(data, 0, _data,0, data.Length);
+        }
+
+        /// <summary>
+        /// Creates a new UTF-8 string from the provided <see cref="System.String"/>.
+        /// </summary>
+        /// <param name="value">The string value to encode as UTF-8.</param>
+        public Utf8String(string value)
+        {
+            _data = Encoding.UTF8.GetBytes(value);
+            _cachedString = value;
+        }
+
+        /// <summary>
+        /// Gets the string value represented by the UTF-8 bytes.
+        /// </summary>
+        public string Value => _cachedString ??= Encoding.UTF8.GetString(_data);
+
+        /// <summary>
+        /// Gets the number of bytes used by the string.
+        /// </summary>
+        public int ByteCount => _data.Length;
+
+        /// <summary>
+        /// Gets the number of characters in the string.
+        /// </summary>
+        public int Length => Value.Length;
+
+        /// <summary>
+        /// Gets a single character in the string.
+        /// </summary>
+        /// <param name="index">The character index.</param>
+        public char this[int index] => Value[index];
+
+        /// <summary>
+        /// Gets the raw UTF-8 bytes of the string.
+        /// </summary>
+        /// <returns>The bytes.</returns>
+        public byte[] GetBytes()
+        {
+            byte[] copy = new byte[_data.Length];
+            GetBytes(copy, 0, copy.Length);
+            return copy;
+        }
+
+        /// <summary>
+        /// Obtains the raw UTF-8 bytes of the string, and writes it into the provided buffer.
+        /// </summary>
+        /// <param name="buffer">The output buffer to receive the bytes in.</param>
+        /// <param name="index">The index into the output buffer to start writing at.</param>
+        /// <param name="length">The number of bytes to write.</param>
+        /// <returns>The actual number of bytes that were written.</returns>
+        public int GetBytes(byte[] buffer, int index, int length)
+        {
+            length = Math.Min(length, ByteCount);
+            Buffer.BlockCopy(_data, 0, buffer,index, length);
+            return length;
+        }
+
+        /// <summary>
+        /// Gets the underlying byte array of this string.
+        /// </summary>
+        /// <remarks>
+        /// This method should only be used if performance is critical. Modifying the returning array
+        /// <strong>will</strong> change the internal state of the string.
+        /// </remarks>
+        /// <returns>The bytes.</returns>
+        public byte[] GetBytesUnsafe() => _data;
+
+        /// <summary>
+        /// Produces a new string that is the concatenation of the current string and the provided string.
+        /// </summary>
+        /// <param name="other">The other string to append..</param>
+        /// <returns>The new string.</returns>
+        public Utf8String Concat(Utf8String? other) => !IsNullOrEmpty(other)
+            ? Concat(other._data)
+            : this;
+
+        /// <summary>
+        /// Produces a new string that is the concatenation of the current string and the provided string.
+        /// </summary>
+        /// <param name="other">The other string to append..</param>
+        /// <returns>The new string.</returns>
+        public Utf8String Concat(string? other) => !string.IsNullOrEmpty(other)
+            ? Concat(Encoding.UTF8.GetBytes(other))
+            : this;
+
+        /// <summary>
+        /// Produces a new string that is the concatenation of the current string and the provided byte array.
+        /// </summary>
+        /// <param name="other">The byte array to append.</param>
+        /// <returns>The new string.</returns>
+        public Utf8String Concat(byte[]? other)
+        {
+            if (other is null || other.Length == 0)
+                return this;
+
+            byte[] result = new byte[Length + other.Length];
+            Buffer.BlockCopy(_data, 0, result, 0, _data.Length);
+            Buffer.BlockCopy(other, 0, result, _data.Length, other.Length);
+            return result;
+        }
+
+        /// <summary>
+        /// Determines whether the provided string is <c>null</c> or the empty string.
+        /// </summary>
+        /// <param name="value">The string to verify.</param>
+        /// <returns><c>true</c> if the string is <c>null</c> or empty, <c>false</c> otherwise.</returns>
+        public static bool IsNullOrEmpty([NotNullWhen(false)] Utf8String? value) =>
+            value is null || value.ByteCount == 0;
+
+        /// <summary>
+        /// Determines whether two strings are considered equal.
+        /// </summary>
+        /// <param name="other">The other string.</param>
+        /// <returns><c>true</c> if the strings are considered equal, <c>false</c> otherwise.</returns>
+        /// <remarks>
+        /// This operation performs a byte-level comparison of the two strings.
+        /// </remarks>
+        public bool Equals(Utf8String other) => ByteArrayEqualityComparer.Instance.Equals(_data, other._data);
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// This operation performs a byte-level comparison of the two strings.
+        /// </remarks>
+        public bool Equals(byte[] other) => ByteArrayEqualityComparer.Instance.Equals(_data, other);
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// This operation performs a byte-level comparison of the two strings.
+        /// </remarks>
+        public bool Equals(string other) => Value.Equals(other);
+
+        /// <inheritdoc />
+        public int CompareTo(Utf8String other) => string.Compare(Value, other.Value, StringComparison.Ordinal);
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// This operation performs a byte-level comparison of the two strings.
+        /// </remarks>
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is Utf8String other && Equals(other);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ByteArrayEqualityComparer.Instance.GetHashCode(_data);
+
+        /// <inheritdoc />
+        public override string ToString() => Value;
+
+        /// <summary>
+        /// Converts a <see cref="System.String"/> into an <see cref="Utf8String"/>.
+        /// </summary>
+        /// <param name="value">The string value to convert.</param>
+        /// <returns>The new UTF-8 encoded string.</returns>
+        [return: NotNullIfNotNull("value")]
+        public static implicit operator Utf8String?(string? value)
+        {
+            if (value is null)
+                return null;
+            if (value.Length == 0)
+                return Empty;
+
+            return new Utf8String(value);
+        }
+
+        /// <summary>
+        /// Converts a raw sequence of bytes into an <see cref="Utf8String"/>.
+        /// </summary>
+        /// <param name="data">The raw data to convert.</param>
+        /// <returns>The new UTF-8 encoded string.</returns>
+        [return: NotNullIfNotNull("data")]
+        public static implicit operator Utf8String?(byte[]? data)
+        {
+            if (data is null)
+                return null;
+            if (data.Length == 0)
+                return Empty;
+
+            return new Utf8String(data);
+        }
+
+        /// <summary>
+        /// Determines whether two UTF-8 encoded strings are considered equal.
+        /// </summary>
+        /// <param name="a">The first string.</param>
+        /// <param name="b">The second string.</param>
+        /// <returns><c>true</c> if the strings are considered equal, <c>false</c> otherwise.</returns>
+        /// <remarks>
+        /// This operation performs a byte-level comparison of the two strings.
+        /// </remarks>
+        public static bool operator ==(Utf8String a, Utf8String b) => a.Equals(b);
+
+        /// <summary>
+        /// Determines whether two UTF-8 encoded strings are not considered equal.
+        /// </summary>
+        /// <param name="a">The first string.</param>
+        /// <param name="b">The second string.</param>
+        /// <returns><c>true</c> if the strings are not considered equal, <c>false</c> otherwise.</returns>
+        /// <remarks>
+        /// This operation performs a byte-level comparison of the two strings.
+        /// </remarks>
+        public static bool operator !=(Utf8String a, Utf8String b) => !(a == b);
+
+        /// <summary>
+        /// Determines whether an UTF-8 encoded string is considered equal to the provided <see cref="System.String"/>.
+        /// </summary>
+        /// <param name="a">The first string.</param>
+        /// <param name="b">The second string.</param>
+        /// <returns><c>true</c> if the strings are considered equal, <c>false</c> otherwise.</returns>
+        /// <remarks>
+        /// This operation performs a string-level comparison.
+        /// </remarks>
+        public static bool operator ==(Utf8String a, string b) => a.Value.Equals(b);
+
+        /// <summary>
+        /// Determines whether an UTF-8 encoded string is not equal to the provided <see cref="System.String"/>.
+        /// </summary>
+        /// <param name="a">The first string.</param>
+        /// <param name="b">The second string.</param>
+        /// <returns><c>true</c> if the strings are not considered equal, <c>false</c> otherwise.</returns>
+        /// <remarks>
+        /// This operation performs a string-level comparison.
+        /// </remarks>
+        public static bool operator !=(Utf8String a, string b) => !(a == b);
+
+        /// <summary>
+        /// Determines whether the underlying bytes of an UTF-8 encoded string is equal to the provided byte array.
+        /// </summary>
+        /// <param name="a">The UTF-8 string.</param>
+        /// <param name="b">The byte array.</param>
+        /// <returns><c>true</c> if the byte arrays are considered equal, <c>false</c> otherwise.</returns>
+        /// <remarks>
+        /// This operation performs a byte-level comparison.
+        /// </remarks>
+        public static bool operator ==(Utf8String a, byte[] b) => a.Value.Equals(b);
+
+        /// <summary>
+        /// Determines whether the underlying bytes of an UTF-8 encoded string is not equal to the provided byte array.
+        /// </summary>
+        /// <param name="a">The UTF-8 string.</param>
+        /// <param name="b">The byte array.</param>
+        /// <returns><c>true</c> if the byte arrays are not considered equal, <c>false</c> otherwise.</returns>
+        /// <remarks>
+        /// This operation performs a byte-level comparison.
+        /// </remarks>
+        public static bool operator !=(Utf8String a, byte[] b) => !(a == b);
+
+        /// <summary>
+        /// Concatenates two UTF-8 encoded strings together.
+        /// </summary>
+        /// <param name="a">The first string.</param>
+        /// <param name="b">The second string.</param>
+        /// <returns>The newly produced string.</returns>
+        public static Utf8String operator +(Utf8String? a, Utf8String? b)
+        {
+            if (IsNullOrEmpty(a))
+                return IsNullOrEmpty(b) ? Utf8String.Empty : b;
+
+            return a.Concat(b);
+        }
+
+        /// <summary>
+        /// Concatenates two UTF-8 encoded strings together.
+        /// </summary>
+        /// <param name="a">The first string.</param>
+        /// <param name="b">The second string.</param>
+        /// <returns>The newly produced string.</returns>
+        public static Utf8String operator +(Utf8String? a, string? b)
+        {
+            if (IsNullOrEmpty(a))
+                return string.IsNullOrEmpty(b) ? Empty : b!;
+
+            return a.Concat(b);
+        }
+
+        /// <summary>
+        /// Concatenates an UTF-8 encoded string together with a byte array.
+        /// </summary>
+        /// <param name="a">The string.</param>
+        /// <param name="b">The byte array.</param>
+        /// <returns>The newly produced string.</returns>
+        public static Utf8String operator +(Utf8String? a, byte[]? b)
+        {
+            if (IsNullOrEmpty(a))
+                return b is null || b.Length == 0 ? Empty : b;
+
+            return a.Concat(b);
+        }
+    }
+}

--- a/src/AsmResolver.PE/DotNet/Metadata/Strings/Utf8String.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Strings/Utf8String.cs
@@ -23,10 +23,21 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
         /// </summary>
         /// <param name="data">The raw UTF-8 data.</param>
         public Utf8String(byte[] data)
+            : this(data, 0, data.Length)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new UTF-8 string from the provided raw data.
+        /// </summary>
+        /// <param name="data">The raw UTF-8 data.</param>
+        /// <param name="index">The starting index to read from.</param>
+        /// <param name="count">The number of bytes to read..</param>
+        public Utf8String(byte[] data, int index, int count)
         {
             // Copy data to enforce immutability.
-            _data = new byte[data.Length];
-            Buffer.BlockCopy(data, 0, _data,0, data.Length);
+            _data = new byte[count];
+            Buffer.BlockCopy(data, index, _data,0, count);
         }
 
         /// <summary>
@@ -173,6 +184,21 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
 
         /// <inheritdoc />
         public override string ToString() => Value;
+
+        /// <summary>
+        /// Converts a <see cref="Utf8String"/> into a <see cref="System.String"/>.
+        /// </summary>
+        /// <param name="value">The UTF-8 string value to convert.</param>
+        /// <returns>The string.</returns>
+        [return: NotNullIfNotNull("value")]
+        public static implicit operator string?(Utf8String? value)
+        {
+            if (value is null)
+                return null;
+            if (value.ByteCount == 0)
+                return string.Empty;
+            return value.Value;
+        }
 
         /// <summary>
         /// Converts a <see cref="System.String"/> into an <see cref="Utf8String"/>.

--- a/src/AsmResolver.PE/DotNet/Metadata/Strings/Utf8String.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Strings/Utf8String.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
@@ -10,6 +11,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
     /// Represents an immutable UTF-8 encoded string stored in the #Strings stream of a .NET image.
     /// This class supports preserving invalid UTF-8 code sequences.
     /// </summary>
+    [DebuggerDisplay("{DebugDisplay}")]
     public sealed class Utf8String :
         IEquatable<Utf8String>,
         IEquatable<string>,
@@ -71,6 +73,9 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
         /// Gets the number of characters in the string.
         /// </summary>
         public int Length => _cachedString is null ? Encoding.UTF8.GetCharCount(_data) : Value.Length;
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        internal string DebugDisplay => Value.CreateEscapedString();
 
         /// <summary>
         /// Gets a single character in the string.

--- a/src/AsmResolver.PE/DotNet/Metadata/Strings/Utf8String.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Strings/Utf8String.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
@@ -8,7 +10,12 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
     /// Represents an immutable UTF-8 encoded string stored in the #Strings stream of a .NET image.
     /// This class supports preserving invalid UTF-8 code sequences.
     /// </summary>
-    public sealed class Utf8String : IEquatable<Utf8String>, IEquatable<string>, IEquatable<byte[]>, IComparable<Utf8String>
+    public sealed class Utf8String :
+        IEquatable<Utf8String>,
+        IEquatable<string>,
+        IEquatable<byte[]>,
+        IComparable<Utf8String>,
+        IEnumerable<char>
     {
         /// <summary>
         /// Represents the empty UTF-8 string.
@@ -63,7 +70,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
         /// <summary>
         /// Gets the number of characters in the string.
         /// </summary>
-        public int Length => Value.Length;
+        public int Length => _cachedString is null ? Encoding.UTF8.GetCharCount(_data) : Value.Length;
 
         /// <summary>
         /// Gets a single character in the string.
@@ -121,7 +128,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
         /// <param name="other">The other string to append..</param>
         /// <returns>The new string.</returns>
         public Utf8String Concat(string? other) => !string.IsNullOrEmpty(other)
-            ? Concat(Encoding.UTF8.GetBytes(other))
+            ? Concat(Encoding.UTF8.GetBytes(other!))
             : this;
 
         /// <summary>
@@ -139,6 +146,107 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
             Buffer.BlockCopy(other, 0, result, _data.Length, other.Length);
             return result;
         }
+
+        /// <summary>
+        /// Gets the zero-based index of the first occurrence of the provided character in the string.
+        /// </summary>
+        /// <param name="needle">The character to search.</param>
+        /// <returns>The index, or -1 if the character is not present.</returns>
+        public int IndexOf(char needle) => Value.IndexOf(needle);
+
+        /// <summary>
+        /// Gets the zero-based index of the first occurrence of the provided character in the string.
+        /// </summary>
+        /// <param name="needle">The character to search.</param>
+        /// <param name="startIndex">The index to start searching at.</param>
+        /// <returns>The index, or -1 if the character is not present.</returns>
+        public int IndexOf(char needle, int startIndex) => Value.IndexOf(needle, startIndex);
+
+        /// <summary>
+        /// Gets the zero-based index of the first occurrence of the provided string in the string.
+        /// </summary>
+        /// <param name="needle">The string to search.</param>
+        /// <returns>The index, or -1 if the string is not present.</returns>
+        public int IndexOf(string needle) => Value.IndexOf(needle);
+
+        /// <summary>
+        /// Gets the zero-based index of the first occurrence of the provided string in the string.
+        /// </summary>
+        /// <param name="needle">The string to search.</param>
+        /// <param name="startIndex">The index to start searching at.</param>
+        /// <returns>The index, or -1 if the string is not present.</returns>
+        public int IndexOf(string needle, int startIndex) => Value.IndexOf(needle, startIndex);
+
+        /// <summary>
+        /// Gets the zero-based index of the first occurrence of the provided string in the string.
+        /// </summary>
+        /// <param name="needle">The string to search.</param>
+        /// <param name="comparison">The comparison algorithm to use.</param>
+        /// <returns>The index, or -1 if the string is not present.</returns>
+        public int IndexOf(string needle, StringComparison comparison) => Value.IndexOf(needle, comparison);
+
+        /// <summary>
+        /// Gets the zero-based index of the first occurrence of the provided string in the string.
+        /// </summary>
+        /// <param name="needle">The string to search.</param>
+        /// <param name="startIndex">The index to start searching at.</param>
+        /// <param name="comparison">The comparison algorithm to use.</param>
+        /// <returns>The index, or -1 if the string is not present.</returns>
+        public int IndexOf(string needle, int startIndex, StringComparison comparison) => Value.IndexOf(needle, startIndex, comparison);
+
+        /// <summary>
+        /// Gets the zero-based index of the last occurrence of the provided character in the string.
+        /// </summary>
+        /// <param name="needle">The character to search.</param>
+        /// <returns>The index, or -1 if the character is not present.</returns>
+        public int LastIndexOf(char needle) => Value.LastIndexOf(needle);
+
+        /// <summary>
+        /// Gets the zero-based index of the last occurrence of the provided character in the string.
+        /// </summary>
+        /// <param name="needle">The character to search.</param>
+        /// <param name="startIndex">The index to start searching at.</param>
+        /// <returns>The index, or -1 if the character is not present.</returns>
+        public int LastIndexOf(char needle, int startIndex) => Value.LastIndexOf(needle, startIndex);
+
+        /// <summary>
+        /// Gets the zero-based index of the last occurrence of the provided string in the string.
+        /// </summary>
+        /// <param name="needle">The string to search.</param>
+        /// <returns>The index, or -1 if the string is not present.</returns>
+        public int LastIndexOf(string needle) => Value.LastIndexOf(needle);
+
+        /// <summary>
+        /// Gets the zero-based index of the first occurrence of the provided string in the string.
+        /// </summary>
+        /// <param name="needle">The string to search.</param>
+        /// <param name="startIndex">The index to start searching at.</param>
+        /// <returns>The index, or -1 if the string is not present.</returns>
+        public int LastIndexOf(string needle, int startIndex) => Value.LastIndexOf(needle, startIndex);
+
+        /// <summary>
+        /// Gets the zero-based index of the last occurrence of the provided string in the string.
+        /// </summary>
+        /// <param name="needle">The string to search.</param>
+        /// <param name="comparison">The comparison algorithm to use.</param>
+        /// <returns>The index, or -1 if the string is not present.</returns>
+        public int LastIndexOf(string needle, StringComparison comparison) => Value.LastIndexOf(needle, comparison);
+
+        /// <summary>
+        /// Gets the zero-based index of the last occurrence of the provided string in the string.
+        /// </summary>
+        /// <param name="needle">The string to search.</param>
+        /// <param name="startIndex">The index to start searching at.</param>
+        /// <param name="comparison">The comparison algorithm to use.</param>
+        /// <returns>The index, or -1 if the string is not present.</returns>
+        public int LastIndexOf(string needle, int startIndex, StringComparison comparison) => Value.LastIndexOf(needle, startIndex, comparison);
+
+        /// <summary>
+        /// Determines whether the string contains the provided string.
+        /// </summary>
+        /// <param name="needle">The string to search.</param>
+        /// <returns><c>true</c> if the string is present, <c>false</c> otherwise.</returns>
+        public bool Contains(string needle) => IndexOf(needle) >= 0;
 
         /// <summary>
         /// Determines whether the provided string is <c>null</c> or the empty string.
@@ -172,6 +280,12 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
 
         /// <inheritdoc />
         public int CompareTo(Utf8String other) => ByteArrayEqualityComparer.Instance.Compare(_data, other._data);
+
+        /// <inheritdoc />
+        public IEnumerator<char> GetEnumerator() => Value.GetEnumerator();
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <inheritdoc />
         /// <remarks>

--- a/src/AsmResolver.PE/DotNet/Metadata/Strings/Utf8String.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Strings/Utf8String.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
     /// Represents an immutable UTF-8 encoded string stored in the #Strings stream of a .NET image.
     /// This class supports preserving invalid UTF-8 code sequences.
     /// </summary>
-    public sealed class Utf8String : IEquatable<string>, IEquatable<byte[]>, IComparable<Utf8String>
+    public sealed class Utf8String : IEquatable<Utf8String>, IEquatable<string>, IEquatable<byte[]>, IComparable<Utf8String>
     {
         /// <summary>
         /// Represents the empty UTF-8 string.

--- a/src/AsmResolver.PE/DotNet/Metadata/Strings/Utf8String.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Strings/Utf8String.cs
@@ -241,7 +241,14 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
         /// <remarks>
         /// This operation performs a byte-level comparison of the two strings.
         /// </remarks>
-        public static bool operator ==(Utf8String a, Utf8String b) => a.Equals(b);
+        public static bool operator ==(Utf8String? a, Utf8String? b)
+        {
+            if (ReferenceEquals(a, b))
+                return true;
+            if (a is null || b is null)
+                return false;
+            return a.Equals(b);
+        }
 
         /// <summary>
         /// Determines whether two UTF-8 encoded strings are not considered equal.
@@ -252,7 +259,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
         /// <remarks>
         /// This operation performs a byte-level comparison of the two strings.
         /// </remarks>
-        public static bool operator !=(Utf8String a, Utf8String b) => !(a == b);
+        public static bool operator !=(Utf8String? a, Utf8String? b) => !(a == b);
 
         /// <summary>
         /// Determines whether an UTF-8 encoded string is considered equal to the provided <see cref="System.String"/>.
@@ -263,7 +270,12 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
         /// <remarks>
         /// This operation performs a string-level comparison.
         /// </remarks>
-        public static bool operator ==(Utf8String a, string b) => a.Value.Equals(b);
+        public static bool operator ==(Utf8String? a, string? b)
+        {
+            if (a is null)
+                return b is null;
+            return b is not null && a.Equals(b);
+        }
 
         /// <summary>
         /// Determines whether an UTF-8 encoded string is not equal to the provided <see cref="System.String"/>.
@@ -274,7 +286,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
         /// <remarks>
         /// This operation performs a string-level comparison.
         /// </remarks>
-        public static bool operator !=(Utf8String a, string b) => !(a == b);
+        public static bool operator !=(Utf8String? a, string? b) => !(a == b);
 
         /// <summary>
         /// Determines whether the underlying bytes of an UTF-8 encoded string is equal to the provided byte array.
@@ -285,7 +297,12 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
         /// <remarks>
         /// This operation performs a byte-level comparison.
         /// </remarks>
-        public static bool operator ==(Utf8String a, byte[] b) => a.Value.Equals(b);
+        public static bool operator ==(Utf8String? a, byte[]? b)
+        {
+            if (a is null)
+                return b is null;
+            return b is not null && a.Equals(b);
+        }
 
         /// <summary>
         /// Determines whether the underlying bytes of an UTF-8 encoded string is not equal to the provided byte array.
@@ -296,7 +313,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Strings
         /// <remarks>
         /// This operation performs a byte-level comparison.
         /// </remarks>
-        public static bool operator !=(Utf8String a, byte[] b) => !(a == b);
+        public static bool operator !=(Utf8String? a, byte[]? b) => !(a == b);
 
         /// <summary>
         /// Concatenates two UTF-8 encoded strings together.

--- a/src/AsmResolver/ByteArrayEqualityComparer.cs
+++ b/src/AsmResolver/ByteArrayEqualityComparer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace AsmResolver
@@ -5,7 +6,7 @@ namespace AsmResolver
     /// <summary>
     /// Provides an implementation to compare byte arrays for equality.
     /// </summary>
-    public class ByteArrayEqualityComparer : IEqualityComparer<byte[]>
+    public class ByteArrayEqualityComparer : IEqualityComparer<byte[]>, IComparer<byte[]>
     {
         /// <summary>
         /// Gets the singleton instance of this comparer.
@@ -80,6 +81,20 @@ namespace AsmResolver
                     result = (result * 31) ^ b;
                 return result;
             }
+        }
+
+        /// <inheritdoc />
+        public int Compare(byte[] x, byte[] y)
+        {
+            int length = Math.Min(x.Length, y.Length);
+            for (int i = 0; i < length; i++)
+            {
+                int result = x[i].CompareTo(y[i]);
+                if (result != 0)
+                    return result;
+            }
+
+            return x.Length.CompareTo(y.Length);
         }
     }
 }

--- a/src/AsmResolver/IO/BinaryStreamReader.cs
+++ b/src/AsmResolver/IO/BinaryStreamReader.cs
@@ -435,7 +435,7 @@ namespace AsmResolver.IO
         /// Reads a serialized UTF8 string from the stream.
         /// </summary>
         /// <returns>The string that was read from the stream.</returns>
-        public string? ReadSerString()
+        public Utf8String? ReadSerString()
         {
             if (!CanRead(1) || DataSource[Offset] == 0xFF)
             {
@@ -448,7 +448,7 @@ namespace AsmResolver.IO
 
             byte[] data = new byte[length];
             length = (uint) ReadBytes(data, 0, (int) length);
-            return Encoding.UTF8.GetString(data, 0, (int) length);
+            return new Utf8String(data, 0, (int)length);
         }
 
         /// <summary>

--- a/src/AsmResolver/IO/IBinaryStreamWriter.cs
+++ b/src/AsmResolver/IO/IBinaryStreamWriter.cs
@@ -222,7 +222,25 @@ namespace AsmResolver.IO
                 return;
             }
 
-            var bytes = Encoding.UTF8.GetBytes(value);
+            byte[] bytes = Encoding.UTF8.GetBytes(value);
+            writer.WriteCompressedUInt32((uint)bytes.Length);
+            writer.WriteBytes(bytes);
+        }
+
+        /// <summary>
+        /// Writes an UTF8 string to the stream.
+        /// </summary>
+        /// <param name="writer">The writer to use.</param>
+        /// <param name="value">The string to write.</param>
+        public static void WriteSerString(this IBinaryStreamWriter writer, Utf8String? value)
+        {
+            if (value is null)
+            {
+                writer.WriteByte(0xFF);
+                return;
+            }
+
+            byte[] bytes = value.GetBytesUnsafe();
             writer.WriteCompressedUInt32((uint)bytes.Length);
             writer.WriteBytes(bytes);
         }

--- a/src/AsmResolver/ISegment.cs
+++ b/src/AsmResolver/ISegment.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Text;
 
@@ -19,6 +20,9 @@ namespace AsmResolver
     public static partial class Extensions
     {
         private const string ReservedStringCharacters = "\\\"\t\r\n\b";
+
+        [ThreadStatic]
+        private static StringBuilder? _buffer;
 
         /// <summary>
         /// Rounds the provided unsigned integer up to the nearest multiple of the provided alignment.
@@ -66,18 +70,19 @@ namespace AsmResolver
         /// <returns>The escaped string.</returns>
         public static string CreateEscapedString(this string literal)
         {
-            var builder = new StringBuilder(literal.Length + 2);
+            _buffer ??= new StringBuilder(literal.Length + 2);
+            _buffer.Clear();
 
-            builder.Append('"');
+            _buffer.Append('"');
             foreach (char currentChar in literal)
             {
                 if (ReservedStringCharacters.Contains(currentChar))
-                    builder.Append('\\');
-                builder.Append(currentChar);
+                    _buffer.Append('\\');
+                _buffer.Append(currentChar);
             }
-            builder.Append('"');
+            _buffer.Append('"');
 
-            return builder.ToString();
+            return _buffer.ToString();
         }
     }
 }

--- a/src/AsmResolver/Utf8String.cs
+++ b/src/AsmResolver/Utf8String.cs
@@ -5,11 +5,10 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
-namespace AsmResolver.PE.DotNet.Metadata.Strings
+namespace AsmResolver
 {
     /// <summary>
-    /// Represents an immutable UTF-8 encoded string stored in the #Strings stream of a .NET image.
-    /// This class supports preserving invalid UTF-8 code sequences.
+    /// Represents an immutable UTF-8 encoded string. This class supports preserving invalid UTF-8 code sequences.
     /// </summary>
     [DebuggerDisplay("{DebugDisplay}")]
     public sealed class Utf8String :

--- a/test/AsmResolver.DotNet.Tests/Builder/StringsStreamBufferTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Builder/StringsStreamBufferTest.cs
@@ -21,7 +21,7 @@ namespace AsmResolver.DotNet.Tests.Builder
             uint index2 = buffer.GetStringIndex(string2);
 
             Assert.NotEqual(index1, index2);
-            
+
             var stringsStream = buffer.CreateStream();
             Assert.Equal(string1, stringsStream.GetStringByIndex(index1));
             Assert.Equal(string2, stringsStream.GetStringByIndex(index2));
@@ -39,7 +39,7 @@ namespace AsmResolver.DotNet.Tests.Builder
             uint index2 = buffer.GetStringIndex(string2);
 
             Assert.Equal(index1, index2);
-            
+
             var stringsStream = buffer.CreateStream();
             Assert.Equal(string1, stringsStream.GetStringByIndex(index1));
         }
@@ -67,7 +67,7 @@ namespace AsmResolver.DotNet.Tests.Builder
             var buffer = new StringsStreamBuffer();
             Assert.Throws<ArgumentException>(() => buffer.GetStringIndex("Test\0Test"));
         }
-        
+
         [Fact]
         public void ImportStringStreamShouldIndexExistingStrings()
         {
@@ -76,7 +76,7 @@ namespace AsmResolver.DotNet.Tests.Builder
                 + "String\0"
                 + "LongerString\0"
                 + "AnEvenLongerString\0"));
-            
+
             var buffer = new StringsStreamBuffer();
             buffer.ImportStream(existingStringsStream);
             var newStream = buffer.CreateStream();
@@ -94,7 +94,7 @@ namespace AsmResolver.DotNet.Tests.Builder
                 + "String\0"
                 + "String\0"
                 + "String\0"));
-            
+
             var buffer = new StringsStreamBuffer();
             buffer.ImportStream(existingStringsStream);
             var newStream = buffer.CreateStream();
@@ -102,6 +102,34 @@ namespace AsmResolver.DotNet.Tests.Builder
             Assert.Equal("String", newStream.GetStringByIndex(1));
             Assert.Equal("String", newStream.GetStringByIndex(8));
             Assert.Equal("String", newStream.GetStringByIndex(15));
+        }
+
+        [Fact]
+        public void StringsStreamBufferShouldPreserveInvalidCharacters()
+        {
+            var str = new Utf8String(new byte[] {0x80, 0x79, 0x78 });
+
+            var buffer = new StringsStreamBuffer();
+            uint index = buffer.GetStringIndex(str);
+
+            var stringsStream = buffer.CreateStream();
+            Assert.Equal(str, stringsStream.GetStringByIndex(index));
+        }
+
+        [Fact]
+        public void StringsStreamBufferShouldDistinguishDifferentInvalidCharacters()
+        {
+            var string1 = new Utf8String(new byte[] {0x80, 0x79, 0x78 });
+            var string2 = new Utf8String(new byte[] {0x80, 0x79, 0x78 });
+            var string3 = new Utf8String(new byte[] {0x81, 0x79, 0x78 });
+
+            var buffer = new StringsStreamBuffer();
+            uint index1 = buffer.GetStringIndex(string1);
+            uint index2 = buffer.GetStringIndex(string2);
+            uint index3 = buffer.GetStringIndex(string3);
+
+            Assert.Equal(index1, index2);
+            Assert.NotEqual(index1, index3);
         }
     }
 }

--- a/test/AsmResolver.DotNet.Tests/Collections/ParameterCollectionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Collections/ParameterCollectionTest.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Types;
 using AsmResolver.DotNet.TestCases.Methods;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using Xunit;
 
 namespace AsmResolver.DotNet.Tests.Collections
@@ -179,6 +180,15 @@ namespace AsmResolver.DotNet.Tests.Collections
             var instanceMethod = type.Methods.First(t => !t.IsStatic);
             var signature = Assert.IsAssignableFrom<CorLibTypeSignature>(instanceMethod.Parameters.ThisParameter.ParameterType);
             Assert.Same(module.CorLibTypeFactory.Object, signature);
+        }
+
+        [Fact]
+        public void UnnamedParameterShouldResultInDummyName()
+        {
+            var method = ObtainInstanceTestMethod(nameof(InstanceMethods.InstanceMultipleParametersMethod));
+            foreach (var param in method.ParameterDefinitions)
+                param.Name = null;
+            Assert.All(method.Parameters, p => Assert.Equal(p.Name, $"A_{p.MethodSignatureIndex}"));
         }
     }
 }

--- a/test/AsmResolver.DotNet.Tests/GenericParameterTest.cs
+++ b/test/AsmResolver.DotNet.Tests/GenericParameterTest.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using AsmResolver.DotNet.TestCases.Generics;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using Xunit;
 
 namespace AsmResolver.DotNet.Tests
@@ -12,7 +13,7 @@ namespace AsmResolver.DotNet.Tests
             var module = ModuleDefinition.FromFile(typeof(GenericType<,,>).Assembly.Location);
             var type = module.TopLevelTypes.First(t => t.Name == typeof(GenericType<,,>).Name);
 
-            Assert.Equal(new[]
+            Assert.Equal(new Utf8String[]
             {
                 "T1", "T2", "T3"
             }, type.GenericParameters.Select(p => p.Name));
@@ -33,7 +34,7 @@ namespace AsmResolver.DotNet.Tests
         public void ReadMethodOwner()
         {
             var module = ModuleDefinition.FromFile(typeof(GenericType<,,>).Assembly.Location);
-            var method = typeof(GenericType<,,>).GetMethod("GenericMethodInGenericType"); 
+            var method = typeof(GenericType<,,>).GetMethod("GenericMethodInGenericType");
             var token = method.GetGenericArguments()[0].MetadataToken;
 
             var genericParameter = (GenericParameter) module.LookupMember(token);
@@ -65,7 +66,7 @@ namespace AsmResolver.DotNet.Tests
                 .MetadataToken;
 
             var genericParameter = (GenericParameter) module.LookupMember(token);
-            Assert.Equal(new[]
+            Assert.Equal(new Utf8String[]
             {
                 nameof(IFoo),
                 nameof(IBar)

--- a/test/AsmResolver.DotNet.Tests/Memory/FindFieldsByOffsetTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Memory/FindFieldsByOffsetTest.cs
@@ -47,7 +47,7 @@ namespace AsmResolver.DotNet.Tests.Memory
             Assert.True(layout.TryGetFieldPath(8, out var path));
             Assert.Equal(
                 new[] {nameof(SequentialTestStructs.MultipleFieldsSequentialStructDefaultPack.LongField)},
-                path.Select(f => f.Field.Name));
+                path.Select(f => f.Field.Name?.Value));
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace AsmResolver.DotNet.Tests.Memory
                     nameof(MixedTestStructs.Struct2.Nest1),
                     nameof(MixedTestStructs.Struct1.Dummy1),
                 },
-                path.Select(f => f.Field.Name));
+                path.Select(f => f.Field.Name?.Value));
         }
 
         [Fact]
@@ -83,7 +83,7 @@ namespace AsmResolver.DotNet.Tests.Memory
                     nameof(MixedTestStructs.Struct2.Nest1),
                     nameof(MixedTestStructs.Struct1.Dummy1),
                 },
-                path.Select(f => f.Field.Name));
+                path.Select(f => f.Field.Name?.Value));
         }
     }
 }

--- a/test/AsmResolver.DotNet.Tests/ModuleDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/ModuleDefinitionTest.cs
@@ -9,6 +9,7 @@ using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.TestCases.NestedClasses;
 using AsmResolver.IO;
 using AsmResolver.PE.DotNet.Builder;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 using AsmResolver.PE.Win32Resources;
@@ -57,14 +58,14 @@ namespace AsmResolver.DotNet.Tests
         public void ReadTypesNoNested()
         {
             var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld);
-            Assert.Equal(new[] {"<Module>", "Program"}, module.TopLevelTypes.Select(t => t.Name));
+            Assert.Equal(new Utf8String[] {"<Module>", "Program"}, module.TopLevelTypes.Select(t => t.Name));
         }
 
         [Fact]
         public void ReadTypesNested()
         {
             var module = ModuleDefinition.FromFile(typeof(TopLevelClass1).Assembly.Location);
-            Assert.Equal(new HashSet<string>
+            Assert.Equal(new HashSet<Utf8String>
             {
                 "<Module>",
                 nameof(TopLevelClass1),
@@ -76,7 +77,7 @@ namespace AsmResolver.DotNet.Tests
         public void ReadMaliciousNestedClassLoop()
         {
             var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld_MaliciousNestedClassLoop);
-            Assert.Equal(new[] {"<Module>", "Program"}, module.TopLevelTypes.Select(t => t.Name));
+            Assert.Equal(new Utf8String[] {"<Module>", "Program"}, module.TopLevelTypes.Select(t => t.Name));
         }
 
         [Fact]
@@ -84,8 +85,8 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld_MaliciousNestedClassLoop2);
             Assert.Equal(
-                new HashSet<string> {"<Module>", "Program", "MaliciousEnclosingClass"},
-                new HashSet<string>(module.TopLevelTypes.Select(t => t.Name)));
+                new HashSet<Utf8String> {"<Module>", "Program", "MaliciousEnclosingClass"},
+                new HashSet<Utf8String>(module.TopLevelTypes.Select(t => t.Name)));
 
             var enclosingClass = module.TopLevelTypes.First(x => x.Name == "MaliciousEnclosingClass");
             Assert.Single(enclosingClass.NestedTypes);

--- a/test/AsmResolver.DotNet.Tests/TypeDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/TypeDefinitionTest.cs
@@ -11,6 +11,7 @@ using AsmResolver.DotNet.TestCases.NestedClasses;
 using AsmResolver.DotNet.TestCases.Properties;
 using AsmResolver.DotNet.TestCases.Types;
 using AsmResolver.DotNet.TestCases.Types.Structs;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 using Xunit;
@@ -109,42 +110,42 @@ namespace AsmResolver.DotNet.Tests
             var module = ModuleDefinition.FromFile(typeof(TopLevelClass1).Assembly.Location);
 
             var class1 = module.TopLevelTypes.First(t => t.Name == nameof(TopLevelClass1));
-            Assert.Equal(new HashSet<string>
+            Assert.Equal(new HashSet<Utf8String>
             {
                 nameof(TopLevelClass1.Nested1),
                 nameof(TopLevelClass1.Nested2)
             }, class1.NestedTypes.Select(t => t.Name));
 
             var nested1 = class1.NestedTypes.First(t => t.Name == nameof(TopLevelClass1.Nested1));
-            Assert.Equal(new HashSet<string>
+            Assert.Equal(new HashSet<Utf8String>
             {
                 nameof(TopLevelClass1.Nested1.Nested1Nested1),
                 nameof(TopLevelClass1.Nested1.Nested1Nested2)
             }, nested1.NestedTypes.Select(t => t.Name));
 
             var nested2 = class1.NestedTypes.First(t => t.Name == nameof(TopLevelClass1.Nested2));
-            Assert.Equal(new HashSet<string>
+            Assert.Equal(new HashSet<Utf8String>
             {
                 nameof(TopLevelClass1.Nested2.Nested2Nested1),
                 nameof(TopLevelClass1.Nested2.Nested2Nested2)
             }, nested2.NestedTypes.Select(t => t.Name));
 
             var class2 = module.TopLevelTypes.First(t => t.Name == nameof(TopLevelClass2));
-            Assert.Equal(new HashSet<string>
+            Assert.Equal(new HashSet<Utf8String>
             {
                 nameof(TopLevelClass2.Nested3),
                 nameof(TopLevelClass2.Nested4)
             }, class2.NestedTypes.Select(t => t.Name));
 
             var nested3 = class2.NestedTypes.First(t => t.Name == nameof(TopLevelClass2.Nested3));
-            Assert.Equal(new HashSet<string>
+            Assert.Equal(new HashSet<Utf8String>
             {
                 nameof(TopLevelClass2.Nested3.Nested3Nested1),
                 nameof(TopLevelClass2.Nested3.Nested3Nested2)
             }, nested3.NestedTypes.Select(t => t.Name));
 
             var nested4 = class2.NestedTypes.First(t => t.Name == nameof(TopLevelClass2.Nested4));
-            Assert.Equal(new HashSet<string>
+            Assert.Equal(new HashSet<Utf8String>
             {
                 nameof(TopLevelClass2.Nested4.Nested4Nested1),
                 nameof(TopLevelClass2.Nested4.Nested4Nested2)
@@ -191,7 +192,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(SingleField).Assembly.Location);
             var type = module.TopLevelTypes.First(t => t.Name == nameof(SingleField));
-            Assert.Equal(new[]
+            Assert.Equal(new Utf8String[]
             {
                 nameof(SingleField.IntField),
             }, type.Fields.Select(p => p.Name));
@@ -211,7 +212,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(MultipleFields).Assembly.Location);
             var type = module.TopLevelTypes.First(t => t.Name == nameof(MultipleFields));
-            Assert.Equal(new[]
+            Assert.Equal(new Utf8String[]
             {
                 nameof(MultipleFields.IntField),
                 nameof(MultipleFields.StringField),
@@ -250,7 +251,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(SingleMethod).Assembly.Location);
             var type = module.TopLevelTypes.First(t => t.Name == nameof(SingleMethod));
-            Assert.Equal(new[]
+            Assert.Equal(new Utf8String[]
             {
                 nameof(SingleMethod.VoidParameterlessMethod),
             }, type.Methods.Select(p => p.Name));
@@ -270,7 +271,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(MultipleMethods).Assembly.Location);
             var type = module.TopLevelTypes.First(t => t.Name == nameof(MultipleMethods));
-            Assert.Equal(new[]
+            Assert.Equal(new Utf8String[]
             {
                 ".ctor",
                 nameof(MultipleMethods.VoidParameterlessMethod),
@@ -312,7 +313,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(SingleProperty).Assembly.Location);
             var type = module.TopLevelTypes.First(t => t.Name == nameof(SingleProperty));
-            Assert.Equal(new[]
+            Assert.Equal(new Utf8String[]
             {
                 nameof(SingleProperty.IntProperty)
             }, type.Properties.Select(p => p.Name));
@@ -324,7 +325,7 @@ namespace AsmResolver.DotNet.Tests
             var module = ModuleDefinition.FromFile(typeof(SingleProperty).Assembly.Location);
             var type = module.TopLevelTypes.First(t => t.Name == nameof(SingleProperty));
             var newType = RebuildAndLookup(type);
-            Assert.Equal(new[]
+            Assert.Equal(new Utf8String[]
             {
                 nameof(SingleProperty.IntProperty)
             }, newType.Properties.Select(p => p.Name));
@@ -335,7 +336,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(MultipleProperties).Assembly.Location);
             var type = module.TopLevelTypes.First(t => t.Name == nameof(MultipleProperties));
-            Assert.Equal(new[]
+            Assert.Equal(new Utf8String[]
             {
                 nameof(MultipleProperties.ReadOnlyProperty), nameof(MultipleProperties.WriteOnlyProperty),
                 nameof(MultipleProperties.ReadWriteProperty), "Item",
@@ -348,7 +349,7 @@ namespace AsmResolver.DotNet.Tests
             var module = ModuleDefinition.FromFile(typeof(MultipleProperties).Assembly.Location);
             var type = module.TopLevelTypes.First(t => t.Name == nameof(MultipleProperties));
             var newType = RebuildAndLookup(type);
-            Assert.Equal(new[]
+            Assert.Equal(new Utf8String[]
             {
                 nameof(MultipleProperties.ReadOnlyProperty), nameof(MultipleProperties.WriteOnlyProperty),
                 nameof(MultipleProperties.ReadWriteProperty), "Item",
@@ -377,7 +378,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(SingleEvent).Assembly.Location);
             var type = module.TopLevelTypes.First(t => t.Name == nameof(SingleEvent));
-            Assert.Equal(new[]
+            Assert.Equal(new Utf8String[]
             {
                 nameof(SingleEvent.SimpleEvent)
             }, type.Events.Select(p => p.Name));
@@ -389,7 +390,7 @@ namespace AsmResolver.DotNet.Tests
             var module = ModuleDefinition.FromFile(typeof(SingleEvent).Assembly.Location);
             var type = module.TopLevelTypes.First(t => t.Name == nameof(SingleEvent));
             var newType = RebuildAndLookup(type);
-            Assert.Equal(new[]
+            Assert.Equal(new Utf8String[]
             {
                 nameof(SingleEvent.SimpleEvent)
             }, newType.Events.Select(p => p.Name));
@@ -400,7 +401,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(MultipleEvents).Assembly.Location);
             var type = module.TopLevelTypes.First(t => t.Name == nameof(MultipleEvents));
-            Assert.Equal(new[]
+            Assert.Equal(new Utf8String[]
             {
                 nameof(MultipleEvents.Event1),
                 nameof(MultipleEvents.Event2),
@@ -414,7 +415,7 @@ namespace AsmResolver.DotNet.Tests
             var module = ModuleDefinition.FromFile(typeof(MultipleEvents).Assembly.Location);
             var type = module.TopLevelTypes.First(t => t.Name == nameof(MultipleEvents));
             var newType = RebuildAndLookup(type);
-            Assert.Equal(new[]
+            Assert.Equal(new Utf8String[]
             {
                 nameof(MultipleEvents.Event1),
                 nameof(MultipleEvents.Event2),
@@ -443,10 +444,10 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(InterfaceImplementations).Assembly.Location);
             var type = module.TopLevelTypes.First(t => t.Name == nameof(InterfaceImplementations));
-            Assert.Equal(new HashSet<string>(new[]
+            Assert.Equal(new HashSet<Utf8String>(new Utf8String[]
             {
                 nameof(IInterface1), nameof(IInterface2),
-            }), new HashSet<string>(type.Interfaces.Select(i => i.Interface.Name)));
+            }), new HashSet<Utf8String>(type.Interfaces.Select(i => i.Interface.Name)));
         }
 
         [Fact]
@@ -455,10 +456,10 @@ namespace AsmResolver.DotNet.Tests
             var module = ModuleDefinition.FromFile(typeof(InterfaceImplementations).Assembly.Location);
             var type = module.TopLevelTypes.First(t => t.Name == nameof(InterfaceImplementations));
             var newType = RebuildAndLookup(type);
-            Assert.Equal(new HashSet<string>(new[]
+            Assert.Equal(new HashSet<Utf8String>(new Utf8String[]
             {
                 nameof(IInterface1), nameof(IInterface2),
-            }), new HashSet<string>(newType.Interfaces.Select(i => i.Interface.Name)));
+            }), new HashSet<Utf8String>(newType.Interfaces.Select(i => i.Interface.Name)));
         }
 
         [Fact]
@@ -467,7 +468,7 @@ namespace AsmResolver.DotNet.Tests
             var module = ModuleDefinition.FromFile(typeof(InterfaceImplementations).Assembly.Location);
             var type = module.TopLevelTypes.First(t => t.Name == nameof(InterfaceImplementations));
 
-            Assert.Contains(type.MethodImplementations, i => i.Declaration.Name == "Interface2Method");
+            Assert.Contains(type.MethodImplementations, i => i.Declaration!.Name == "Interface2Method");
         }
 
         [Fact]
@@ -477,7 +478,7 @@ namespace AsmResolver.DotNet.Tests
             var type = module.TopLevelTypes.First(t => t.Name == nameof(InterfaceImplementations));
             var newType = RebuildAndLookup(type);
 
-            Assert.Contains(newType.MethodImplementations, i => i.Declaration.Name == "Interface2Method");
+            Assert.Contains(newType.MethodImplementations, i => i.Declaration!.Name == "Interface2Method");
         }
 
         [Fact]

--- a/test/AsmResolver.PE.Tests/DotNet/Metadata/Strings/Utf8StringTest.cs
+++ b/test/AsmResolver.PE.Tests/DotNet/Metadata/Strings/Utf8StringTest.cs
@@ -73,5 +73,62 @@ namespace AsmResolver.PE.Tests.DotNet.Metadata.Strings
             Utf8String? s2 = b;
             Assert.Equal((a ?? Array.Empty<byte>()).Concat(b ?? Array.Empty<byte>()), (s1 + s2)?.GetBytes());
         }
+
+        [Theory]
+        [InlineData("0123456789", '0', 0)]
+        [InlineData("0123456789", '5', 5)]
+        [InlineData("0123456789", 'a', -1)]
+        public void IndexOfChar(string haystack, char needle, int expected)
+        {
+            Assert.Equal(expected, new Utf8String(haystack).IndexOf(needle));
+        }
+
+        [Theory]
+        [InlineData("012345678901234567890123456789", '0', 0, 0)]
+        [InlineData("012345678901234567890123456789", '0', 1, 10)]
+        [InlineData("012345678901234567890123456789", '0', 11, 20)]
+        [InlineData("012345678901234567890123456789", '0', 21, -1)]
+        public void IndexOfCharStartingAtIndex(string haystack, char needle, int startIndex, int expected)
+        {
+            Assert.Equal(expected, new Utf8String(haystack).IndexOf(needle, startIndex));
+        }
+
+        [Theory]
+        [InlineData("01234567890123456789", '0', 10)]
+        [InlineData("01234567890123456789", '5', 15)]
+        [InlineData("01234567890123456789", 'a', -1)]
+        public void LastIndexOfChar(string haystack, char needle, int expected)
+        {
+            Assert.Equal(expected, new Utf8String(haystack).LastIndexOf(needle));
+        }
+
+        [Theory]
+        [InlineData("012345678901234567890123456789", '0', 29, 20)]
+        [InlineData("012345678901234567890123456789", '0', 19, 10)]
+        [InlineData("012345678901234567890123456789", '0', 9, 0)]
+        [InlineData("012345678901234567890123456789", 'a', 20, -1)]
+        public void LastIndexOfCharStartingAtIndex(string haystack, char needle, int startIndex, int expected)
+        {
+            Assert.Equal(expected, new Utf8String(haystack).LastIndexOf(needle, startIndex));
+        }
+
+        [Theory]
+        [InlineData("0123456789", "01", 0)]
+        [InlineData("0123456789", "56", 5)]
+        [InlineData("0123456789", "ab", -1)]
+        public void IndexOfString(string haystack, string needle, int expected)
+        {
+            Assert.Equal(expected, new Utf8String(haystack).IndexOf(needle));
+        }
+
+        [Theory]
+        [InlineData("012345678901234567890123456789", "01", 0, 0)]
+        [InlineData("012345678901234567890123456789", "01", 1, 10)]
+        [InlineData("012345678901234567890123456789", "01", 11, 20)]
+        [InlineData("012345678901234567890123456789", "01", 21, -1)]
+        public void IndexOfStringStartingAtIndex(string haystack, string needle, int startIndex, int expected)
+        {
+            Assert.Equal(expected, new Utf8String(haystack).IndexOf(needle, startIndex));
+        }
     }
 }

--- a/test/AsmResolver.PE.Tests/DotNet/Metadata/Strings/Utf8StringTest.cs
+++ b/test/AsmResolver.PE.Tests/DotNet/Metadata/Strings/Utf8StringTest.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq;
+using AsmResolver.PE.DotNet.Metadata.Strings;
+using Xunit;
+
+namespace AsmResolver.PE.Tests.DotNet.Metadata.Strings
+{
+    public class Utf8StringTest
+    {
+        [Fact]
+        public void ConvertFromString()
+        {
+            const string text = "Hello, World";
+            Utf8String utf8 = text;
+            Assert.Equal(text, utf8.Value);
+        }
+
+        [Theory]
+        [InlineData("ABC", "ABC")]
+        [InlineData("ABC", "DEF")]
+        public void StringEquality(string a, string b)
+        {
+            var s1 = new Utf8String(a);
+            var s2 = new Utf8String(b);
+            Assert.Equal(a == b, s1 == s2);
+        }
+
+        [Theory]
+        [InlineData(new byte[] { 1, 2, 3 }, new byte[] { 1, 2, 3 })]
+        [InlineData(new byte[] { 1, 2, 3 }, new byte[] { 4, 5, 6 })]
+        public void ByteEquality(byte[] a, byte[] b)
+        {
+            var s1 = new Utf8String(a);
+            var s2 = new Utf8String(b);
+            Assert.Equal(ByteArrayEqualityComparer.Instance.Equals(a, b), s1 == s2);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("Hello")]
+        public void StringNullOrEmpty(string x)
+        {
+            var s1 = new Utf8String(x);
+            Assert.Equal(string.IsNullOrEmpty(x), Utf8String.IsNullOrEmpty(s1));
+        }
+
+        [Theory]
+        [InlineData("Hello, ", "World")]
+        [InlineData("", "World")]
+        [InlineData("Hello", "")]
+        [InlineData("", null)]
+        [InlineData(null, "")]
+        [InlineData(null, null)]
+        [InlineData("", "")]
+        public void StringConcat(string? a, string? b)
+        {
+            Utf8String? s1 = a;
+            Utf8String? s2 = b;
+            Assert.Equal(a + b, s1 + s2);
+        }
+
+        [Theory]
+        [InlineData(new byte[] { 0x41, 0x42 }, new byte[] { 0x43, 0x44 })]
+        [InlineData(new byte[] { 0x41, 0x42 }, new byte[0])]
+        [InlineData(new byte[0], new byte[] { 0x43, 0x44 })]
+        [InlineData(new byte[0], null)]
+        [InlineData(null, new byte[0])]
+        [InlineData(null, null)]
+        [InlineData(new byte[0], new byte[0])]
+        public void ByteConcat(byte[]? a, byte[]? b)
+        {
+            Utf8String? s1 = a;
+            Utf8String? s2 = b;
+            Assert.Equal((a ?? Array.Empty<byte>()).Concat(b ?? Array.Empty<byte>()), (s1 + s2)?.GetBytes());
+        }
+    }
+}

--- a/test/AsmResolver.PE.Tests/DotNet/Metadata/Strings/Utf8StringTest.cs
+++ b/test/AsmResolver.PE.Tests/DotNet/Metadata/Strings/Utf8StringTest.cs
@@ -16,6 +16,17 @@ namespace AsmResolver.PE.Tests.DotNet.Metadata.Strings
         }
 
         [Theory]
+        [InlineData(new byte[] { 0x41, 0x42, 0x43 }, 3)]
+        [InlineData(new byte[] { 0x80, 0x42, 0x43 }, 3)]
+        public void LengthBeforeAndAfterValueAccessShouldBeConsistentProperty(byte[] data, int expected)
+        {
+            var s1 = new Utf8String(data);
+            Assert.Equal(expected, s1.Length);
+            _ = s1.Value;
+            Assert.Equal(expected, s1.Length);
+        }
+
+        [Theory]
         [InlineData("ABC", "ABC")]
         [InlineData("ABC", "DEF")]
         public void StringEquality(string a, string b)

--- a/test/AsmResolver.Tests/Utf8StringTest.cs
+++ b/test/AsmResolver.Tests/Utf8StringTest.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Linq;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using Xunit;
 
-namespace AsmResolver.PE.Tests.DotNet.Metadata.Strings
+namespace AsmResolver.Tests
 {
     public class Utf8StringTest
     {


### PR DESCRIPTION
Includes:
- All exposed `string` properties in metadata member classes are replaced with `Utf8String` properties. 
   - `ITypeDefOrRef` is affected.
   - Derivatives of `TypeSignature` are not affected.
   - `INameProvider` and `ITypeDescriptor` are not affected.
   - CustomAttribute signatures holding strings as arguments are affected, but it is made possible to use both `string` and `Utf8String` as arguments in the `Element` or `Elements` property of `CustomAttributeArgument`.
- Preservation of invalid UTF-8 code sequences.

Closes #200 

This is a breaking change.