### PR TITLE
Strings stream optimization

### DIFF
--- a/docs/dotnet/advanced-pe-image-building.rst
+++ b/docs/dotnet/advanced-pe-image-building.rst
@@ -99,6 +99,27 @@ If everything is supposed to be preserved as much as possible, then instead of s
     Preserving RIDs within metadata tables might require AsmResolver to make use of the Edit-And-Continue metadata tables (such as the pointer tables). The resulting tables stream could therefore be renamed from ``#~`` to ``#-``, and the file size might increase.
 
 
+String folding in #Strings stream
+---------------------------------
+
+Named metadata members (such as types, methods and fields) are assigned a name by referencing a string in the ``#Strings`` stream by its starting offset. When a metadata member has a name that is a suffix of another member's name, then it is possible to only store the longer name in the ``#Strings`` stream, and let the member with the shorter name use an offset within the middle of this longer name. For example, consider two members with the names ``ABCDEFG`` and ``DEFG``. If ``ABCDEFG`` is stored at offset ``1``, then the name ``DEFG`` is implicitly defined at offset ``1 + 3 = 4``, and can thus be referenced without appending ``DEFG`` to the stream a second time.
+
+By default, the PE image builder will fold strings in the ``#Strings`` stream as described in the above. However, for some input binaries, this might make the building process take a significant amount of time. Therefore, to disable this folding of strings, specify the ``NoStringsStreamOptimization`` flag in your ``DotNetDirectoryFactory``:
+
+.. code-block:: csharp
+
+    factory.MetadataBuilderFlags |= MetadataBuilderFlags.NoStringsStreamOptimization;
+
+
+.. warning::
+    Some obfuscated binaries might include lots of members that have very long but similar names. For these types of binaries, disabling this optimization can result in a significantly larger output file size.
+
+
+.. note::
+
+    When ``PreserveStringIndices`` is set and string folding is enabled (``NoStringsStreamOptimization`` is unset), the PE image builder will not fold strings from the original ``#Strings`` stream into each other. However, it will still try to reuse these original strings as much as possible.
+
+
 Preserving maximum stack depth
 ------------------------------
 

--- a/src/AsmResolver.DotNet/Builder/DotNetDirectoryBuffer.MemberTree.cs
+++ b/src/AsmResolver.DotNet/Builder/DotNetDirectoryBuffer.MemberTree.cs
@@ -204,7 +204,7 @@ namespace AsmResolver.DotNet.Builder
                 // serialization of the method body, as well as determining the parameter list.
 
                 var row = new MethodDefinitionRow(
-                    SegmentReference.Null, 
+                    SegmentReference.Null,
                     method.ImplAttributes,
                     method.Attributes,
                     Metadata.StringsStream.GetStringIndex(method.Name),
@@ -301,14 +301,10 @@ namespace AsmResolver.DotNet.Builder
                 var type = _tokenMapping.GetTypeByToken(typeToken);
 
                 // Update extends, field list and method list columns.
-                var typeRow = typeDefTable[rid];
-                typeDefTable[rid] = new TypeDefinitionRow(
-                    typeRow.Attributes,
-                    typeRow.Name,
-                    typeRow.Namespace,
-                    GetTypeDefOrRefIndex(type.BaseType),
-                    fieldList,
-                    methodList);
+                ref var typeRow = ref typeDefTable.GetRowRef(rid);
+                typeRow.Extends = GetTypeDefOrRefIndex(type.BaseType);
+                typeRow.FieldList = fieldList;
+                typeRow.MethodList = methodList;
 
                 // Finalize fields and methods.
                 FinalizeFieldsInType(type, ref fieldPtrRequired);
@@ -412,15 +408,9 @@ namespace AsmResolver.DotNet.Builder
                 var method = _tokenMapping.GetMethodByToken(newToken);
 
                 // Serialize method body and update column.
-                var row = definitionTable[newToken.Rid];
-
-                definitionTable[newToken.Rid] = new MethodDefinitionRow(
-                    MethodBodySerializer.SerializeMethodBody(context, method),
-                    row.ImplAttributes,
-                    row.Attributes,
-                    row.Name,
-                    row.Signature,
-                    paramList);
+                ref var row = ref definitionTable.GetRowRef(rid);
+                row.Body = MethodBodySerializer.SerializeMethodBody(context, method);
+                row.ParameterList = paramList;
 
                 // Finalize parameters.
                 FinalizeParametersInMethod(method, ref paramList, ref paramPtrRequired);

--- a/src/AsmResolver.DotNet/Builder/DotNetDirectoryFactory.cs
+++ b/src/AsmResolver.DotNet/Builder/DotNetDirectoryFactory.cs
@@ -156,7 +156,10 @@ namespace AsmResolver.DotNet.Builder
 
         private IMetadataBuffer CreateMetadataBuffer(ModuleDefinition module)
         {
-            var metadataBuffer = new MetadataBuffer(module.RuntimeVersion);
+            var metadataBuffer = new MetadataBuffer(module.RuntimeVersion)
+            {
+                OptimizeStringIndices = (MetadataBuilderFlags & MetadataBuilderFlags.NoStringsStreamOptimization) == 0
+            };
 
             // Check if there exists a .NET directory to base off the metadata buffer on.
             var originalMetadata = module.DotNetDirectory?.Metadata;

--- a/src/AsmResolver.DotNet/Builder/Metadata/MetadataBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/MetadataBuffer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using AsmResolver.DotNet.Builder.Metadata.Blob;
 using AsmResolver.DotNet.Builder.Metadata.Guid;
 using AsmResolver.DotNet.Builder.Metadata.Strings;
@@ -9,6 +10,7 @@ using AsmResolver.PE.DotNet.Metadata.Blob;
 using AsmResolver.PE.DotNet.Metadata.Guid;
 using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
+using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 using AsmResolver.PE.DotNet.Metadata.UserStrings;
 
 namespace AsmResolver.DotNet.Builder.Metadata
@@ -67,6 +69,12 @@ namespace AsmResolver.DotNet.Builder.Metadata
             get;
         } = new();
 
+        public bool OptimizeStringIndices
+        {
+            get;
+            set;
+        } = true;
+
         /// <inheritdoc />
         public IMetadata CreateMetadata()
         {
@@ -78,6 +86,11 @@ namespace AsmResolver.DotNet.Builder.Metadata
 
             // Create and add streams.
             var tablesStream = Add<TablesStream>(result, TablesStream);
+
+            // Optimize strings.
+            if (OptimizeStringIndices)
+                OptimizeIndices(tablesStream);
+
             var stringsStream =  AddIfNotEmpty<StringsStream>(result, StringsStream);
             AddIfNotEmpty<UserStringsStream>(result, UserStringsStream);
             var guidStream = AddIfNotEmpty<GuidStream>(result, GuidStream);
@@ -105,6 +118,204 @@ namespace AsmResolver.DotNet.Builder.Metadata
             var stream = streamBuffer.CreateStream();
             metadata.Streams.Add(stream);
             return (TStream) stream;
+        }
+
+        private void OptimizeIndices(TablesStream tablesStream)
+        {
+            var translationTable = StringsStream.Optimize();
+
+            OptimizeAssemblyTable(translationTable, tablesStream);
+            OptimizeAssemblyReferenceTable(translationTable, tablesStream);
+            OptimizeEventDefinitionTable(translationTable, tablesStream);
+            OptimizeExportedTypeTable(translationTable, tablesStream);
+            OptimizeFieldDefinitionTable(translationTable, tablesStream);
+            OptimizeFileReferenceTable(translationTable, tablesStream);
+            OptimizeGenericParameterTable(translationTable, tablesStream);
+            OptimizeImplementationMapTable(translationTable, tablesStream);
+            OptimizeManifestResourceTable(translationTable, tablesStream);
+            OptimizeMemberReferenceTable(translationTable, tablesStream);
+            OptimizeMethodDefinitionTable(translationTable, tablesStream);
+            OptimizeModuleDefinitionTable(translationTable, tablesStream);
+            OptimizeModuleReferenceTable(translationTable, tablesStream);
+            OptimizeParameterDefinitionTable(translationTable, tablesStream);
+            OptimizePropertyDefinitionTable(translationTable, tablesStream);
+            OptimizeTypeDefinitionTable(translationTable, tablesStream);
+            OptimizeTypeReferenceTable(translationTable, tablesStream);
+        }
+
+        private void OptimizeAssemblyTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        {
+            var table = tablesStream.GetTable<AssemblyDefinitionRow>(TableIndex.Assembly);
+            for (uint rid = 1; rid <= table.Count; rid++)
+            {
+                ref var row = ref table.GetRowRef(rid);
+                row.Name = translationTable[row.Name];
+                row.Culture = translationTable[row.Culture];
+            }
+        }
+
+        private void OptimizeAssemblyReferenceTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        {
+            var table = tablesStream.GetTable<AssemblyReferenceRow>(TableIndex.AssemblyRef);
+            for (uint rid = 1; rid <= table.Count; rid++)
+            {
+                ref var row = ref table.GetRowRef(rid);
+                row.Name = translationTable[row.Name];
+                row.Culture = translationTable[row.Culture];
+            }
+        }
+
+        private void OptimizeEventDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        {
+            var table = tablesStream.GetTable<EventDefinitionRow>(TableIndex.Event);
+            for (uint rid = 1; rid <= table.Count; rid++)
+            {
+                ref var row = ref table.GetRowRef(rid);
+                row.Name = translationTable[row.Name];
+            }
+        }
+
+        private void OptimizeExportedTypeTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        {
+            var table = tablesStream.GetTable<ExportedTypeRow>(TableIndex.ExportedType);
+            for (uint rid = 1; rid <= table.Count; rid++)
+            {
+                ref var row = ref table.GetRowRef(rid);
+                row.Name = translationTable[row.Name];
+                row.Namespace = translationTable[row.Namespace];
+            }
+        }
+
+        private void OptimizeFieldDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        {
+            var table = tablesStream.GetTable<FieldDefinitionRow>(TableIndex.Field);
+            for (uint rid = 1; rid <= table.Count; rid++)
+            {
+                ref var row = ref table.GetRowRef(rid);
+                row.Name = translationTable[row.Name];
+            }
+        }
+
+        private void OptimizeFileReferenceTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        {
+            var table = tablesStream.GetTable<FileReferenceRow>(TableIndex.File);
+            for (uint rid = 1; rid <= table.Count; rid++)
+            {
+                ref var row = ref table.GetRowRef(rid);
+                row.Name = translationTable[row.Name];
+            }
+        }
+
+        private void OptimizeGenericParameterTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        {
+            var table = tablesStream.GetTable<GenericParameterRow>(TableIndex.GenericParam);
+            for (uint rid = 1; rid <= table.Count; rid++)
+            {
+                ref var row = ref table.GetRowRef(rid);
+                row.Name = translationTable[row.Name];
+            }
+        }
+
+        private void OptimizeImplementationMapTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        {
+            var table = tablesStream.GetTable<ImplementationMapRow>(TableIndex.ImplMap);
+            for (uint rid = 1; rid <= table.Count; rid++)
+            {
+                ref var row = ref table.GetRowRef(rid);
+                row.ImportName = translationTable[row.ImportName];
+            }
+        }
+
+        private void OptimizeManifestResourceTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        {
+            var table = tablesStream.GetTable<ManifestResourceRow>(TableIndex.ManifestResource);
+            for (uint rid = 1; rid <= table.Count; rid++)
+            {
+                ref var row = ref table.GetRowRef(rid);
+                row.Name = translationTable[row.Name];
+            }
+        }
+
+        private void OptimizeMemberReferenceTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        {
+            var table = tablesStream.GetTable<MemberReferenceRow>(TableIndex.MemberRef);
+            for (uint rid = 1; rid <= table.Count; rid++)
+            {
+                ref var row = ref table.GetRowRef(rid);
+                row.Name = translationTable[row.Name];
+            }
+        }
+
+        private void OptimizeMethodDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        {
+            var table = tablesStream.GetTable<MethodDefinitionRow>(TableIndex.Method);
+            for (uint rid = 1; rid <= table.Count; rid++)
+            {
+                ref var row = ref table.GetRowRef(rid);
+                row.Name = translationTable[row.Name];
+            }
+        }
+
+        private void OptimizeModuleDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        {
+            var table = tablesStream.GetTable<ModuleDefinitionRow>(TableIndex.Module);
+            for (uint rid = 1; rid <= table.Count; rid++)
+            {
+                ref var row = ref table.GetRowRef(rid);
+                row.Name = translationTable[row.Name];
+            }
+        }
+
+        private void OptimizeModuleReferenceTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        {
+            var table = tablesStream.GetTable<ModuleReferenceRow>(TableIndex.ModuleRef);
+            for (uint rid = 1; rid <= table.Count; rid++)
+            {
+                ref var row = ref table.GetRowRef(rid);
+                row.Name = translationTable[row.Name];
+            }
+        }
+
+        private void OptimizeParameterDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        {
+            var table = tablesStream.GetTable<ParameterDefinitionRow>(TableIndex.Param);
+            for (uint rid = 1; rid <= table.Count; rid++)
+            {
+                ref var row = ref table.GetRowRef(rid);
+                row.Name = translationTable[row.Name];
+            }
+        }
+
+        private void OptimizePropertyDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        {
+            var table = tablesStream.GetTable<PropertyDefinitionRow>(TableIndex.Property);
+            for (uint rid = 1; rid <= table.Count; rid++)
+            {
+                ref var row = ref table.GetRowRef(rid);
+                row.Name = translationTable[row.Name];
+            }
+        }
+
+        private void OptimizeTypeDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        {
+            var table = tablesStream.GetTable<TypeDefinitionRow>(TableIndex.TypeDef);
+            for (uint rid = 1; rid <= table.Count; rid++)
+            {
+                ref var row = ref table.GetRowRef(rid);
+                row.Name = translationTable[row.Name];
+                row.Namespace = translationTable[row.Namespace];
+            }
+        }
+
+        private void OptimizeTypeReferenceTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        {
+            var table = tablesStream.GetTable<TypeReferenceRow>(TableIndex.TypeRef);
+            for (uint rid = 1; rid <= table.Count; rid++)
+            {
+                ref var row = ref table.GetRowRef(rid);
+                row.Name = translationTable[row.Name];
+                row.Namespace = translationTable[row.Namespace];
+            }
         }
     }
 }

--- a/src/AsmResolver.DotNet/Builder/Metadata/MetadataBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/MetadataBuffer.cs
@@ -69,6 +69,12 @@ namespace AsmResolver.DotNet.Builder.Metadata
             get;
         } = new();
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the strings stream should be optimized for size upon constructing
+        /// the metadata directory. This means that strings that are a suffix of another will not be added twice to the
+        /// buffer, but rather will be referenced using an offset within the longer string. This avoids lots of
+        /// duplication in the final stream.
+        /// </summary>
         public bool OptimizeStringIndices
         {
             get;
@@ -143,7 +149,7 @@ namespace AsmResolver.DotNet.Builder.Metadata
             OptimizeTypeReferenceTable(translationTable, tablesStream);
         }
 
-        private void OptimizeAssemblyTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        private static void OptimizeAssemblyTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
         {
             var table = tablesStream.GetTable<AssemblyDefinitionRow>(TableIndex.Assembly);
             for (uint rid = 1; rid <= table.Count; rid++)
@@ -154,7 +160,7 @@ namespace AsmResolver.DotNet.Builder.Metadata
             }
         }
 
-        private void OptimizeAssemblyReferenceTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        private static void OptimizeAssemblyReferenceTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
         {
             var table = tablesStream.GetTable<AssemblyReferenceRow>(TableIndex.AssemblyRef);
             for (uint rid = 1; rid <= table.Count; rid++)
@@ -165,7 +171,7 @@ namespace AsmResolver.DotNet.Builder.Metadata
             }
         }
 
-        private void OptimizeEventDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        private static void OptimizeEventDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
         {
             var table = tablesStream.GetTable<EventDefinitionRow>(TableIndex.Event);
             for (uint rid = 1; rid <= table.Count; rid++)
@@ -175,7 +181,7 @@ namespace AsmResolver.DotNet.Builder.Metadata
             }
         }
 
-        private void OptimizeExportedTypeTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        private static void OptimizeExportedTypeTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
         {
             var table = tablesStream.GetTable<ExportedTypeRow>(TableIndex.ExportedType);
             for (uint rid = 1; rid <= table.Count; rid++)
@@ -186,7 +192,7 @@ namespace AsmResolver.DotNet.Builder.Metadata
             }
         }
 
-        private void OptimizeFieldDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        private static void OptimizeFieldDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
         {
             var table = tablesStream.GetTable<FieldDefinitionRow>(TableIndex.Field);
             for (uint rid = 1; rid <= table.Count; rid++)
@@ -196,7 +202,7 @@ namespace AsmResolver.DotNet.Builder.Metadata
             }
         }
 
-        private void OptimizeFileReferenceTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        private static void OptimizeFileReferenceTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
         {
             var table = tablesStream.GetTable<FileReferenceRow>(TableIndex.File);
             for (uint rid = 1; rid <= table.Count; rid++)
@@ -206,7 +212,7 @@ namespace AsmResolver.DotNet.Builder.Metadata
             }
         }
 
-        private void OptimizeGenericParameterTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        private static void OptimizeGenericParameterTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
         {
             var table = tablesStream.GetTable<GenericParameterRow>(TableIndex.GenericParam);
             for (uint rid = 1; rid <= table.Count; rid++)
@@ -216,7 +222,7 @@ namespace AsmResolver.DotNet.Builder.Metadata
             }
         }
 
-        private void OptimizeImplementationMapTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        private static void OptimizeImplementationMapTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
         {
             var table = tablesStream.GetTable<ImplementationMapRow>(TableIndex.ImplMap);
             for (uint rid = 1; rid <= table.Count; rid++)
@@ -226,7 +232,7 @@ namespace AsmResolver.DotNet.Builder.Metadata
             }
         }
 
-        private void OptimizeManifestResourceTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        private static void OptimizeManifestResourceTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
         {
             var table = tablesStream.GetTable<ManifestResourceRow>(TableIndex.ManifestResource);
             for (uint rid = 1; rid <= table.Count; rid++)
@@ -236,7 +242,7 @@ namespace AsmResolver.DotNet.Builder.Metadata
             }
         }
 
-        private void OptimizeMemberReferenceTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        private static void OptimizeMemberReferenceTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
         {
             var table = tablesStream.GetTable<MemberReferenceRow>(TableIndex.MemberRef);
             for (uint rid = 1; rid <= table.Count; rid++)
@@ -246,7 +252,7 @@ namespace AsmResolver.DotNet.Builder.Metadata
             }
         }
 
-        private void OptimizeMethodDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        private static void OptimizeMethodDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
         {
             var table = tablesStream.GetTable<MethodDefinitionRow>(TableIndex.Method);
             for (uint rid = 1; rid <= table.Count; rid++)
@@ -256,7 +262,7 @@ namespace AsmResolver.DotNet.Builder.Metadata
             }
         }
 
-        private void OptimizeModuleDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        private static void OptimizeModuleDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
         {
             var table = tablesStream.GetTable<ModuleDefinitionRow>(TableIndex.Module);
             for (uint rid = 1; rid <= table.Count; rid++)
@@ -266,7 +272,7 @@ namespace AsmResolver.DotNet.Builder.Metadata
             }
         }
 
-        private void OptimizeModuleReferenceTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        private static void OptimizeModuleReferenceTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
         {
             var table = tablesStream.GetTable<ModuleReferenceRow>(TableIndex.ModuleRef);
             for (uint rid = 1; rid <= table.Count; rid++)
@@ -276,7 +282,7 @@ namespace AsmResolver.DotNet.Builder.Metadata
             }
         }
 
-        private void OptimizeParameterDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        private static void OptimizeParameterDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
         {
             var table = tablesStream.GetTable<ParameterDefinitionRow>(TableIndex.Param);
             for (uint rid = 1; rid <= table.Count; rid++)
@@ -286,7 +292,7 @@ namespace AsmResolver.DotNet.Builder.Metadata
             }
         }
 
-        private void OptimizePropertyDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        private static void OptimizePropertyDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
         {
             var table = tablesStream.GetTable<PropertyDefinitionRow>(TableIndex.Property);
             for (uint rid = 1; rid <= table.Count; rid++)
@@ -296,7 +302,7 @@ namespace AsmResolver.DotNet.Builder.Metadata
             }
         }
 
-        private void OptimizeTypeDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        private static void OptimizeTypeDefinitionTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
         {
             var table = tablesStream.GetTable<TypeDefinitionRow>(TableIndex.TypeDef);
             for (uint rid = 1; rid <= table.Count; rid++)
@@ -307,7 +313,7 @@ namespace AsmResolver.DotNet.Builder.Metadata
             }
         }
 
-        private void OptimizeTypeReferenceTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
+        private static void OptimizeTypeReferenceTable(IDictionary<uint, uint> translationTable, TablesStream tablesStream)
         {
             var table = tablesStream.GetTable<TypeReferenceRow>(TableIndex.TypeRef);
             for (uint rid = 1; rid <= table.Count; rid++)

--- a/src/AsmResolver.DotNet/Builder/Metadata/Strings/StringIndex.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Strings/StringIndex.cs
@@ -1,0 +1,26 @@
+namespace AsmResolver.DotNet.Builder.Metadata.Strings
+{
+    internal readonly struct StringIndex
+    {
+        public StringIndex(int blobIndex, uint offset)
+        {
+            BlobIndex = blobIndex;
+            Offset = offset;
+        }
+
+        public int BlobIndex
+        {
+            get;
+        }
+
+        public uint Offset
+        {
+            get;
+        }
+
+        #if DEBUG
+        /// <inheritdoc />
+        public override string ToString() => $"{nameof(BlobIndex)}: {BlobIndex}, {nameof(Offset)}: {Offset}";
+        #endif
+    }
+}

--- a/src/AsmResolver.DotNet/Builder/Metadata/Strings/StringsStreamBlob.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Strings/StringsStreamBlob.cs
@@ -1,0 +1,46 @@
+using AsmResolver.IO;
+
+namespace AsmResolver.DotNet.Builder.Metadata.Strings
+{
+    internal readonly struct StringsStreamBlob : IWritable
+    {
+        public StringsStreamBlob(Utf8String blob, bool isFixed)
+        {
+            Blob = blob.GetBytesUnsafe();
+            Flags = isFixed
+                ? StringsStreamBlobFlags.ZeroTerminated | StringsStreamBlobFlags.Fixed
+                : StringsStreamBlobFlags.ZeroTerminated;
+        }
+
+        public StringsStreamBlob(Utf8String blob, StringsStreamBlobFlags flags)
+        {
+            Blob = blob;
+            Flags = flags;
+        }
+
+        public Utf8String Blob
+        {
+            get;
+        }
+
+        public StringsStreamBlobFlags Flags
+        {
+            get;
+        }
+
+        public bool IsZeroTerminated => (Flags & StringsStreamBlobFlags.ZeroTerminated) != 0;
+
+        public bool IsFixed => (Flags & StringsStreamBlobFlags.Fixed) != 0;
+
+        /// <inheritdoc />
+        public uint GetPhysicalSize() => (uint) (Blob.Length + (IsZeroTerminated ? 1 : 0));
+
+        /// <inheritdoc />
+        public void Write(IBinaryStreamWriter writer)
+        {
+            writer.WriteBytes(Blob.GetBytesUnsafe());
+            if (IsZeroTerminated)
+                writer.WriteByte(0);
+        }
+    }
+}

--- a/src/AsmResolver.DotNet/Builder/Metadata/Strings/StringsStreamBlobFlags.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Strings/StringsStreamBlobFlags.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace AsmResolver.DotNet.Builder.Metadata.Strings
+{
+    [Flags]
+    internal enum StringsStreamBlobFlags : byte
+    {
+        ZeroTerminated = 1,
+        Fixed = 2
+    }
+}

--- a/src/AsmResolver.DotNet/Builder/Metadata/Strings/StringsStreamBlobSuffixComparer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Strings/StringsStreamBlobSuffixComparer.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+
+namespace AsmResolver.DotNet.Builder.Metadata.Strings
+{
+    /// <summary>
+    /// Provides an implementation of a string comparer that groups strings with the same suffix next to each other.
+    /// The largest string is ordered first, and any string that is a suffix of this large string will follow in
+    /// descending order.
+    /// </summary>
+    internal sealed class StringsStreamBlobSuffixComparer : IComparer<byte[]>, IComparer<StringsStreamBlob>,  IComparer<KeyValuePair<Utf8String, StringIndex>>
+    {
+        /// <summary>
+        /// Gets the instance of the suffix comparer.
+        /// </summary>
+        public static StringsStreamBlobSuffixComparer Instance
+        {
+            get;
+        } = new();
+
+        /// <inheritdoc />
+        public int Compare(StringsStreamBlob x, StringsStreamBlob y)
+        {
+            return Compare(x.Blob.GetBytesUnsafe(), y.Blob.GetBytesUnsafe());
+        }
+
+        public int Compare(KeyValuePair<Utf8String, StringIndex> x, KeyValuePair<Utf8String, StringIndex> y)
+        {
+            return Compare(x.Key.GetBytesUnsafe(), y.Key.GetBytesUnsafe());
+        }
+
+        /// <inheritdoc />
+        public int Compare(byte[] x, byte[] y)
+        {
+            for (int i = x.Length - 1, j = y.Length - 1; i >= 0 && j >= 0; i--, j--)
+            {
+                int charComparison = x[i].CompareTo(y[j]);
+                if (charComparison != 0)
+                    return charComparison;
+            }
+
+            return y.Length.CompareTo(x.Length);
+        }
+    }
+}

--- a/src/AsmResolver.DotNet/Builder/Metadata/Strings/StringsStreamBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Strings/StringsStreamBuffer.cs
@@ -129,15 +129,16 @@ namespace AsmResolver.DotNet.Builder.Metadata.Strings
             for (int i = 0; i < sortedEntries.Count; i++)
             {
                 var currentEntry = sortedEntries[i];
+                var currentBlob = _blobs[currentEntry.Value.BlobIndex];
 
                 // Ignore blobs that are already added.
-                if (_blobs[currentEntry.Value.BlobIndex].IsFixed)
+                if (currentBlob.IsFixed)
                     continue;
 
                 if (i == 0)
                 {
                     // First blob should always be added, since it has no common prefix with anything else.
-                    AppendBlob(_blobs[currentEntry.Value.BlobIndex]);
+                    AppendBlob(currentBlob);
                 }
                 else
                 {
@@ -150,7 +151,7 @@ namespace AsmResolver.DotNet.Builder.Metadata.Strings
                     if (reusedIndex != i)
                         ReuseBlob(currentEntry, reusedIndex);
                     else
-                        AppendBlob(_blobs[currentEntry.Value.BlobIndex]);
+                        AppendBlob(currentBlob);
                 }
             }
 

--- a/src/AsmResolver.DotNet/Builder/Metadata/Strings/StringsStreamBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Strings/StringsStreamBuffer.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
+using System.Linq;
 using AsmResolver.IO;
 using AsmResolver.PE.DotNet.Metadata;
 using AsmResolver.PE.DotNet.Metadata.Strings;
@@ -13,9 +13,10 @@ namespace AsmResolver.DotNet.Builder.Metadata.Strings
     /// </summary>
     public class StringsStreamBuffer : IMetadataStreamBuffer
     {
-        private readonly MemoryStream _rawStream = new();
-        private readonly IBinaryStreamWriter _writer;
-        private readonly Dictionary<Utf8String, uint> _strings = new();
+        private readonly Dictionary<Utf8String, StringIndex> _index = new();
+        private List<StringsStreamBlob> _blobs = new();
+        private uint _currentOffset = 1;
+        private int _fixedBlobCount = 0;
 
         /// <summary>
         /// Creates a new strings stream buffer with the default strings stream name.
@@ -32,8 +33,6 @@ namespace AsmResolver.DotNet.Builder.Metadata.Strings
         public StringsStreamBuffer(string name)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
-            _writer = new BinaryStreamWriter(_rawStream);
-            _writer.WriteByte(0);
         }
 
         /// <inheritdoc />
@@ -43,46 +42,38 @@ namespace AsmResolver.DotNet.Builder.Metadata.Strings
         }
 
         /// <inheritdoc />
-        public bool IsEmpty => _rawStream.Length <= 1;
+        public bool IsEmpty => _blobs.Count == 0;
 
         /// <summary>
         /// Imports the contents of a strings stream and indexes all present strings.
         /// </summary>
         /// <param name="stream">The stream to import.</param>
+        /// <exception cref="InvalidOperationException">Occurs when the stream buffer is not empty.</exception>
         public void ImportStream(StringsStream stream)
         {
-            uint index = 1;
-            while (index < stream.GetPhysicalSize())
-            {
-                var @string = stream.GetStringByIndex(index)!;
-                uint newIndex = AppendString(@string);
-                _strings[@string] = newIndex;
+            if (!IsEmpty)
+                throw new InvalidOperationException("Cannot import a stream if the buffer is not empty.");
 
-                index += (uint) Encoding.UTF8.GetByteCount(@string) + 1;
+            uint offset = 1;
+            uint size = stream.GetPhysicalSize();
+
+            while (offset < size)
+            {
+                var value = stream.GetStringByIndex(offset)!;
+
+                uint newOffset = AppendString(value, true);
+                _index[value] = new StringIndex(_blobs.Count - 1, newOffset);
+
+                offset += (uint) value.ByteCount + 1;
+                _fixedBlobCount++;
             }
         }
 
-        /// <summary>
-        /// Appends raw data to the stream.
-        /// </summary>
-        /// <param name="data">The data to append.</param>
-        /// <returns>The index to the start of the data.</returns>
-        /// <remarks>
-        /// This method does not index the string. Calling <see cref="AppendRawData"/> or <see cref="GetStringIndex" />
-        /// on the same data will append the data a second time.
-        /// </remarks>
-        public uint AppendRawData(byte[] data)
+        private uint AppendString(Utf8String value, bool isFixed)
         {
-            uint offset = (uint) _rawStream.Length;
-            _writer.WriteBytes(data, 0, data.Length);
-            return offset;
-        }
-
-        private uint AppendString(Utf8String value)
-        {
-            uint offset = (uint) _rawStream.Length;
-            AppendRawData(value.GetBytesUnsafe());
-            _writer.WriteByte(0);
+            uint offset = _currentOffset;
+            _blobs.Add(new StringsStreamBlob(value, isFixed));
+            _currentOffset += (uint)value.ByteCount + 1;
             return offset;
         }
 
@@ -100,13 +91,104 @@ namespace AsmResolver.DotNet.Builder.Metadata.Strings
             if (Array.IndexOf(value.GetBytesUnsafe(), (byte) 0x00) >= 0)
                 throw new ArgumentException("String contains a zero byte.");
 
-            if (!_strings.TryGetValue(value, out uint offset))
+            if (!_index.TryGetValue(value, out var offsetId))
             {
-                offset = AppendString(value);
-                _strings.Add(value, offset);
+                uint offset = AppendString(value, false);
+                offsetId = new StringIndex(_blobs.Count - 1, offset);
+                _index.Add(value, offsetId);
             }
 
-            return offset;
+            return offsetId.Offset;
+        }
+
+        /// <summary>
+        /// Optimizes the buffer by removing string entries that have a common suffix with another.
+        /// </summary>
+        /// <returns>A translation table that maps old offsets to the new ones after optimizing.</returns>
+        /// <remarks>
+        /// This method might invalidate all offsets obtained by <see cref="GetStringIndex"/>.
+        /// </remarks>
+        public Dictionary<uint, uint> Optimize()
+        {
+            uint finalOffset = 1;
+            var newBlobs = new List<StringsStreamBlob>(_fixedBlobCount);
+            var translationTable = new Dictionary<uint, uint>();
+
+            // Import fixed blobs.
+            for (int i = 0; i < _fixedBlobCount; i++)
+                AppendBlob(_blobs[i]);
+
+            // Sort all blobs based on common suffix.
+            var sortedEntries = _index.ToList();
+            sortedEntries.Sort(StringsStreamBlobSuffixComparer.Instance);
+
+            for (int i = 0; i < sortedEntries.Count; i++)
+            {
+                var currentEntry = sortedEntries[i];
+
+                // Ignore blobs that are already added.
+                if (_blobs[currentEntry.Value.BlobIndex].IsFixed)
+                    continue;
+
+                if (i == 0)
+                {
+                    // First blob should always be added, since it has no common prefix with anything else.
+                    AppendBlob(_blobs[currentEntry.Value.BlobIndex]);
+                }
+                else
+                {
+                    // Check if any blobs have a common suffix.
+                    int reusedIndex = i;
+                    while (reusedIndex > 0 && BytesEndsWith(sortedEntries[reusedIndex - 1].Key.GetBytesUnsafe(), currentEntry.Key.GetBytesUnsafe()))
+                        reusedIndex--;
+
+                    // Reuse blob if blob had a common suffix.
+                    if (reusedIndex != i)
+                        ReuseBlob(currentEntry, reusedIndex);
+                    else
+                        AppendBlob(_blobs[currentEntry.Value.BlobIndex]);
+                }
+            }
+
+            // Replace contents of current buffer with the newly constructed buffer.
+            _blobs = newBlobs;
+            _currentOffset = finalOffset;
+            return translationTable;
+
+            void AppendBlob(in StringsStreamBlob blob)
+            {
+                newBlobs.Add(blob);
+
+                var index = _index[blob.Blob];
+                translationTable[index.Offset] = finalOffset;
+                _index[blob.Blob] = new StringIndex(index.BlobIndex, finalOffset);
+
+                finalOffset += blob.GetPhysicalSize();
+            }
+
+            void ReuseBlob(in KeyValuePair<Utf8String, StringIndex> currentEntry, int reusedIndex)
+            {
+                var reusedEntry = sortedEntries[reusedIndex];
+                int relativeOffset = reusedEntry.Key.ByteCount - currentEntry.Key.ByteCount;
+                uint newOffset = (uint)(reusedEntry.Value.Offset + relativeOffset);
+
+                translationTable[currentEntry.Value.Offset] = newOffset;
+                _index[currentEntry.Key] = new StringIndex(reusedEntry.Value.BlobIndex, newOffset);
+            }
+        }
+
+        private static bool BytesEndsWith(byte[] x, byte[] y)
+        {
+            if (x.Length < y.Length)
+                return false;
+
+            for (int i = x.Length - 1, j = y.Length - 1; i >= 0 && j >= 0; i--, j--)
+            {
+                if (x[i] != y[j])
+                    return false;
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -115,8 +197,17 @@ namespace AsmResolver.DotNet.Builder.Metadata.Strings
         /// <returns>The metadata stream.</returns>
         public StringsStream CreateStream()
         {
-            _writer.Align(4);
-            return new SerializedStringsStream(Name, _rawStream.ToArray());
+            using var outputStream = new MemoryStream();
+
+            var writer = new BinaryStreamWriter(outputStream);
+            writer.WriteByte(0);
+
+            foreach (var blob in _blobs)
+                blob.Write(writer);
+
+            writer.Align(4);
+
+            return new SerializedStringsStream(Name, outputStream.ToArray());
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/Builder/Metadata/Tables/DistinctMetadataTableBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Tables/DistinctMetadataTableBuffer.cs
@@ -45,6 +45,9 @@ namespace AsmResolver.DotNet.Builder.Metadata.Tables
         }
 
         /// <inheritdoc />
+        public ref TRow GetRowRef(uint rid) => ref _underlyingBuffer.GetRowRef(rid);
+
+        /// <inheritdoc />
         public MetadataToken Add(in TRow row)
         {
             if (!_entries.TryGetValue(row, out var token))

--- a/src/AsmResolver.DotNet/Builder/Metadata/Tables/IMetadataTableBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Tables/IMetadataTableBuffer.cs
@@ -45,6 +45,12 @@ namespace AsmResolver.DotNet.Builder.Metadata.Tables
         }
 
         /// <summary>
+        /// Gets or sets a reference to a row in the metadata table.
+        /// </summary>
+        /// <param name="rid">The identifier of the metadata row.</param>
+        ref TRow GetRowRef(uint rid);
+
+        /// <summary>
         /// Adds a row to the metadata table.
         /// </summary>
         /// <param name="row">The row to add.</param>

--- a/src/AsmResolver.DotNet/Builder/Metadata/Tables/UnsortedMetadataTableBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Tables/UnsortedMetadataTableBuffer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using AsmResolver.Collections;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
@@ -13,7 +14,7 @@ namespace AsmResolver.DotNet.Builder.Metadata.Tables
     public class UnsortedMetadataTableBuffer<TRow> : IMetadataTableBuffer<TRow>
         where TRow : struct, IMetadataRow
     {
-        private readonly List<TRow> _entries = new();
+        private readonly RefList<TRow> _entries = new();
         private readonly MetadataTable<TRow> _table;
 
         /// <summary>
@@ -34,6 +35,9 @@ namespace AsmResolver.DotNet.Builder.Metadata.Tables
             get => _entries[(int) (rid - 1)];
             set => _entries[(int) (rid - 1)] = value;
         }
+
+        /// <inheritdoc />
+        public ref TRow GetRowRef(uint rid) => ref _entries.GetElementRef((int)(rid - 1));
 
         /// <inheritdoc />
         public virtual MetadataToken Add(in TRow row)

--- a/src/AsmResolver.DotNet/Builder/MetadataBuilderFlags.cs
+++ b/src/AsmResolver.DotNet/Builder/MetadataBuilderFlags.cs
@@ -12,124 +12,136 @@ namespace AsmResolver.DotNet.Builder
         /// Indicates no special metadata builder flags.
         /// </summary>
         None = 0,
-        
+
         /// <summary>
         /// Indicates indices into the #Blob stream should be preserved whenever possible during the construction
-        /// of the metadata directory. 
+        /// of the metadata directory.
         /// </summary>
         PreserveBlobIndices = 0x1,
-        
+
         /// <summary>
         /// Indicates indices into the #GUID stream should be preserved whenever possible during the construction
-        /// of the metadata directory. 
+        /// of the metadata directory.
         /// </summary>
         PreserveGuidIndices = 0x2,
-        
+
         /// <summary>
         /// Indicates indices into the #Strings stream should be preserved whenever possible during the construction
-        /// of the metadata directory. 
+        /// of the metadata directory.
         /// </summary>
         PreserveStringIndices = 0x4,
-        
+
         /// <summary>
         /// Indicates indices into the #US stream should be preserved whenever possible during the construction
-        /// of the metadata directory. 
+        /// of the metadata directory.
         /// </summary>
         PreserveUserStringIndices = 0x8,
-        
+
         /// <summary>
         /// Indicates indices into the type references table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
         PreserveTypeReferenceIndices = 0x10,
-        
+
         /// <summary>
         /// Indicates indices into the type definition table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
         PreserveTypeDefinitionIndices = 0x20,
-        
+
         /// <summary>
         /// Indicates indices into the field definition table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
         PreserveFieldDefinitionIndices = 0x40,
-        
+
         /// <summary>
         /// Indicates indices into the method definition table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
         PreserveMethodDefinitionIndices = 0x80,
-        
+
         /// <summary>
         /// Indicates indices into the parameter definition table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
         PreserveParameterDefinitionIndices = 0x100,
-        
+
         /// <summary>
         /// Indicates indices into the member reference table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
         PreserveMemberReferenceIndices = 0x200,
-        
+
         /// <summary>
         /// Indicates indices into the stand-alone signature table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
         PreserveStandAloneSignatureIndices = 0x400,
-        
+
         /// <summary>
         /// Indicates indices into the event definition table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
         PreserveEventDefinitionIndices = 0x800,
-        
+
         /// <summary>
         /// Indicates indices into the property definition table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
         PreservePropertyDefinitionIndices = 0x1000,
-        
+
         /// <summary>
         /// Indicates indices into the module reference table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
         PreserveModuleReferenceIndices = 0x2000,
-        
+
         /// <summary>
         /// Indicates indices into the type specification table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
         PreserveTypeSpecificationIndices = 0x4000,
-        
+
         /// <summary>
         /// Indicates indices into the assembly reference table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
         PreserveAssemblyReferenceIndices = 0x8000,
-        
+
         /// <summary>
         /// Indicates indices into the method specification table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
         PreserveMethodSpecificationIndices = 0x10000,
-        
+
         /// <summary>
         /// Indicates indices into the tables stream should be preserved whenever possible during the construction
-        /// of the metadata directory. 
+        /// of the metadata directory.
         /// </summary>
         PreserveTableIndices = PreserveTypeReferenceIndices | PreserveTypeDefinitionIndices
             | PreserveFieldDefinitionIndices | PreserveMethodDefinitionIndices | PreserveParameterDefinitionIndices
             | PreserveMemberReferenceIndices | PreserveStandAloneSignatureIndices | PreserveEventDefinitionIndices
             | PreservePropertyDefinitionIndices | PreserveModuleReferenceIndices | PreserveTypeSpecificationIndices
             | PreserveAssemblyReferenceIndices | PreserveMethodSpecificationIndices,
-        
+
         /// <summary>
         /// Indicates any kind of index into a blob or tables stream should be preserved whenever possible during the
-        /// construction of the metadata directory. 
+        /// construction of the metadata directory.
         /// </summary>
-        PreserveAll = PreserveBlobIndices | PreserveGuidIndices | PreserveStringIndices | PreserveUserStringIndices 
+        PreserveAll = PreserveBlobIndices | PreserveGuidIndices | PreserveStringIndices | PreserveUserStringIndices
                       | PreserveTableIndices,
+
+        /// <summary>
+        /// <para>
+        /// By default, AsmResolver will optimize the #Strings stream for size. This means that strings that are a
+        /// suffix of another will not be added twice to the buffer, but rather will be referenced using an offset
+        /// within the longer string. This avoids lots of duplication in the final stream.
+        /// </para>
+        /// <para>
+        /// Setting this flag will disable this optimization.
+        /// </para>
+        /// </summary>
+        NoStringsStreamOptimization = 0x20000,
     }
 }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyDefinitionRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyDefinitionRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the assembly definition metadata table.
     /// </summary>
-    public readonly struct AssemblyDefinitionRow : IMetadataRow
+    public struct AssemblyDefinitionRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single assembly definition row from an input stream.
@@ -80,55 +80,61 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the hashing algorithm that was used to sign the assembly.
+        /// Gets or sets the hashing algorithm that was used to sign the assembly.
         /// </summary>
         public AssemblyHashAlgorithm HashAlgorithm
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the major version number of the assembly.
+        /// Gets or sets the major version number of the assembly.
         /// </summary>
         public ushort MajorVersion
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the minor version number of the assembly.
+        /// Gets or sets the minor version number of the assembly.
         /// </summary>
         public ushort MinorVersion
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the build number of the assembly.
+        /// Gets or sets the build number of the assembly.
         /// </summary>
         public ushort BuildNumber
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the revision number of the assembly.
+        /// Gets or sets the revision number of the assembly.
         /// </summary>
         public ushort RevisionNumber
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the attributes associated to the assembly.
+        /// Gets or sets the attributes associated to the assembly.
         /// </summary>
         public AssemblyAttributes Attributes
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Blob stream referencing the public key of the assembly to use for verification of
+        /// Gets or sets an index into the #Blob stream referencing the public key of the assembly to use for verification of
         /// a signature.
         /// </summary>
         /// <remarks>
@@ -137,18 +143,20 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint PublicKey
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings stream referencing the name of the assembly.
+        /// Gets or sets an index into the #Strings stream referencing the name of the assembly.
         /// </summary>
         public uint Name
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings stream referencing the locale string of the assembly.
+        /// Gets or sets an index into the #Strings stream referencing the locale string of the assembly.
         /// </summary>
         /// <remarks>
         /// When this field is set to zero, the default culture is used.
@@ -156,6 +164,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Culture
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyOSRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyOSRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the assembly operating system metadata table.
     /// </summary>
-    public readonly struct AssemblyOSRow : IMetadataRow
+    public struct AssemblyOSRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single assembly operating system row from an input stream.
@@ -53,27 +53,30 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the identifier of the platform the assembly is targeting.
+        /// Gets or sets the identifier of the platform the assembly is targeting.
         /// </summary>
         public uint PlatformId
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the major version of the platform the assembly is targeting.
+        /// Gets or sets the major version of the platform the assembly is targeting.
         /// </summary>
         public uint MajorVersion
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the minor version of the platform the assembly is targeting.
+        /// Gets or sets the minor version of the platform the assembly is targeting.
         /// </summary>
         public uint MinorVersion
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyProcessorRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyProcessorRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the assembly processor metadata table.
     /// </summary>
-    public readonly struct AssemblyProcessorRow : IMetadataRow
+    public struct AssemblyProcessorRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single assembly processor row from an input stream.
@@ -44,11 +44,12 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the processor identifier the assembly is targeting.
+        /// Gets or sets the processor identifier the assembly is targeting.
         /// </summary>
         public uint ProcessorId
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyRefOSRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyRefOSRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the assembly reference operating system metadata table.
     /// </summary>
-    public readonly struct AssemblyRefOSRow : IMetadataRow
+    public struct AssemblyRefOSRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single assembly reference operating system row from an input stream.
@@ -58,36 +58,40 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the identifier of the platform the assembly is targeting.
+        /// Gets or sets the identifier of the platform the assembly is targeting.
         /// </summary>
         public uint PlatformId
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the major version of the platform the assembly is targeting.
+        /// Gets or sets the major version of the platform the assembly is targeting.
         /// </summary>
         public uint MajorVersion
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the minor version of the platform the assembly is targeting.
+        /// Gets or sets the minor version of the platform the assembly is targeting.
         /// </summary>
         public uint MinorVersion
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the AssemblyRef table referencing the assembly reference that this operating system row
+        /// Gets or sets an index into the AssemblyRef table referencing the assembly reference that this operating system row
         /// was assigned to.
         /// </summary>
         public uint AssemblyReference
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyRefProcessorRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyRefProcessorRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the assembly reference processor metadata table.
     /// </summary>
-    public readonly struct AssemblyRefProcessorRow : IMetadataRow
+    public struct AssemblyRefProcessorRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single assembly reference processor row from an input stream.
@@ -49,20 +49,22 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the processor identifier the assembly is targeting.
+        /// Gets or sets the processor identifier the assembly is targeting.
         /// </summary>
         public uint ProcessorId
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the AssemblyRef table referencing the assembly reference that this processor row
+        /// Gets or sets an index into the AssemblyRef table referencing the assembly reference that this processor row
         /// was assigned to.
         /// </summary>
         public uint AssemblyReference
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyReferenceRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyReferenceRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the assembly definition metadata table.
     /// </summary>
-    public readonly struct AssemblyReferenceRow : IMetadataRow
+    public struct AssemblyReferenceRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single assembly definition row from an input stream.
@@ -79,47 +79,52 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the major version number of the assembly.
+        /// Gets or sets the major version number of the assembly.
         /// </summary>
         public ushort MajorVersion
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the minor version number of the assembly.
+        /// Gets or sets the minor version number of the assembly.
         /// </summary>
         public ushort MinorVersion
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the build number of the assembly.
+        /// Gets or sets the build number of the assembly.
         /// </summary>
         public ushort BuildNumber
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the revision number of the assembly.
+        /// Gets or sets the revision number of the assembly.
         /// </summary>
         public ushort RevisionNumber
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the attributes associated to the assembly.
+        /// Gets or sets the attributes associated to the assembly.
         /// </summary>
         public AssemblyAttributes Attributes
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Blob stream referencing the public key or token of the assembly to use for
+        /// Gets or sets an index into the #Blob stream referencing the public key or token of the assembly to use for
         /// verification of a signature.
         /// </summary>
         /// <remarks>
@@ -128,18 +133,20 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint PublicKeyOrToken
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings stream referencing the name of the assembly.
+        /// Gets or sets an index into the #Strings stream referencing the name of the assembly.
         /// </summary>
         public uint Name
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings stream referencing the locale string of the assembly.
+        /// Gets or sets an index into the #Strings stream referencing the locale string of the assembly.
         /// </summary>
         /// <remarks>
         /// When this field is set to zero, the default culture is used.
@@ -147,14 +154,16 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Culture
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Blob stream referencing the hash value of the assembly reference.
+        /// Gets or sets an index into the #Blob stream referencing the hash value of the assembly reference.
         /// </summary>
         public uint HashValue
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ClassLayoutRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ClassLayoutRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the class layout metadata table.
     /// </summary>
-    public readonly struct ClassLayoutRow : IMetadataRow
+    public struct ClassLayoutRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single class layout row from an input stream.
@@ -53,7 +53,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the alignment in bytes of each field in the type.
+        /// Gets or sets the alignment in bytes of each field in the type.
         /// </summary>
         /// <remarks>
         /// This value should be a power of two between 0 and 128.
@@ -61,22 +61,25 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public ushort PackingSize
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the size in bytes of the type.
+        /// Gets or sets the size in bytes of the type.
         /// </summary>
         public uint ClassSize
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the TypeDef table indicating the type that this layout is assigned to.
+        /// Gets or sets an index into the TypeDef table indicating the type that this layout is assigned to.
         /// </summary>
         public uint Parent
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ConstantRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ConstantRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the constants metadata table.
     /// </summary>
-    public readonly struct ConstantRow : IMetadataRow
+    public struct ConstantRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single constant row from an input stream.
@@ -73,7 +73,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the type of constant that is stored in the blob stream.
+        /// Gets or sets the type of constant that is stored in the blob stream.
         /// </summary>
         /// <remarks>This field must always be a value-type.</remarks>
         public ElementType Type
@@ -82,12 +82,13 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <summary>
-        /// Gets the single padding byte between the type and parent columns.
+        /// Gets or sets the single padding byte between the type and parent columns.
         /// </summary>
         /// <remarks>This field should always be zero.</remarks>
         public byte Padding
         {
             get;
+            set;
         }
 
         /// <summary>
@@ -97,14 +98,16 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Parent
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Blob stream containing the serialized constant value.
+        /// Gets or sets an index into the #Blob stream containing the serialized constant value.
         /// </summary>
         public uint Value
         {
             get;
+            set;
         }
 
         /// <summary>

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/CustomAttributeRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/CustomAttributeRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the custom attribute metadata table.
     /// </summary>
-    public readonly struct CustomAttributeRow : IMetadataRow
+    public struct CustomAttributeRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single custom attribute row from an input stream.
@@ -62,6 +62,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Parent
         {
             get;
+            set;
         }
 
         /// <summary>
@@ -71,14 +72,16 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Type
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Blob stream containing the arguments of the constructor call.
+        /// Gets or sets an index into the #Blob stream containing the arguments of the constructor call.
         /// </summary>
         public uint Value
         {
             get;
+            set;
         }
 
         /// <summary>

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/EncLogRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/EncLogRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the Edit-and-Continue log metadata table.
     /// </summary>
-    public readonly struct EncLogRow : IMetadataRow
+    public struct EncLogRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single edit-and-continue log row from an input stream.
@@ -49,19 +49,21 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the metadata token to apply the delta function to.
+        /// Gets or sets the metadata token to apply the delta function to.
         /// </summary>
         public MetadataToken Token
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the delta function to apply.
+        /// Gets or sets the delta function to apply.
         /// </summary>
         public DeltaFunctionCode FuncCode
         {
             get;
+            set;
         }
 
         /// <summary>

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/EncMapRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/EncMapRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the Edit-and-Continue remap metadata table.
     /// </summary>
-    public readonly struct EncMapRow : IMetadataRow
+    public struct EncMapRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single edit-and-continue remap row from an input stream.
@@ -44,11 +44,12 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the token that was remapped.
+        /// Gets or sets the token that was remapped.
         /// </summary>
         public MetadataToken Token
         {
             get;
+            set;
         }
 
         /// <summary>

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/EventDefinitionRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/EventDefinitionRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the event map metadata table.
     /// </summary>
-    public readonly struct EventDefinitionRow : IMetadataRow
+    public struct EventDefinitionRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single event definition row from an input stream.
@@ -54,15 +54,16 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the attributes associated to the event definition.
+        /// Gets or sets the attributes associated to the event definition.
         /// </summary>
         public EventAttributes Attributes
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings stream referencing the name of the event.
+        /// Gets or sets an index into the #Strings stream referencing the name of the event.
         /// </summary>
         /// <remarks>
         /// This value should always index a non-empty string.
@@ -70,6 +71,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Name
         {
             get;
+            set;
         }
 
         /// <summary>
@@ -79,6 +81,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint EventType
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/EventMapRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/EventMapRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the event map metadata table.
     /// </summary>
-    public readonly struct EventMapRow : IMetadataRow
+    public struct EventMapRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single event map row from an input stream.
@@ -49,19 +49,21 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets an index into the TypeDef table that this mapping is associating to an event list.
+        /// Gets or sets an index into the TypeDef table that this mapping is associating to an event list.
         /// </summary>
         public uint Parent
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the Event table indicating the first event that is defined in the event list.
+        /// Gets or sets an index into the Event table indicating the first event that is defined in the event list.
         /// </summary>
         public uint EventList
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/EventPointerRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/EventPointerRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the event pointer metadata table.
     /// </summary>
-    public readonly struct EventPointerRow : IMetadataRow
+    public struct EventPointerRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single event pointer row from an input stream.
@@ -44,11 +44,12 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets an index into the Event table that this pointer references.
+        /// Gets or sets an index into the Event table that this pointer references.
         /// </summary>
         public uint Event
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ExportedTypeRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ExportedTypeRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the exported type metadata table.
     /// </summary>
-    public readonly struct ExportedTypeRow : IMetadataRow
+    public struct ExportedTypeRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single exported type row from an input stream.
@@ -62,15 +62,16 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the attributes associated to the exported type.
+        /// Gets or sets the attributes associated to the exported type.
         /// </summary>
         public TypeAttributes Attributes
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the RID hint of the type definition that was exported.
+        /// Gets or sets the RID hint of the type definition that was exported.
         /// </summary>
         /// <remarks>
         /// This field is used as a hint only. If the entry in the table does not match the name and namespace referenced
@@ -80,10 +81,11 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint TypeDefinitionId
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings heap containing the name of the type reference.
+        /// Gets or sets an index into the #Strings heap containing the name of the type reference.
         /// </summary>
         /// <remarks>
         /// This value should always index a non-empty string.
@@ -91,10 +93,11 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Name
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings heap containing the namespace of the type reference.
+        /// Gets or sets an index into the #Strings heap containing the namespace of the type reference.
         /// </summary>
         /// <remarks>
         /// This value can be zero. If it is not, it should always index a non-empty string.
@@ -102,15 +105,17 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Namespace
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an Implementation index (an index into either the File, ExportedType or AssemblyRef table), indicating
+        /// Gets or sets an Implementation index (an index into either the File, ExportedType or AssemblyRef table), indicating
         /// the scope that can be used to resolve the exported type.
         /// </summary>
         public uint Implementation
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FieldDefinitionRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FieldDefinitionRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the field definition metadata table.
     /// </summary>
-    public readonly struct FieldDefinitionRow : IMetadataRow
+    public struct FieldDefinitionRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single field definition row from an input stream.
@@ -53,15 +53,16 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the attributes associated to the field definition.
+        /// Gets or sets the attributes associated to the field definition.
         /// </summary>
         public FieldAttributes Attributes
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings heap containing the name of the type reference.
+        /// Gets or sets an index into the #Strings heap containing the name of the type reference.
         /// </summary>
         /// <remarks>
         /// This value should always index a non-empty string.
@@ -69,10 +70,11 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Name
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Blob heap containing the signature of the field. This includes the field type.
+        /// Gets or sets an index into the #Blob heap containing the signature of the field. This includes the field type.
         /// </summary>
         /// <remarks>
         /// This value should always index a valid field signature.

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FieldLayoutRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FieldLayoutRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the field layout metadata table.
     /// </summary>
-    public readonly struct FieldLayoutRow : IMetadataRow
+    public struct FieldLayoutRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single field layout row from an input stream.
@@ -49,19 +49,21 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the offset of the field relative to the start of the enclosing structure type.
+        /// Gets or sets the offset of the field relative to the start of the enclosing structure type.
         /// </summary>
         public uint Offset
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the Field type referencing the field that this layout was assigned to.
+        /// Gets or sets an index into the Field type referencing the field that this layout was assigned to.
         /// </summary>
         public uint Field
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FieldMarshalRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FieldMarshalRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the field marshal metadata table.
     /// </summary>
-    public readonly struct FieldMarshalRow : IMetadataRow
+    public struct FieldMarshalRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single field marshal row from an input stream.
@@ -56,14 +56,16 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Parent
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Blob stream containing the marshaller data.
+        /// Gets or sets an index into the #Blob stream containing the marshaller data.
         /// </summary>
         public uint NativeType
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FieldPointerRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FieldPointerRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the field pointer metadata table.
     /// </summary>
-    public readonly struct FieldPointerRow : IMetadataRow
+    public struct FieldPointerRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single field pointer row from an input stream.
@@ -44,11 +44,12 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets an index into the Field table that this pointer references.
+        /// Gets or sets an index into the Field table that this pointer references.
         /// </summary>
         public uint Field
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FieldRvaRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FieldRvaRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the implementation map metadata table.
     /// </summary>
-    public readonly struct FieldRvaRow : IMetadataRow
+    public struct FieldRvaRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single field RVA row from an input stream.
@@ -60,14 +60,16 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public ISegmentReference Data
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the Field table indicating the field that was assigned an initial value.
+        /// Gets or sets an index into the Field table indicating the field that was assigned an initial value.
         /// </summary>
         public uint Field
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FileReferenceRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FileReferenceRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the file metadata table.
     /// </summary>
-    public readonly struct FileReferenceRow : IMetadataRow
+    public struct FileReferenceRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single file row from an input stream.
@@ -53,27 +53,30 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the attributes associated to the file reference.
+        /// Gets or sets the attributes associated to the file reference.
         /// </summary>
         public FileAttributes Attributes
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings stream referencing the name of the file.
+        /// Gets or sets an index into the #Strings stream referencing the name of the file.
         /// </summary>
         public uint Name
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Blob stream referencing the hash value of the file.
+        /// Gets or sets an index into the #Blob stream referencing the hash value of the file.
         /// </summary>
         public uint HashValue
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/GenericParameterConstraintRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/GenericParameterConstraintRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the generic parameter metadata table.
     /// </summary>
-    public readonly struct GenericParameterConstraintRow : IMetadataRow
+    public struct GenericParameterConstraintRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single generic parameter row from an input stream.
@@ -50,11 +50,12 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets an index into the GenericParam table indicating the owner of the constraint.
+        /// Gets or sets an index into the GenericParam table indicating the owner of the constraint.
         /// </summary>
         public uint Owner
         {
             get;
+            set;
         }
 
         /// <summary>
@@ -64,6 +65,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Constraint
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/GenericParameterRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/GenericParameterRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the generic parameter metadata table.
     /// </summary>
-    public readonly struct GenericParameterRow : IMetadataRow
+    public struct GenericParameterRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single generic parameter row from an input stream.
@@ -57,19 +57,21 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the index of the generic parameter.
+        /// Gets or sets the index of the generic parameter.
         /// </summary>
         public ushort Number
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the attributes associated to the generic parameter.
+        /// Gets or sets the attributes associated to the generic parameter.
         /// </summary>
         public GenericParameterAttributes Attributes
         {
             get;
+            set;
         }
 
         /// <summary>
@@ -79,14 +81,16 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Owner
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings stream referencing the name of the generic parameter.
+        /// Gets or sets an index into the #Strings stream referencing the name of the generic parameter.
         /// </summary>
         public uint Name
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/IMetadataRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/IMetadataRow.cs
@@ -16,7 +16,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         #endif
     {
         /// <summary>
-        /// Gets the index of the table that this row is stored in.
+        /// Gets or sets the index of the table that this row is stored in.
         /// </summary>
         TableIndex TableIndex
         {
@@ -25,7 +25,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
 
         #if NET20 || NET35 || NET40
         /// <summary>
-        /// Gets the number of columns that the metadata row defines.
+        /// Gets or sets the number of columns that the metadata row defines.
         /// </summary>
         int Count
         {
@@ -33,7 +33,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <summary>
-        /// Gets the value of a column, zero-extended to an unsigned int32.
+        /// Gets or sets the value of a column, zero-extended to an unsigned int32.
         /// </summary>
         /// <param name="index">The column index.</param>
         uint this[int index]

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ImplementationMapRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ImplementationMapRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the implementation map metadata table.
     /// </summary>
-    public readonly struct ImplementationMapRow : IMetadataRow
+    public struct ImplementationMapRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single implementation map row from an input stream.
@@ -58,7 +58,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the attributes associated to the implementation mapping.
+        /// Gets or sets the attributes associated to the implementation mapping.
         /// </summary>
         public ImplementationMapAttributes Attributes
         {
@@ -72,22 +72,25 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint MemberForwarded
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings stream referencing the name of the imported member.
+        /// Gets or sets an index into the #Strings stream referencing the name of the imported member.
         /// </summary>
         public uint ImportName
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the ModuleRef table indicating the module that this imported member defines.
+        /// Gets or sets an index into the ModuleRef table indicating the module that this imported member defines.
         /// </summary>
         public uint ImportScope
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/InterfaceImplementationRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/InterfaceImplementationRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the interface implementation metadata table.
     /// </summary>
-    public readonly struct InterfaceImplementationRow : IMetadataRow
+    public struct InterfaceImplementationRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single interface implementation row from an input stream.
@@ -50,11 +50,12 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets an index into the TypeDef table indicating the type that implements the interface.
+        /// Gets or sets an index into the TypeDef table indicating the type that implements the interface.
         /// </summary>
         public uint Class
         {
             get;
+            set;
         }
 
         /// <summary>
@@ -64,6 +65,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Interface
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ManifestResourceRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ManifestResourceRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the manifest resource metadata table.
     /// </summary>
-    public readonly struct ManifestResourceRow : IMetadataRow
+    public struct ManifestResourceRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single manifest resource row from an input stream.
@@ -58,31 +58,34 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the byte offset within the referenced file at which the resource record begins.
+        /// Gets or sets the byte offset within the referenced file at which the resource record begins.
         /// </summary>
         public uint Offset
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the attributes associated with this resource.
+        /// Gets or sets the attributes associated with this resource.
         /// </summary>
         public ManifestResourceAttributes Attributes
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings heap referencing the name of the resource.
+        /// Gets or sets an index into the #Strings heap referencing the name of the resource.
         /// </summary>
         public uint Name
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an Implementation index (an index into either the File, AssemblyRef or ExportedType table) indicating
+        /// Gets or sets an Implementation index (an index into either the File, AssemblyRef or ExportedType table) indicating
         /// the file that contains the resource data.
         /// </summary>
         /// <remarks>
@@ -91,6 +94,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Implementation
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MemberReferenceRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MemberReferenceRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the member reference metadata table.
     /// </summary>
-    public readonly struct MemberReferenceRow : IMetadataRow
+    public struct MemberReferenceRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single member reference row from an input stream.
@@ -60,10 +60,11 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Parent
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings heap containing the name of the member reference.
+        /// Gets or sets an index into the #Strings heap containing the name of the member reference.
         /// </summary>
         /// <remarks>
         /// This value should always index a non-empty string.
@@ -71,10 +72,11 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Name
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Blob heap containing the signature of the member.
+        /// Gets or sets an index into the #Blob heap containing the signature of the member.
         /// </summary>
         /// <remarks>
         /// This value should always index a valid member signature. This value can also be used to determine whether
@@ -83,6 +85,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Signature
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MethodDefinitionRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MethodDefinitionRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the method definition metadata table.
     /// </summary>
-    public readonly struct MethodDefinitionRow : IMetadataRow
+    public struct MethodDefinitionRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single method definition row from an input stream.
@@ -80,10 +80,11 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public ISegmentReference Body
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the characteristics of the implementation of the method body.
+        /// Gets or sets the characteristics of the implementation of the method body.
         /// </summary>
         /// <remarks>
         /// These attributes dictate the format of <see cref="Body"/>.
@@ -91,18 +92,20 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public MethodImplAttributes ImplAttributes
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the attributes associated to the method.
+        /// Gets or sets the attributes associated to the method.
         /// </summary>
         public MethodAttributes Attributes
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings heap containing the name of the type reference.
+        /// Gets or sets an index into the #Strings heap containing the name of the type reference.
         /// </summary>
         /// <remarks>
         /// This value should always index a non-empty string.
@@ -110,10 +113,11 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Name
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Blob heap containing the signature of the method. This includes the return type,
+        /// Gets or sets an index into the #Blob heap containing the signature of the method. This includes the return type,
         /// as well as parameter types.
         /// </summary>
         /// <remarks>
@@ -122,14 +126,16 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Signature
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the Param (or ParamPtr) table, representing the first parameter that this method defines.
+        /// Gets or sets an index into the Param (or ParamPtr) table, representing the first parameter that this method defines.
         /// </summary>
         public uint ParameterList
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MethodImplementationRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MethodImplementationRow.cs
@@ -22,7 +22,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the method implementation metadata table.
     /// </summary>
-    public readonly struct MethodImplementationRow : IMetadataRow
+    public struct MethodImplementationRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single method implementation row from an input stream.
@@ -68,11 +68,12 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets an index into the TypeDef table indicating the class that inherited methods from an interface.
+        /// Gets or sets an index into the TypeDef table indicating the class that inherited methods from an interface.
         /// </summary>
         public uint Class
         {
             get;
+            set;
         }
 
         /// <summary>
@@ -82,6 +83,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint MethodBody
         {
             get;
+            set;
         }
 
         /// <summary>
@@ -91,6 +93,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint MethodDeclaration
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MethodPointerRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MethodPointerRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the method pointer metadata table.
     /// </summary>
-    public readonly struct MethodPointerRow : IMetadataRow
+    public struct MethodPointerRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single field pointer row from an input stream.
@@ -44,11 +44,12 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets an index into the Method table that this pointer references.
+        /// Gets or sets an index into the Method table that this pointer references.
         /// </summary>
         public uint Method
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MethodSemanticsRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MethodSemanticsRow.cs
@@ -22,7 +22,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the method semantics metadata table.
     /// </summary>
-    public readonly struct MethodSemanticsRow : IMetadataRow
+    public struct MethodSemanticsRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single method semantics row from an input stream.
@@ -69,19 +69,21 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the semantic attributes that are assigned to the method.
+        /// Gets or sets the semantic attributes that are assigned to the method.
         /// </summary>
         public MethodSemanticsAttributes Attributes
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the method definition table indicating the method that was assigned special semantics.
+        /// Gets or sets an index into the method definition table indicating the method that was assigned special semantics.
         /// </summary>
         public uint Method
         {
             get;
+            set;
         }
 
         /// <summary>
@@ -91,6 +93,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Association
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MethodSpecificationRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MethodSpecificationRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the method specification metadata table.
     /// </summary>
-    public readonly struct MethodSpecificationRow : IMetadataRow
+    public struct MethodSpecificationRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single method specification row from an input stream.
@@ -49,19 +49,21 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets an index into the method definition table indicating the method to be instantiated.
+        /// Gets or sets an index into the method definition table indicating the method to be instantiated.
         /// </summary>
         public uint Method
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Blob stream referencing the instantiation parameters of the method.
+        /// Gets or sets an index into the #Blob stream referencing the instantiation parameters of the method.
         /// </summary>
         public uint Instantiation
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ModuleDefinitionRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ModuleDefinitionRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the module definition metadata table.
     /// </summary>
-    public readonly struct ModuleDefinitionRow : IMetadataRow
+    public struct ModuleDefinitionRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single module definition row from an input stream.
@@ -62,7 +62,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
     /// <summary>
-        /// Gets the generation number of the module.
+        /// Gets or sets the generation number of the module.
         /// </summary>
         /// <remarks>
         /// This value is reserved and should be set to zero.
@@ -70,40 +70,45 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public ushort Generation
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings heap containing the name of the module.
+        /// Gets or sets an index into the #Strings heap containing the name of the module.
         /// </summary>
         public uint Name
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #GUID heap containing the unique identifier to distinguish between two versions
+        /// Gets or sets an index into the #GUID heap containing the unique identifier to distinguish between two versions
         /// of the same module.
         /// </summary>
         public uint Mvid
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #GUID heap containing the unique identifier to distinguish between two
+        /// Gets or sets an index into the #GUID heap containing the unique identifier to distinguish between two
         /// edit-and-continue generations.
         /// </summary>
         public uint EncId
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #GUID heap containing the base identifier of an edit-and-continue generation.
+        /// Gets or sets an index into the #GUID heap containing the base identifier of an edit-and-continue generation.
         /// </summary>
         public uint EncBaseId
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ModuleReferenceRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ModuleReferenceRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the module definition metadata table.
     /// </summary>
-    public readonly struct ModuleReferenceRow : IMetadataRow
+    public struct ModuleReferenceRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single module reference row from an input stream.
@@ -45,11 +45,12 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets an index into the #Strings heap referencing the name of the external module that was imported.
+        /// Gets or sets an index into the #Strings heap referencing the name of the external module that was imported.
         /// </summary>
         public uint Name
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/NestedClassRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/NestedClassRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the nested class metadata table.
     /// </summary>
-    public readonly struct NestedClassRow : IMetadataRow
+    public struct NestedClassRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single nested class row from an input stream.
@@ -49,19 +49,21 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets an index into the TypeDef table indicating the class that was nested into another class.
+        /// Gets or sets an index into the TypeDef table indicating the class that was nested into another class.
         /// </summary>
         public uint NestedClass
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the TypeDef table indicating the enclosing class.
+        /// Gets or sets an index into the TypeDef table indicating the enclosing class.
         /// </summary>
         public uint EnclosingClass
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ParameterDefinitionRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ParameterDefinitionRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the parameter definition metadata table.
     /// </summary>
-    public readonly struct ParameterDefinitionRow : IMetadataRow
+    public struct ParameterDefinitionRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single parameter definition row from an input stream.
@@ -53,23 +53,25 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the attributes associated to the parameter.
+        /// Gets or sets the attributes associated to the parameter.
         /// </summary>
         public ParameterAttributes Attributes
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets the index of the parameter definition.
+        /// Gets or sets the index of the parameter definition.
         /// </summary>
         public ushort Sequence
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings heap containing the name of the type reference.
+        /// Gets or sets an index into the #Strings heap containing the name of the type reference.
         /// </summary>
         /// <remarks>
         /// If this value is zero, the parameter name is considered <c>null</c>.
@@ -77,6 +79,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Name
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ParameterPointerRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ParameterPointerRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the parameter pointer metadata table.
     /// </summary>
-    public readonly struct ParameterPointerRow : IMetadataRow
+    public struct ParameterPointerRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single parameter pointer row from an input stream.
@@ -44,11 +44,12 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets an index into the Parameter table that this pointer references.
+        /// Gets or sets an index into the Parameter table that this pointer references.
         /// </summary>
         public uint Parameter
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/PropertyDefinitionRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/PropertyDefinitionRow.cs
@@ -22,7 +22,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the property definition metadata table.
     /// </summary>
-    public readonly struct PropertyDefinitionRow : IMetadataRow
+    public struct PropertyDefinitionRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single property definition row from an input stream.
@@ -67,15 +67,16 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the attributes associated to the property definition.
+        /// Gets or sets the attributes associated to the property definition.
         /// </summary>
         public PropertyAttributes Attributes
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings stream referencing the name of the property.
+        /// Gets or sets an index into the #Strings stream referencing the name of the property.
         /// </summary>
         /// <remarks>
         /// This value should always index a non-empty string.
@@ -83,15 +84,17 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Name
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Blob stream referencing the signature of the property. This includes the property
+        /// Gets or sets an index into the #Blob stream referencing the signature of the property. This includes the property
         /// type.
         /// </summary>
         public uint Type
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/PropertyMapRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/PropertyMapRow.cs
@@ -22,7 +22,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the property map metadata table.
     /// </summary>
-    public readonly struct PropertyMapRow : IMetadataRow
+    public struct PropertyMapRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single property map row from an input stream.
@@ -64,19 +64,21 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets an index into the TypeDef table that this mapping is associating to an property list.
+        /// Gets or sets an index into the TypeDef table that this mapping is associating to an property list.
         /// </summary>
         public uint Parent
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the Event table indicating the first property that is defined in the property list.
+        /// Gets or sets an index into the Event table indicating the first property that is defined in the property list.
         /// </summary>
         public uint PropertyList
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/PropertyPointerRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/PropertyPointerRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the property pointer metadata table.
     /// </summary>
-    public readonly struct PropertyPointerRow : IMetadataRow
+    public struct PropertyPointerRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single property pointer row from an input stream.
@@ -44,11 +44,12 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets an index into the Property table that this pointer references.
+        /// Gets or sets an index into the Property table that this pointer references.
         /// </summary>
         public uint Property
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/SecurityDeclarationRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/SecurityDeclarationRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the security declaration metadata table.
     /// </summary>
-    public readonly struct SecurityDeclarationRow : IMetadataRow
+    public struct SecurityDeclarationRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single security declaration row from an input stream.
@@ -53,11 +53,12 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the action to be performed.
+        /// Gets or sets the action to be performed.
         /// </summary>
         public SecurityAction Action
         {
             get;
+            set;
         }
 
         /// <summary>
@@ -67,14 +68,16 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Parent
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Blob stream referencing the permission set assigned to the member.
+        /// Gets or sets an index into the #Blob stream referencing the permission set assigned to the member.
         /// </summary>
         public uint PermissionSet
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/StandAloneSignatureRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/StandAloneSignatureRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the stand-alone signature metadata table.
     /// </summary>
-    public readonly struct StandAloneSignatureRow : IMetadataRow
+    public struct StandAloneSignatureRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single stand-alone signature row from an input stream.
@@ -44,11 +44,12 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets an index into the #Blob stream referencing the signature that was exposed by this row.
+        /// Gets or sets an index into the #Blob stream referencing the signature that was exposed by this row.
         /// </summary>
         public uint Signature
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/TypeDefinitionRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/TypeDefinitionRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the type definition metadata table.
     /// </summary>
-    public readonly struct TypeDefinitionRow : IMetadataRow
+    public struct TypeDefinitionRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single type definition row from an input stream.
@@ -67,15 +67,16 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets the attributes associated to the type.
+        /// Gets or sets the attributes associated to the type.
         /// </summary>
         public  TypeAttributes Attributes
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings heap containing the name of the type reference.
+        /// Gets or sets an index into the #Strings heap containing the name of the type reference.
         /// </summary>
         /// <remarks>
         /// This value should always index a non-empty string.
@@ -83,10 +84,11 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Name
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings heap containing the namespace of the type reference.
+        /// Gets or sets an index into the #Strings heap containing the namespace of the type reference.
         /// </summary>
         /// <remarks>
         /// This value can be zero. If it is not, it should always index a non-empty string.
@@ -94,6 +96,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Namespace
         {
             get;
+            set;
         }
 
         /// <summary>
@@ -103,22 +106,25 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Extends
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the Field (or FieldPtr) table, representing the first field defined in the type.
+        /// Gets or sets an index into the Field (or FieldPtr) table, representing the first field defined in the type.
         /// </summary>
         public uint FieldList
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the Method (or MethodPtr) table, representing the first method defined in the type.
+        /// Gets or sets an index into the Method (or MethodPtr) table, representing the first method defined in the type.
         /// </summary>
         public uint MethodList
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/TypeReferenceRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/TypeReferenceRow.cs
@@ -60,10 +60,11 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint ResolutionScope
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings heap containing the name of the type reference.
+        /// Gets or sets an index into the #Strings heap containing the name of the type reference.
         /// </summary>
         /// <remarks>
         /// This value should always index a non-empty string.
@@ -71,10 +72,11 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Name
         {
             get;
+            set;
         }
 
         /// <summary>
-        /// Gets an index into the #Strings heap containing the namespace of the type reference.
+        /// Gets or sets an index into the #Strings heap containing the namespace of the type reference.
         /// </summary>
         /// <remarks>
         /// This value can be zero. If it is not, it should always index a non-empty string.
@@ -82,6 +84,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         public uint Namespace
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/TypeSpecificationRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/TypeSpecificationRow.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
     /// <summary>
     /// Represents a single row in the type specification metadata table.
     /// </summary>
-    public readonly struct TypeSpecificationRow : IMetadataRow
+    public struct TypeSpecificationRow : IMetadataRow
     {
         /// <summary>
         /// Reads a single type specification row from an input stream.
@@ -45,11 +45,12 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         };
 
         /// <summary>
-        /// Gets an index into the #Blob stream referencing the type signature that was exposed by this row.
+        /// Gets or sets an index into the #Blob stream referencing the type signature that was exposed by this row.
         /// </summary>
         public uint Signature
         {
             get;
+            set;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/SerializedMetadataTable.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/SerializedMetadataTable.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using AsmResolver.Collections;
 using AsmResolver.IO;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
@@ -60,13 +61,13 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables
         /// <param name="originalLayout">The layout of the table.</param>
         /// <param name="readRow">The method to use for reading each row in the table.</param>
         public SerializedMetadataTable(
-                PEReaderContext context,
-                in BinaryStreamReader reader,
-                TableIndex tableIndex,
-                TableLayout originalLayout,
-                ReadRowExtendedDelegate readRow)
+            PEReaderContext context,
+            in BinaryStreamReader reader,
+            TableIndex tableIndex,
+            TableLayout originalLayout,
+            ReadRowExtendedDelegate readRow)
             : this(reader, tableIndex, originalLayout,
-                (ref BinaryStreamReader reader, TableLayout layout) => readRow(context, ref reader, layout))
+                (ref BinaryStreamReader r, TableLayout l) => readRow(context, ref r, l))
         {
         }
 
@@ -74,9 +75,9 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables
         public override int Count => IsInitialized ? Rows.Count : _rowCount;
 
         /// <inheritdoc />
-        protected override IList<TRow> GetRows()
+        protected override RefList<TRow> GetRows()
         {
-            var result = new List<TRow>();
+            var result = new RefList<TRow>(_rowCount);
 
             var reader = _reader.Fork();
             for (int i = 0; i < _rowCount; i++)

--- a/src/AsmResolver/Collections/RefList.cs
+++ b/src/AsmResolver/Collections/RefList.cs
@@ -1,0 +1,306 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace AsmResolver.Collections
+{
+    /// <summary>
+    /// Provides an implementation of a collection for which the raw elements can be accessed by-reference.
+    /// This allows for dynamically sized lists that work on mutable structs.
+    /// </summary>
+    /// <typeparam name="T">The type of elements to store.</typeparam>
+    /// <remarks>
+    /// This list should be regarded as a mutable array that is not thread-safe.
+    /// </remarks>
+    public class RefList<T> : ICollection, IList<T>, IReadOnlyList<T>
+        where T : struct
+    {
+        /// <summary>
+        /// Gets the default capacity of a ref-list.
+        /// </summary>
+        public const int DefaultCapacity = 4;
+
+        private T[] _items;
+        private int _count;
+        private int _version;
+
+        /// <summary>
+        /// Creates a new empty list with the default capacity.
+        /// </summary>
+        public RefList()
+            : this(DefaultCapacity)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new empty list with the provided capacity.
+        /// </summary>
+        /// <param name="capacity">The capacity of the list.</param>
+        public RefList(int capacity)
+        {
+            _items = new T[capacity];
+        }
+
+        /// <inheritdoc cref="ICollection{T}.Count" />
+        public int Count => _count;
+
+        /// <summary>
+        /// Gets the capacity of the underlying array.
+        /// </summary>
+        public int Capacity => _items.Length;
+
+        /// <summary>
+        /// Gets a number indicating the current version of the list.
+        /// </summary>
+        /// <remarks>
+        /// This number is incremented each time the underlying array is resized or when an element is replaced.
+        /// It can also be used to verify that the reference returned by <see cref="GetElementRef"/> is still
+        /// referencing an element in the current array.
+        /// </remarks>
+        public int Version => _version;
+
+        /// <inheritdoc />
+        bool ICollection<T>.IsReadOnly => false;
+
+        /// <inheritdoc />
+        bool ICollection.IsSynchronized => false;
+
+        /// <inheritdoc />
+        object ICollection.SyncRoot => this;
+
+        /// <summary>
+        /// Gets or sets an individual element within the list.
+        /// </summary>
+        /// <param name="index">The index of the element to access.</param>
+        /// <exception cref="IndexOutOfRangeException">
+        /// Occurs when <paramref name="index"/> is not a valid index within the array.
+        /// </exception>
+        public T this[int index]
+        {
+            get
+            {
+                AssertIsValidIndex(index);
+                return _items[index];
+            }
+            set
+            {
+                AssertIsValidIndex(index);
+                _items[index] = value;
+                _version++;
+            }
+        }
+
+        /// <summary>
+        /// Gets an element within the list by reference.
+        /// </summary>
+        /// <param name="index">The index of the element to access.</param>
+        /// <returns>A reference to the element.</returns>
+        /// <exception cref="IndexOutOfRangeException">
+        /// Occurs when <paramref name="index"/> is not a valid index within the array.
+        /// </exception>
+        public ref T GetElementRef(int index)
+        {
+            AssertIsValidIndex(index);
+            return ref _items[index];
+        }
+
+        /// <summary>
+        /// Gets an element within the list by reference.
+        /// </summary>
+        /// <param name="index">The index of the element to access.</param>
+        /// <param name="version">The version of the list upon obtaining the reference.</param>
+        /// <returns>A reference to the element.</returns>
+        /// <exception cref="IndexOutOfRangeException">
+        /// Occurs when <paramref name="index"/> is not a valid index within the array.
+        /// </exception>
+        public ref T GetElementRef(int index, out int version)
+        {
+            AssertIsValidIndex(index);
+            version = _version;
+            return ref _items[index];
+        }
+
+        /// <summary>
+        /// Adds an element to the end of the list.
+        /// </summary>
+        /// <param name="item">The element.</param>
+        public void Add(in T item)
+        {
+            EnsureEnoughCapacity(_count + 1);
+            _items[_count] = item;
+            _count++;
+            _version++;
+        }
+
+        /// <inheritdoc />
+        void ICollection<T>.Add(T item) => Add(item);
+
+        /// <inheritdoc />
+        public void Clear()
+        {
+            Array.Clear(_items, 0, _items.Length);
+            _count = 0;
+            _version++;
+        }
+
+        /// <inheritdoc />
+        bool ICollection<T>.Contains(T item) => IndexOf(item) >= 0;
+
+        /// <summary>
+        /// Determines whether an item is present in the reference list.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        /// <returns><c>true</c> if the element is present, <c>false</c> otherwise.</returns>
+        public bool Contains(in T item) => IndexOf(item) >= 0;
+
+        /// <inheritdoc />
+        public void CopyTo(T[] array, int arrayIndex) => _items.CopyTo(array, arrayIndex);
+
+        /// <inheritdoc />
+        public void CopyTo(Array array, int index) => _items.CopyTo(array, index);
+
+        /// <summary>
+        /// Removes an element from the list.
+        /// </summary>
+        /// <param name="item">The element to remove.</param>
+        /// <returns><c>true</c> if the element was removed successfully, <c>false</c> otherwise.</returns>
+        public bool Remove(in T item)
+        {
+            int index = IndexOf(item);
+            if (index > 0)
+            {
+                RemoveAt(index);
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc />
+        bool ICollection<T>.Remove(T item) => Remove(item);
+
+        /// <summary>
+        /// Determines the first index within the list that contains the provided element.
+        /// </summary>
+        /// <param name="item">The element to search.</param>
+        /// <returns>The index, or -1 if the element is not present in the list.</returns>
+        public int IndexOf(in T item) => Array.IndexOf(_items, item, 0, _count);
+
+        /// <summary>
+        /// Inserts an element into the list at the provided index.
+        /// </summary>
+        /// <param name="index">The index to insert into.</param>
+        /// <param name="item">The element to insert.</param>
+        public void Insert(int index, in T item)
+        {
+            EnsureEnoughCapacity(_count + 1);
+
+            if (index < _count)
+                Array.Copy(_items, index, _items, index + 1, _count - index);
+
+            _items[index] = item;
+            _count++;
+            _version++;
+        }
+
+        /// <inheritdoc />
+        void IList<T>.Insert(int index, T item) => Insert(index, item);
+
+        /// <inheritdoc />
+        public int IndexOf(T item) => Array.IndexOf(_items, item, 0, _count);
+
+        /// <summary>
+        /// Removes a single element from the list at the provided index.
+        /// </summary>
+        /// <param name="index">The index of the element to remove.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Occurs when the provided index is invalid.</exception>
+        public void RemoveAt(int index)
+        {
+            if (index < 0 || index >= _count)
+                throw new ArgumentOutOfRangeException(nameof(index));
+
+            _count--;
+
+            if (index < _count)
+                Array.Copy(_items, index + 1, _items, index, _count - index);
+
+            _items[_count] = default!;
+            _version++;
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates all elements in the list.
+        /// </summary>
+        public Enumerator GetEnumerator() => new(this);
+
+        /// <inheritdoc />
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        private void AssertIsValidIndex(int index)
+        {
+            if (index < 0 || index >= Count)
+                throw new IndexOutOfRangeException();
+        }
+
+        private void EnsureEnoughCapacity(int requiredCount)
+        {
+            if (_items.Length >= requiredCount)
+                return;
+
+            int newCapacity = _items.Length == 0 ? 1 : _items.Length * 2;
+            if (newCapacity < requiredCount)
+                newCapacity = requiredCount;
+
+            Array.Resize(ref _items, newCapacity);
+        }
+
+        /// <summary>
+        /// Provides an implementation for an enumerator that iterates elements in a ref-list.
+        /// </summary>
+        public struct Enumerator : IEnumerator<T>
+        {
+            private readonly RefList<T> _list;
+            private readonly int _version;
+            private int _index;
+
+            /// <summary>
+            /// Creates a new instance of a ref-list enumerator.
+            /// </summary>
+            /// <param name="list">The list to enumerate.</param>
+            public Enumerator(RefList<T> list)
+            {
+                _list = list;
+                _version = list._version;
+                _index = -1;
+            }
+
+            /// <inheritdoc />
+            public T Current => _index >= 0 && _index < _list._count
+                ? _list[_index]
+                : default;
+
+            /// <inheritdoc />
+            object IEnumerator.Current => Current;
+
+            /// <inheritdoc />
+            public bool MoveNext()
+            {
+                if (_version != _list._version)
+                    throw new InvalidOperationException("Collection was modified.");
+                _index++;
+                return _index >= 0 && _index < _list._count;
+            }
+
+            /// <inheritdoc />
+            public void Reset() => throw new NotSupportedException();
+
+            /// <inheritdoc />
+            void IDisposable.Dispose()
+            {
+            }
+        }
+    }
+}

--- a/src/AsmResolver/Collections/RefList.cs
+++ b/src/AsmResolver/Collections/RefList.cs
@@ -55,8 +55,8 @@ namespace AsmResolver.Collections
         /// </summary>
         /// <remarks>
         /// This number is incremented each time the underlying array is resized or when an element is replaced.
-        /// It can also be used to verify that the reference returned by <see cref="GetElementRef"/> is still
-        /// referencing an element in the current array.
+        /// It can also be used to verify that the reference returned by <see cref="GetElementRef(int, out int)"/> is
+        /// still referencing an element in the current array.
         /// </remarks>
         public int Version => _version;
 

--- a/src/AsmResolver/Collections/RefList.cs
+++ b/src/AsmResolver/Collections/RefList.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace AsmResolver.Collections
 {
@@ -86,7 +87,7 @@ namespace AsmResolver.Collections
             {
                 AssertIsValidIndex(index);
                 _items[index] = value;
-                _version++;
+                IncrementVersion();
             }
         }
 
@@ -129,7 +130,7 @@ namespace AsmResolver.Collections
             EnsureEnoughCapacity(_count + 1);
             _items[_count] = item;
             _count++;
-            _version++;
+            IncrementVersion();
         }
 
         /// <inheritdoc />
@@ -140,7 +141,7 @@ namespace AsmResolver.Collections
         {
             Array.Clear(_items, 0, _items.Length);
             _count = 0;
-            _version++;
+            IncrementVersion();
         }
 
         /// <inheritdoc />
@@ -200,7 +201,7 @@ namespace AsmResolver.Collections
 
             _items[index] = item;
             _count++;
-            _version++;
+            IncrementVersion();
         }
 
         /// <inheritdoc />
@@ -225,7 +226,7 @@ namespace AsmResolver.Collections
                 Array.Copy(_items, index + 1, _items, index, _count - index);
 
             _items[_count] = default!;
-            _version++;
+            IncrementVersion();
         }
 
         /// <summary>
@@ -255,6 +256,15 @@ namespace AsmResolver.Collections
                 newCapacity = requiredCount;
 
             Array.Resize(ref _items, newCapacity);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void IncrementVersion()
+        {
+            unchecked
+            {
+                _version++;
+            }
         }
 
         /// <summary>

--- a/src/AsmResolver/IO/BinaryStreamReader.cs
+++ b/src/AsmResolver/IO/BinaryStreamReader.cs
@@ -312,17 +312,17 @@ namespace AsmResolver.IO
         /// <returns>The read bytes, including the delimeter if it was found.</returns>
         public byte[] ReadBytesUntil(byte delimeter)
         {
-            var buffer = new List<byte>();
-
-            while (RelativeOffset < Length)
+            var lookahead = Fork();
+            while (lookahead.RelativeOffset < lookahead.Length)
             {
-                byte b = ReadByte();
-                buffer.Add(b);
+                byte b = lookahead.ReadByte();
                 if (b == delimeter)
                     break;
             }
 
-            return buffer.ToArray();
+            byte[] buffer = new byte[lookahead.RelativeOffset - RelativeOffset];
+            ReadBytes(buffer, 0, buffer.Length);
+            return buffer;
         }
 
         /// <summary>

--- a/test/AsmResolver.DotNet.Tests/Builder/StringsStreamBufferTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Builder/StringsStreamBufferTest.cs
@@ -124,7 +124,7 @@ namespace AsmResolver.DotNet.Tests.Builder
             Assert.True(buffer.IsEmpty);
         }
 
-        private void OptimizeAndVerifyIndices(StringsStreamBuffer buffer, params Utf8String[] values)
+        private static void OptimizeAndVerifyIndices(StringsStreamBuffer buffer, params Utf8String[] values)
         {
             uint[] indices = new uint[values.Length];
             for (int i = 0; i < values.Length; i++)

--- a/test/AsmResolver.DotNet.Tests/Builder/StringsStreamBufferTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Builder/StringsStreamBufferTest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using AsmResolver.DotNet.Builder;
 using AsmResolver.DotNet.Builder.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Strings;
 using Xunit;
@@ -125,7 +124,7 @@ namespace AsmResolver.DotNet.Tests.Builder
             Assert.True(buffer.IsEmpty);
         }
 
-        private void OptimizeAndVerifyIndices(StringsStreamBuffer buffer, params string[] values)
+        private void OptimizeAndVerifyIndices(StringsStreamBuffer buffer, params Utf8String[] values)
         {
             uint[] indices = new uint[values.Length];
             for (int i = 0; i < values.Length; i++)
@@ -256,5 +255,17 @@ namespace AsmResolver.DotNet.Tests.Builder
                 stream.GetPhysicalSize());
         }
 
+        [Fact]
+        public void OptimizeWithInvalidUtf8Characters()
+        {
+            var string1 = new Utf8String(new byte[] { 0x80, 0x79, 0x78 });
+            var string2 = new Utf8String(new byte[] { 0x79, 0x78 });
+
+            var buffer = new StringsStreamBuffer();
+            OptimizeAndVerifyIndices(buffer, string1, string2);
+
+            uint index = buffer.GetStringIndex(string1);
+            Assert.Equal(index + 1, buffer.GetStringIndex(string2));
+        }
     }
 }

--- a/test/AsmResolver.DotNet.Tests/Builder/StringsStreamBufferTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Builder/StringsStreamBufferTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using AsmResolver.DotNet.Builder;
 using AsmResolver.DotNet.Builder.Metadata.Strings;
@@ -42,23 +43,6 @@ namespace AsmResolver.DotNet.Tests.Builder
 
             var stringsStream = buffer.CreateStream();
             Assert.Equal(string1, stringsStream.GetStringByIndex(index1));
-        }
-
-        [Fact]
-        public void AddRaw()
-        {
-            var buffer = new StringsStreamBuffer();
-
-            const string string1 = "String 1";
-            var rawData = Encoding.UTF8.GetBytes(string1);
-
-            uint index1 = buffer.AppendRawData(rawData);
-            uint index2 = buffer.GetStringIndex(string1);
-
-            Assert.NotEqual(index1, index2);
-
-            var stringsStream = buffer.CreateStream();
-            Assert.Equal(string1, stringsStream.GetStringByIndex(index2));
         }
 
         [Fact]
@@ -131,5 +115,126 @@ namespace AsmResolver.DotNet.Tests.Builder
             Assert.Equal(index1, index2);
             Assert.NotEqual(index1, index3);
         }
+
+        [Fact]
+        public void OptimizeEmpty()
+        {
+            var buffer = new StringsStreamBuffer();
+            buffer.Optimize();
+
+            Assert.True(buffer.IsEmpty);
+        }
+
+        private void OptimizeAndVerifyIndices(StringsStreamBuffer buffer, params string[] values)
+        {
+            uint[] indices = new uint[values.Length];
+            for (int i = 0; i < values.Length; i++)
+                indices[i] = buffer.GetStringIndex(values[i]);
+            var translationTable = buffer.Optimize();
+            for (int i = 0; i < values.Length; i++)
+                Assert.Equal(translationTable[indices[i]], buffer.GetStringIndex(values[i]));
+        }
+
+        [Fact]
+        public void AddStringsWithSameSuffixShouldResultInStringReuseAfterOptimize()
+        {
+            var buffer = new StringsStreamBuffer();
+            OptimizeAndVerifyIndices(buffer,
+                "AAAABBBB",
+                "BBBB",
+                "BB");
+
+            uint index1 = buffer.GetStringIndex("AAAABBBB");
+            uint index2 = buffer.GetStringIndex("BBBB");
+            uint index3 = buffer.GetStringIndex("BB");
+
+            Assert.Equal(index1 + 4u, index2);
+            Assert.Equal(index1 + 6u, index3);
+
+            var stream = buffer.CreateStream();
+            Assert.Equal((1u + 8u + 1u).Align(4), stream.GetPhysicalSize());
+        }
+
+        [Fact]
+        public void OptimizeAfterImportedStreamShouldPreserveImportedData()
+        {
+            var existingStringsStream = new SerializedStringsStream(StringsStream.DefaultName, Encoding.UTF8.GetBytes(
+                "\0"
+                + "AAAABBBB\0"
+                + "abc\0"));
+
+            var buffer = new StringsStreamBuffer();
+            buffer.ImportStream(existingStringsStream);
+            OptimizeAndVerifyIndices(buffer, "AAAABBBB", "BBBB");
+
+            Assert.Equal(1u, buffer.GetStringIndex("AAAABBBB"));
+            Assert.Equal(1u + 4u, buffer.GetStringIndex("BBBB"));
+
+            var stream = buffer.CreateStream();
+            Assert.Equal((1u + 9u + 4u).Align(4), stream.GetPhysicalSize());
+        }
+
+        [Fact]
+        public void OptimizeAfterImportedStreamShouldPreserveImportedData2()
+        {
+            var existingStringsStream = new SerializedStringsStream(StringsStream.DefaultName, Encoding.UTF8.GetBytes(
+                "\0"
+                + "AAAABBBB\0"
+                + "abc\0"));
+
+            var buffer = new StringsStreamBuffer();
+            buffer.ImportStream(existingStringsStream);
+            OptimizeAndVerifyIndices(buffer, "AAAABBBBCCCC");
+
+            var stream = buffer.CreateStream();
+            Assert.Equal("AAAABBBB", stream.GetStringByIndex(1u));
+            Assert.Equal("AAAABBBBCCCC", stream.GetStringByIndex(1u + 9u + 4u));
+        }
+
+        [Fact]
+        public void OptimizeLongChainOfSuffixStrings()
+        {
+            const string templateString = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+            var oldIndices = new List<uint>();
+
+            var buffer = new StringsStreamBuffer();
+            for (int i = 0; i < templateString.Length; i++)
+                oldIndices.Add(buffer.GetStringIndex(templateString[i..]));
+            var table = buffer.Optimize();
+
+            for (uint i = 0; i < templateString.Length; i++)
+            {
+                Assert.Equal(i + 1, buffer.GetStringIndex(templateString[(int) i..]));
+                Assert.Equal(i + 1, table[oldIndices[(int) i]]);
+            }
+
+            var stream = buffer.CreateStream();
+            Assert.Equal((1u + (uint)templateString.Length + 1u).Align(4), stream.GetPhysicalSize());
+        }
+
+        [Fact]
+        public void OptimizeMultipleLongChainsOfSuffixStrings()
+        {
+            const string templateString1 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+            const string templateString2 = "zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA";
+
+            var strings = new List<string>();
+            for (int i = 0; i < templateString1.Length; i++)
+                strings.Add(templateString1[i..]);
+            for (int i = 0; i < templateString2.Length; i++)
+                strings.Add(templateString2[i..]);
+            strings.Sort((_, _) => Guid.NewGuid().CompareTo(Guid.NewGuid()));
+
+            var buffer = new StringsStreamBuffer();
+            foreach (string s in strings)
+                buffer.GetStringIndex(s);
+            buffer.Optimize();
+
+            var stream = buffer.CreateStream();
+            Assert.Equal(
+                (1u + (uint)templateString1.Length + 1u + (uint)templateString2.Length + 1u).Align(4),
+                stream.GetPhysicalSize());
+        }
+
     }
 }

--- a/test/AsmResolver.DotNet.Tests/Builder/StringsStreamBufferTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Builder/StringsStreamBufferTest.cs
@@ -156,6 +156,26 @@ namespace AsmResolver.DotNet.Tests.Builder
         }
 
         [Fact]
+        public void AddStringsWithSameSuffixReversedShouldResultInStringReuseAfterOptimize()
+        {
+            var buffer = new StringsStreamBuffer();
+            OptimizeAndVerifyIndices(buffer,
+                "BB",
+                "BBBB",
+                "AAAABBBB");
+
+            uint index1 = buffer.GetStringIndex("AAAABBBB");
+            uint index2 = buffer.GetStringIndex("BBBB");
+            uint index3 = buffer.GetStringIndex("BB");
+
+            Assert.Equal(index1 + 4u, index2);
+            Assert.Equal(index1 + 6u, index3);
+
+            var stream = buffer.CreateStream();
+            Assert.Equal((1u + 8u + 1u).Align(4), stream.GetPhysicalSize());
+        }
+
+        [Fact]
         public void OptimizeAfterImportedStreamShouldPreserveImportedData()
         {
             var existingStringsStream = new SerializedStringsStream(StringsStream.DefaultName, Encoding.UTF8.GetBytes(

--- a/test/AsmResolver.Tests/Collections/LazyListTest.cs
+++ b/test/AsmResolver.Tests/Collections/LazyListTest.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using AsmResolver.Collections;
 using Xunit;
 
-namespace AsmResolver.Tests
+namespace AsmResolver.Tests.Collections
 {
     public class LazyListTest
     {
@@ -15,12 +15,12 @@ namespace AsmResolver.Tests
                 get;
                 private set;
             }
-            
+
             public DummyLazyList(IList<int> items)
             {
                 _items = items;
             }
-            
+
             protected override void Initialize()
             {
                 foreach (var item in _items)
@@ -53,7 +53,7 @@ namespace AsmResolver.Tests
                 3
             };
             var list = new DummyLazyList(actualItems);
-            var enumerator = list.GetEnumerator(); 
+            var enumerator = list.GetEnumerator();
             Assert.False(list.InitializeMethodCalled);
         }
     }

--- a/test/AsmResolver.Tests/Collections/RefListTest.cs
+++ b/test/AsmResolver.Tests/Collections/RefListTest.cs
@@ -1,0 +1,54 @@
+using AsmResolver.Collections;
+using Xunit;
+
+namespace AsmResolver.Tests.Collections
+{
+    public class RefListTest
+    {
+        [Fact]
+        public void EmptyList()
+        {
+            Assert.Empty(new RefList<int>());
+        }
+
+        [Fact]
+        public void AddItemShouldUpdateVersion()
+        {
+            var list = new RefList<int>();
+            int version = list.Version;
+            list.Add(1);
+            Assert.Equal(1, Assert.Single(list));
+            Assert.NotEqual(version, list.Version);
+        }
+
+        [Fact]
+        public void InsertItemShouldUpdateVersion()
+        {
+            var list = new RefList<int> { 1, 2, 3 };
+            int version = list.Version;
+            list.Insert(1, 4);
+            Assert.Equal(new[] { 1, 4, 2, 3 }, list);
+            Assert.NotEqual(version, list.Version);
+        }
+
+        [Fact]
+        public void RemoveItemShouldUpdateVersion()
+        {
+            var list = new RefList<int> { 1, 2, 3 };
+            int version = list.Version;
+            list.RemoveAt(1);
+            Assert.Equal(new[] { 1, 3 }, list);
+            Assert.NotEqual(version, list.Version);
+        }
+
+        [Fact]
+        public void UpdateElementFromRefShouldUpdateList()
+        {
+            var list = new RefList<int> { 1, 2, 3 };
+            ref int element = ref list.GetElementRef(1);
+            element = 1337;
+            Assert.Equal(new[] { 1, 1337, 3 }, list);
+        }
+
+    }
+}


### PR DESCRIPTION
Includes:
- `RefList<T>`, a list type that allows for accessing elements by reference.
- Makes rows in metadata tables mutable and accessible by reference.
- Adds `StringsStreamBuffer.Optimize()`.
- Adds `MetadataBuilderFlags.NoStringsStreamOptimization`.

Closes #192 