### PR TITLE
Bump test app framework version

### DIFF
--- a/test/TestBinaries/DotNet/HelloWorld/HelloWorld.csproj
+++ b/test/TestBinaries/DotNet/HelloWorld/HelloWorld.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net40;netcoreapp2.1</TargetFrameworks>
+        <TargetFrameworks>net47;netcoreapp2.1</TargetFrameworks>
         <ApplicationIcon>Resources\Icon.ico</ApplicationIcon>
     </PropertyGroup>
 

--- a/test/TestBinaries/DotNet/TheAnswer/TheAnswer.csproj
+++ b/test/TestBinaries/DotNet/TheAnswer/TheAnswer.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net40;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net47;netcoreapp3.1</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />


### PR DESCRIPTION
Due to new visual studio installer not having .net 4.0 install option, i bumped test app versions to later framework version.