### PR TITLE
Hotfix/4.7.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
         <RepositoryUrl>https://github.com/Washi1337/AsmResolver</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <LangVersion>9</LangVersion>
-        <Version>4.7.0</Version>
+        <Version>4.7.1</Version>
     </PropertyGroup>
 
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
       - master
 
   image: Visual Studio 2019
-  version: 4.7.0-master-build.{build}
+  version: 4.7.1-master-build.{build}
   configuration: Release
 
   skip_commits:
@@ -33,7 +33,7 @@
       - development
 
   image: Visual Studio 2019
-  version: 4.7.0-dev-build.{build}
+  version: 4.7.1-dev-build.{build}
   configuration: Release
 
   skip_commits:

--- a/src/AsmResolver.DotNet/Builder/Metadata/Strings/StringsStreamBlob.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Strings/StringsStreamBlob.cs
@@ -33,7 +33,7 @@ namespace AsmResolver.DotNet.Builder.Metadata.Strings
         public bool IsFixed => (Flags & StringsStreamBlobFlags.Fixed) != 0;
 
         /// <inheritdoc />
-        public uint GetPhysicalSize() => (uint) (Blob.Length + (IsZeroTerminated ? 1 : 0));
+        public uint GetPhysicalSize() => (uint) (Blob.ByteCount + (IsZeroTerminated ? 1 : 0));
 
         /// <inheritdoc />
         public void Write(IBinaryStreamWriter writer)

--- a/src/AsmResolver.DotNet/Code/Cil/CilLabelVerifier.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilLabelVerifier.cs
@@ -124,7 +124,7 @@ namespace AsmResolver.DotNet.Code.Cil
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool IsPresentInBody(int offset) =>
-            _body.Instructions.GetIndexByOffset(offset) >= 0;
+            _body.Instructions.GetIndexByOffset(offset) >= 0 || _body.Instructions.EndLabel.Offset == offset;
 
         private void AddDiagnostic(string message)
         {

--- a/src/AsmResolver.DotNet/Signatures/CustomAttributeArgumentWriter.cs
+++ b/src/AsmResolver.DotNet/Signatures/CustomAttributeArgumentWriter.cs
@@ -60,7 +60,7 @@ namespace AsmResolver.DotNet.Signatures
 
                 case ElementType.Object:
                     // Most efficient way to store "null" is writing null as a string (two bytes).
-                    TypeSignature.WriteFieldOrPropType(writer, argumentType.Module!.CorLibTypeFactory.String);
+                    TypeSignature.WriteFieldOrPropType(_context, argumentType.Module!.CorLibTypeFactory.String);
                     break;
 
                 case ElementType.SzArray:
@@ -166,7 +166,7 @@ namespace AsmResolver.DotNet.Signatures
                         value = null;
                     }
 
-                    TypeSignature.WriteFieldOrPropType(writer, innerTypeSig);
+                    TypeSignature.WriteFieldOrPropType(_context, innerTypeSig);
                     WriteElement(innerTypeSig, value);
                     break;
 

--- a/src/AsmResolver.DotNet/Signatures/CustomAttributeNamedArgument.cs
+++ b/src/AsmResolver.DotNet/Signatures/CustomAttributeNamedArgument.cs
@@ -90,7 +90,7 @@ namespace AsmResolver.DotNet.Signatures
             var writer = context.Writer;
 
             writer.WriteByte((byte) MemberType);
-            TypeSignature.WriteFieldOrPropType(writer, ArgumentType);
+            TypeSignature.WriteFieldOrPropType(context, ArgumentType);
             writer.WriteSerString(MemberName);
             Argument.Write(context);
         }

--- a/src/AsmResolver.PE/DotNet/Builder/ManagedPEFileBuilder.cs
+++ b/src/AsmResolver.PE/DotNet/Builder/ManagedPEFileBuilder.cs
@@ -233,7 +233,7 @@ namespace AsmResolver.PE.DotNet.Builder
 
         private static void CreateImportDirectory(IPEImage image, ManagedPEBuilderContext context)
         {
-            bool importEntrypointRequired = image.PEKind == OptionalHeaderMagic.Pe32;
+            bool importEntrypointRequired = image.MachineType == MachineType.I386;
             string entrypointName = (image.Characteristics & Characteristics.Dll) != 0
                 ? "_CorDllMain"
                 : "_CorExeMain";

--- a/test/AsmResolver.DotNet.Tests/Code/Cil/CilMethodBodyTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Code/Cil/CilMethodBodyTest.cs
@@ -430,6 +430,7 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
             var module = ModuleDefinition.FromBytes(Properties.Resources.HandlerEndAtEndOfMethodBody);
             var body = module.ManagedEntrypointMethod.CilMethodBody;
             Assert.Same(body.Instructions.EndLabel, body.ExceptionHandlers[0].HandlerEnd);
+            body.VerifyLabels();
         }
 
         [Fact]


### PR DESCRIPTION
- Fixes an issue with invalid string offsets being calculated as a result of using multibyte UTF-8 code-points.
- Assume explicitly typed CA arguments are enum types if they cannot be resolved.
- Fixes an issue where `EndLabel` was not considered during the label verification of a CIL body.
- Fixes an issue where `mscoree.dll` was not included as module import in the build process when the binary targeted the i386 machine type.