### PR TITLE
Fix: Throw on generic context GetTypeArgument + Add: GenericContext From  methods

### DIFF
--- a/src/AsmResolver.DotNet/Signatures/GenericContext.cs
+++ b/src/AsmResolver.DotNet/Signatures/GenericContext.cs
@@ -51,6 +51,7 @@ namespace AsmResolver.DotNet.Signatures
 
         /// <summary>
         /// Resolves a type parameter to a type argument, based on the current generic context.
+        /// If generic argument provider is not initialised for type parameter, than it will return itself.
         /// </summary>
         /// <param name="parameter">The parameter to get the argument value for.</param>
         /// <returns>The argument type.</returns>

--- a/src/AsmResolver.DotNet/Signatures/GenericContext.cs
+++ b/src/AsmResolver.DotNet/Signatures/GenericContext.cs
@@ -99,20 +99,5 @@ namespace AsmResolver.DotNet.Signatures
                 (TypeSpecification typeSpec, _) => FromTypeSpecification(typeSpec),
                 _ => null
             };
-
-        /// <summary>
-        /// Tries to get method and/or type generic context from <see cref="IMemberDescriptor"/>.
-        /// </summary>
-        /// <param name="member">Member to get generic context from.</param>
-        /// <returns>Generic context</returns>
-        public static GenericContext? FromMember(IMemberDescriptor member) =>
-            (member.DeclaringType, member) switch
-            {
-                (_, TypeSpecification typeSpec) => FromTypeSpecification(typeSpec),
-                (_, MethodSpecification methodSpec) => FromMethodSpecification(methodSpec),
-                (_, GenericInstanceTypeSignature typeSig) => new GenericContext(typeSig, null),
-                ({ } declaringType, _) => FromMember(declaringType),
-                _ => null
-            };
     }
 }

--- a/src/AsmResolver.DotNet/Signatures/GenericContext.cs
+++ b/src/AsmResolver.DotNet/Signatures/GenericContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using AsmResolver.DotNet.Signatures.Types;
 
 namespace AsmResolver.DotNet.Signatures
@@ -57,8 +58,12 @@ namespace AsmResolver.DotNet.Signatures
 
         /// <summary>
         /// Resolves a type parameter to a type argument, based on the current generic context.
-        /// If generic argument provider is not initialised for type parameter, than it will return itself.
         /// </summary>
+        /// <remarks>
+        /// If a type parameter within the signature references a parameter that is not captured by the context
+        /// (i.e. the corresponding generic argument provider is set to null),
+        /// then this type parameter will not be substituted.
+        /// </remarks>
         /// <param name="parameter">The parameter to get the argument value for.</param>
         /// <returns>The argument type.</returns>
         public TypeSignature GetTypeArgument(GenericParameterSignature parameter)
@@ -81,9 +86,9 @@ namespace AsmResolver.DotNet.Signatures
 
 
         /// <summary>
-        /// Gets type generic context from <see cref="TypeSpecification"/>.
+        /// Gets a type generic context from <see cref="TypeSpecification"/>.
         /// </summary>
-        /// <param name="type">Type specification to get generic context from.</param>
+        /// <param name="type">Type specification to get the generic context from.</param>
         /// <returns>Generic context.</returns>
         public static GenericContext FromType(TypeSpecification type) => type.Signature switch
         {
@@ -92,16 +97,16 @@ namespace AsmResolver.DotNet.Signatures
         };
 
         /// <summary>
-        /// Gets type generic context from <see cref="GenericInstanceTypeSignature"/>.
+        /// Gets a type generic context from <see cref="GenericInstanceTypeSignature"/>.
         /// </summary>
-        /// <param name="type">Generic type signature to get generic context from.</param>
+        /// <param name="type">Generic type signature to get the generic context from.</param>
         /// <returns>Generic context.</returns>
         public static GenericContext FromType(GenericInstanceTypeSignature type) => new(type, null);
 
         /// <summary>
-        /// Gets type generic context from <see cref="ITypeDescriptor"/>.
+        /// Gets a type generic context from <see cref="ITypeDescriptor"/>.
         /// </summary>
-        /// <param name="type">Type to get generic context from.</param>
+        /// <param name="type">Type to get the generic context from.</param>
         /// <returns>Generic context.</returns>
         public static GenericContext FromType(ITypeDescriptor type) => type switch
         {
@@ -111,24 +116,21 @@ namespace AsmResolver.DotNet.Signatures
         };
 
         /// <summary>
-        /// Gets method and/or type generic context from <see cref="MethodSpecification"/>.
+        /// Gets a method and/or type generic context from <see cref="MethodSpecification"/>.
         /// </summary>
-        /// <param name="method">Method specification to get generic context from.</param>
+        /// <param name="method">Method specification to get the generic context from.</param>
         /// <returns>Generic context.</returns>
-        public static GenericContext FromMethod(MethodSpecification method) =>
-            (method.DeclaringType, method.Signature) switch
-            {
-                (TypeSpecification {Signature: GenericInstanceTypeSignature typeSig}, { } methodSig) =>
-                    new GenericContext(typeSig, methodSig),
-                (_, { } methodSig) => new GenericContext(null, methodSig),
-                (TypeSpecification typeSpec, _) => FromType(typeSpec),
-                _ => default
-            };
+        public static GenericContext FromMethod(MethodSpecification method)
+        {
+            return method.DeclaringType is TypeSpecification {Signature: GenericInstanceTypeSignature typeSig}
+                ? new GenericContext(typeSig, method.Signature)
+                : new GenericContext(null, method.Signature);
+        }
 
         /// <summary>
-        /// Gets method and/or type generic context from <see cref="IMethodDescriptor"/>.
+        /// Gets a method and/or type generic context from <see cref="IMethodDescriptor"/>.
         /// </summary>
-        /// <param name="method">Method to get generic context from.</param>
+        /// <param name="method">Method to get the generic context from.</param>
         /// <returns>Generic context.</returns>
         public static GenericContext FromMethod(IMethodDescriptor method) =>
             method switch
@@ -139,9 +141,9 @@ namespace AsmResolver.DotNet.Signatures
             };
 
         /// <summary>
-        /// Gets type generic context from <see cref="IFieldDescriptor"/>.
+        /// Gets a type generic context from <see cref="IFieldDescriptor"/>.
         /// </summary>
-        /// <param name="field">Field to get generic context from.</param>
+        /// <param name="field">Field to get the generic context from.</param>
         /// <returns>Generic context.</returns>
         public static GenericContext FromField(IFieldDescriptor field) =>
             field switch
@@ -151,9 +153,9 @@ namespace AsmResolver.DotNet.Signatures
             };
 
         /// <summary>
-        /// Gets type generic context from <see cref="MemberReference"/>.
+        /// Gets a type generic context from <see cref="MemberReference"/>.
         /// </summary>
-        /// <param name="member">Member reference to get generic context from.</param>
+        /// <param name="member">Member reference to get the generic context from.</param>
         /// <returns>Generic context.</returns>
         public static GenericContext FromMember(MemberReference member) =>
             member.DeclaringType switch
@@ -163,9 +165,9 @@ namespace AsmResolver.DotNet.Signatures
             };
 
         /// <summary>
-        /// Gets type generic context from <see cref="IMemberDescriptor"/>.
+        /// Gets a type generic context from <see cref="IMemberDescriptor"/>.
         /// </summary>
-        /// <param name="member">Member to get generic context from.</param>
+        /// <param name="member">Member to get the generic context from.</param>
         /// <returns>Generic context.</returns>
         public static GenericContext FromMember(IMemberDescriptor member) =>
             member switch

--- a/src/AsmResolver.DotNet/Signatures/GenericContext.cs
+++ b/src/AsmResolver.DotNet/Signatures/GenericContext.cs
@@ -163,11 +163,11 @@ namespace AsmResolver.DotNet.Signatures
             };
 
         /// <summary>
-        /// Gets type generic context from <see cref="MemberReference"/>.
+        /// Gets type generic context from <see cref="IMemberDescriptor"/>.
         /// </summary>
-        /// <param name="member">Metadata member to get generic context from.</param>
+        /// <param name="member">Member to get generic context from.</param>
         /// <returns>Generic context.</returns>
-        public static GenericContext FromMember(IMetadataMember member) =>
+        public static GenericContext FromMember(IMemberDescriptor member) =>
             member switch
             {
                 IMethodDescriptor method => FromMethod(method),

--- a/src/AsmResolver.DotNet/Signatures/GenericContext.cs
+++ b/src/AsmResolver.DotNet/Signatures/GenericContext.cs
@@ -71,5 +71,47 @@ namespace AsmResolver.DotNet.Signatures
 
             throw new ArgumentOutOfRangeException();
         }
+
+
+        /// <summary>
+        /// Tries to get type generic context from <see cref="TypeSpecification"/>.
+        /// </summary>
+        /// <param name="type">Type specification to get generic context from.</param>
+        /// <returns>Generic context.</returns>
+        public static GenericContext? FromTypeSpecification(TypeSpecification type) => type.Signature switch
+        {
+            GenericInstanceTypeSignature typeSig => new GenericContext(typeSig, null),
+            _ => null
+        };
+
+        /// <summary>
+        /// Tries to get method and/or type generic context from <see cref="MethodSpecification"/>.
+        /// </summary>
+        /// <param name="method">Method specification to get generic context from.</param>
+        /// <returns>Generic context.</returns>
+        public static GenericContext? FromMethodSpecification(MethodSpecification method) =>
+            (method.DeclaringType, method.Signature) switch
+            {
+                (TypeSpecification {Signature: GenericInstanceTypeSignature typeSig}, { } methodSig) =>
+                    new GenericContext(typeSig, methodSig),
+                (_, { } methodSig) => new GenericContext(null, methodSig),
+                (TypeSpecification typeSpec, _) => FromTypeSpecification(typeSpec),
+                _ => null
+            };
+
+        /// <summary>
+        /// Tries to get method and/or type generic context from <see cref="IMemberDescriptor"/>.
+        /// </summary>
+        /// <param name="member">Member to get generic context from.</param>
+        /// <returns>Generic context</returns>
+        public static GenericContext? FromMember(IMemberDescriptor member) =>
+            (member.DeclaringType, member) switch
+            {
+                (_, TypeSpecification typeSpec) => FromTypeSpecification(typeSpec),
+                (_, MethodSpecification methodSpec) => FromMethodSpecification(methodSpec),
+                (_, GenericInstanceTypeSignature typeSig) => new GenericContext(typeSig, null),
+                ({ } declaringType, _) => FromMember(declaringType),
+                _ => null
+            };
     }
 }

--- a/src/AsmResolver.DotNet/Signatures/GenericContext.cs
+++ b/src/AsmResolver.DotNet/Signatures/GenericContext.cs
@@ -4,7 +4,7 @@ using AsmResolver.DotNet.Signatures.Types;
 namespace AsmResolver.DotNet.Signatures
 {
     /// <summary>
-    /// Provides a context within a generic instantiation, including the type arguments of the enclosing type and method. 
+    /// Provides a context within a generic instantiation, including the type arguments of the enclosing type and method.
     /// </summary>
     public readonly struct GenericContext
     {
@@ -18,9 +18,9 @@ namespace AsmResolver.DotNet.Signatures
             Type = type;
             Method = method;
         }
-        
+
         /// <summary>
-        /// Gets the object responsible for providing type arguments defined by the current generic type instantiation. 
+        /// Gets the object responsible for providing type arguments defined by the current generic type instantiation.
         /// </summary>
         public IGenericArgumentsProvider? Type
         {
@@ -28,7 +28,7 @@ namespace AsmResolver.DotNet.Signatures
         }
 
         /// <summary>
-        /// Gets the object responsible for providing type arguments defined by the current generic method instantiation. 
+        /// Gets the object responsible for providing type arguments defined by the current generic method instantiation.
         /// </summary>
         public IGenericArgumentsProvider? Method
         {
@@ -36,14 +36,14 @@ namespace AsmResolver.DotNet.Signatures
         }
 
         /// <summary>
-        /// Enters a new generic context with a new type providing type arguments. 
+        /// Enters a new generic context with a new type providing type arguments.
         /// </summary>
         /// <param name="type">The new type providing the type arguments.</param>
         /// <returns>The new generic context.</returns>
         public GenericContext WithType(IGenericArgumentsProvider type) => new GenericContext(type, Method);
-        
+
         /// <summary>
-        /// Enters a new generic context with a new method providing type arguments. 
+        /// Enters a new generic context with a new method providing type arguments.
         /// </summary>
         /// <param name="method">The new method providing the type arguments.</param>
         /// <returns>The new generic context.</returns>
@@ -62,9 +62,9 @@ namespace AsmResolver.DotNet.Signatures
                 GenericParameterType.Method => Method,
                 _ => throw new ArgumentOutOfRangeException()
             };
-            
+
             if (argumentProvider is null)
-                throw new ArgumentOutOfRangeException();
+                return parameter;
 
             if (parameter.Index >= 0 && parameter.Index < argumentProvider.TypeArguments.Count)
                 return argumentProvider.TypeArguments[parameter.Index];

--- a/test/AsmResolver.DotNet.Tests/Signatures/GenericContextTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Signatures/GenericContextTest.cs
@@ -115,7 +115,9 @@ namespace AsmResolver.DotNet.Tests.Signatures
             var typeSpecification = new TypeSpecification(genericInstance);
 
             var context = GenericContext.FromType(typeSpecification);
+            var context2 = GenericContext.FromMember(typeSpecification);
 
+            Assert.Equal(context, context2);
             Assert.False(context.IsEmpty);
             Assert.Equal(genericInstance, context.Type);
             Assert.Null(context.Method);
@@ -132,7 +134,9 @@ namespace AsmResolver.DotNet.Tests.Signatures
             var methodSpecification = new MethodSpecification(method, genericInstance);
 
             var context = GenericContext.FromMethod(methodSpecification);
+            var context2 = GenericContext.FromMember(methodSpecification);
 
+            Assert.Equal(context, context2);
             Assert.False(context.IsEmpty);
             Assert.Null(context.Type);
             Assert.Equal(genericInstance, context.Method);
@@ -155,7 +159,9 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
 
             var context = GenericContext.FromMethod(methodSpecification);
+            var context2 = GenericContext.FromMember(methodSpecification);
 
+            Assert.Equal(context, context2);
             Assert.False(context.IsEmpty);
             Assert.Equal(genericTypeInstance, context.Type);
             Assert.Equal(genericMethodInstance, context.Method);
@@ -170,7 +176,9 @@ namespace AsmResolver.DotNet.Tests.Signatures
             var typeSpecification = new TypeSpecification(notGenericSignature);
 
             var context = GenericContext.FromType(typeSpecification);
+            var context2 = GenericContext.FromMember(typeSpecification);
 
+            Assert.Equal(context, context2);
             Assert.True(context.IsEmpty);
         }
 
@@ -185,7 +193,9 @@ namespace AsmResolver.DotNet.Tests.Signatures
             var methodSpecification = new MethodSpecification(method, null);
 
             var context = GenericContext.FromMethod(methodSpecification);
+            var context2 = GenericContext.FromMember(methodSpecification);
 
+            Assert.Equal(context, context2);
             Assert.True(context.IsEmpty);
         }
 
@@ -204,10 +214,136 @@ namespace AsmResolver.DotNet.Tests.Signatures
             var methodSpecification = new MethodSpecification(method, null);
 
             var context = GenericContext.FromMethod(methodSpecification);
+            var context2 = GenericContext.FromMember(methodSpecification);
 
+            Assert.Equal(context, context2);
             Assert.False(context.IsEmpty);
             Assert.Equal(genericTypeInstance, context.Type);
             Assert.Null(context.Method);
         }
+
+        [Fact]
+        public void ParseGenericFromField()
+        {
+            var genericTypeInstance = new GenericInstanceTypeSignature(_importer.ImportType(typeof(List<>)), false);
+            genericTypeInstance.TypeArguments.Add(_importer.ImportTypeSignature(typeof(string)));
+            var typeSpecification = new TypeSpecification(genericTypeInstance);
+
+            var genericParameter = new GenericParameterSignature(GenericParameterType.Type, 0);
+
+            var field = new FieldDefinition("Field", FieldAttributes.Private,
+                FieldSignature.CreateStatic(genericParameter));
+
+            var member = new MemberReference(typeSpecification, field.Name, field.Signature);
+
+            var context = GenericContext.FromField(member);
+            var context2 = GenericContext.FromMember(member);
+
+            Assert.Equal(context, context2);
+            Assert.False(context.IsEmpty);
+            Assert.Equal(genericTypeInstance, context.Type);
+            Assert.Null(context.Method);
+        }
+
+        [Fact]
+        public void ParseGenericFromNotGenericField()
+        {
+            var type = new TypeDefinition("","Test type", TypeAttributes.Public);
+            var notGenericSignature = new TypeDefOrRefSignature(type);
+
+            var field = new FieldDefinition("Field", FieldAttributes.Private,
+                FieldSignature.CreateStatic(notGenericSignature));
+
+            var member = new MemberReference(type, field.Name, field.Signature);
+
+            var context = GenericContext.FromField(member);
+            var context2 = GenericContext.FromMember(member);
+
+            Assert.Equal(context, context2);
+            Assert.True(context.IsEmpty);
+        }
+
+        [Fact]
+        public void ParseGenericFromMethod()
+        {
+            var genericTypeInstance = new GenericInstanceTypeSignature(_importer.ImportType(typeof(List<>)), false);
+            genericTypeInstance.TypeArguments.Add(_importer.ImportTypeSignature(typeof(string)));
+            var typeSpecification = new TypeSpecification(genericTypeInstance);
+
+            var genericParameter = new GenericParameterSignature(GenericParameterType.Type, 0);
+
+            var method = new MethodDefinition("Method", MethodAttributes.Private,
+                MethodSignature.CreateStatic(genericParameter));
+
+            var member = new MemberReference(typeSpecification, method.Name, method.Signature);
+
+            var context = GenericContext.FromField(member);
+            var context2 = GenericContext.FromMember(member);
+
+            Assert.Equal(context, context2);
+            Assert.False(context.IsEmpty);
+            Assert.Equal(genericTypeInstance, context.Type);
+            Assert.Null(context.Method);
+        }
+
+        [Fact]
+        public void ParseGenericFromNotGenericMethod()
+        {
+            var type = new TypeDefinition("","Test type", TypeAttributes.Public);
+            var notGenericSignature = new TypeDefOrRefSignature(type);
+
+            var method = new MethodDefinition("Method", MethodAttributes.Private,
+                MethodSignature.CreateStatic(notGenericSignature));
+
+            var member = new MemberReference(type, method.Name, method.Signature);
+
+            var context = GenericContext.FromField(member);
+            var context2 = GenericContext.FromMember(member);
+
+            Assert.Equal(context, context2);
+            Assert.True(context.IsEmpty);
+        }
+
+        [Fact]
+        public void ParseGenericFromProperty()
+        {
+            var genericTypeInstance = new GenericInstanceTypeSignature(_importer.ImportType(typeof(List<>)), false);
+            genericTypeInstance.TypeArguments.Add(_importer.ImportTypeSignature(typeof(string)));
+            var typeSpecification = new TypeSpecification(genericTypeInstance);
+
+            var genericParameter = new GenericParameterSignature(GenericParameterType.Type, 0);
+
+            var property = new PropertyDefinition("Property", PropertyAttributes.None,
+                PropertySignature.CreateStatic(genericParameter));
+
+            var member = new MemberReference(typeSpecification, property.Name, property.Signature);
+
+            var context = GenericContext.FromField(member);
+            var context2 = GenericContext.FromMember(member);
+
+            Assert.Equal(context, context2);
+            Assert.False(context.IsEmpty);
+            Assert.Equal(genericTypeInstance, context.Type);
+            Assert.Null(context.Method);
+        }
+
+        [Fact]
+        public void ParseGenericFromNotGenericProperty()
+        {
+            var type = new TypeDefinition("","Test type", TypeAttributes.Public);
+            var notGenericSignature = new TypeDefOrRefSignature(type);
+
+            var property = new PropertyDefinition("Property", PropertyAttributes.None,
+                PropertySignature.CreateStatic(notGenericSignature));
+
+            var member = new MemberReference(type, property.Name, property.Signature);
+
+            var context = GenericContext.FromField(member);
+            var context2 = GenericContext.FromMember(member);
+
+            Assert.Equal(context, context2);
+            Assert.True(context.IsEmpty);
+        }
+
     }
 }

--- a/test/AsmResolver.DotNet.Tests/Signatures/GenericContextTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Signatures/GenericContextTest.cs
@@ -1,16 +1,14 @@
-using System;
 using System.Collections.Generic;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Types;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 using Xunit;
-using Xunit.Sdk;
 
 namespace AsmResolver.DotNet.Tests.Signatures
 {
     public class GenericContextTest
     {
-        private ReferenceImporter _importer;
+        private readonly ReferenceImporter _importer;
 
         public GenericContextTest()
         {
@@ -92,7 +90,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
             var context = new GenericContext(null, genericInstance);
 
             var parameter = new GenericParameterSignature(GenericParameterType.Type, 0);
-            Assert.Equal(parameter,context.GetTypeArgument(parameter));
+            Assert.Equal(parameter, context.GetTypeArgument(parameter));
         }
 
         [Fact]
@@ -116,7 +114,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
             var context = GenericContext.FromType(genericInstance);
             var context2 = GenericContext.FromMember(genericInstance);
-            var context3 = GenericContext.FromType((ITypeDescriptor)genericInstance);
+            var context3 = GenericContext.FromType((ITypeDescriptor) genericInstance);
 
             Assert.Equal(context, context3);
             Assert.Equal(context, context2);
@@ -128,7 +126,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
         [Fact]
         public void ParseGenericFromNonGenericTypeSignature()
         {
-            var type = new TypeDefinition("","Test type", TypeAttributes.Public);
+            var type = new TypeDefinition("", "Test type", TypeAttributes.Public);
             var notGenericSignature = new TypeDefOrRefSignature(type);
 
             var context = GenericContext.FromType(notGenericSignature);
@@ -147,7 +145,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
             var context = GenericContext.FromType(typeSpecification);
             var context2 = GenericContext.FromMember(typeSpecification);
-            var context3 = GenericContext.FromType((ITypeDescriptor)typeSpecification);
+            var context3 = GenericContext.FromType((ITypeDescriptor) typeSpecification);
 
             Assert.Equal(context, context3);
             Assert.Equal(context, context2);
@@ -168,7 +166,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
             var context = GenericContext.FromMethod(methodSpecification);
             var context2 = GenericContext.FromMember(methodSpecification);
-            var context3 = GenericContext.FromMethod((IMethodDescriptor)methodSpecification);
+            var context3 = GenericContext.FromMethod((IMethodDescriptor) methodSpecification);
 
             Assert.Equal(context, context3);
             Assert.Equal(context, context2);
@@ -195,7 +193,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
             var context = GenericContext.FromMethod(methodSpecification);
             var context2 = GenericContext.FromMember(methodSpecification);
-            var context3 = GenericContext.FromMethod((IMethodDescriptor)methodSpecification);
+            var context3 = GenericContext.FromMethod((IMethodDescriptor) methodSpecification);
 
             Assert.Equal(context, context3);
             Assert.Equal(context, context2);
@@ -207,14 +205,14 @@ namespace AsmResolver.DotNet.Tests.Signatures
         [Fact]
         public void ParseGenericFromNotGenericTypeSpecification()
         {
-            var type = new TypeDefinition("","Test type", TypeAttributes.Public);
+            var type = new TypeDefinition("", "Test type", TypeAttributes.Public);
             var notGenericSignature = new TypeDefOrRefSignature(type);
 
             var typeSpecification = new TypeSpecification(notGenericSignature);
 
             var context = GenericContext.FromType(typeSpecification);
             var context2 = GenericContext.FromMember(typeSpecification);
-            var context3 = GenericContext.FromType((ITypeDescriptor)typeSpecification);
+            var context3 = GenericContext.FromType((ITypeDescriptor) typeSpecification);
 
             Assert.Equal(context, context3);
             Assert.Equal(context, context2);
@@ -224,7 +222,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
         [Fact]
         public void ParseGenericFromNotGenericMethodSpecification()
         {
-            var type = new TypeDefinition("","Test type", TypeAttributes.Public);
+            var type = new TypeDefinition("", "Test type", TypeAttributes.Public);
             var notGenericSignature = new TypeDefOrRefSignature(type);
 
             var method = new MethodDefinition("TestMethod", MethodAttributes.Private,
@@ -233,7 +231,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
             var context = GenericContext.FromMethod(methodSpecification);
             var context2 = GenericContext.FromMember(methodSpecification);
-            var context3 = GenericContext.FromMethod((IMethodDescriptor)methodSpecification);
+            var context3 = GenericContext.FromMethod((IMethodDescriptor) methodSpecification);
 
             Assert.Equal(context, context3);
             Assert.Equal(context, context2);
@@ -247,7 +245,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
             genericTypeInstance.TypeArguments.Add(_importer.ImportTypeSignature(typeof(string)));
             var typeSpecification = new TypeSpecification(genericTypeInstance);
 
-            var type = new TypeDefinition("","Test type", TypeAttributes.Public);
+            var type = new TypeDefinition("", "Test type", TypeAttributes.Public);
             var notGenericSignature = new TypeDefOrRefSignature(type);
 
             var method = new MemberReference(typeSpecification, "TestMethod",
@@ -256,7 +254,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
             var context = GenericContext.FromMethod(methodSpecification);
             var context2 = GenericContext.FromMember(methodSpecification);
-            var context3 = GenericContext.FromMethod((IMethodDescriptor)methodSpecification);
+            var context3 = GenericContext.FromMethod((IMethodDescriptor) methodSpecification);
 
             Assert.Equal(context, context3);
             Assert.Equal(context, context2);
@@ -291,7 +289,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
         [Fact]
         public void ParseGenericFromNotGenericField()
         {
-            var type = new TypeDefinition("","Test type", TypeAttributes.Public);
+            var type = new TypeDefinition("", "Test type", TypeAttributes.Public);
             var notGenericSignature = new TypeDefOrRefSignature(type);
 
             var field = new FieldDefinition("Field", FieldAttributes.Private,
@@ -332,7 +330,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
         [Fact]
         public void ParseGenericFromNotGenericMethod()
         {
-            var type = new TypeDefinition("","Test type", TypeAttributes.Public);
+            var type = new TypeDefinition("", "Test type", TypeAttributes.Public);
             var notGenericSignature = new TypeDefOrRefSignature(type);
 
             var method = new MethodDefinition("Method", MethodAttributes.Private,
@@ -373,7 +371,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
         [Fact]
         public void ParseGenericFromNotGenericProperty()
         {
-            var type = new TypeDefinition("","Test type", TypeAttributes.Public);
+            var type = new TypeDefinition("", "Test type", TypeAttributes.Public);
             var notGenericSignature = new TypeDefOrRefSignature(type);
 
             var property = new PropertyDefinition("Property", PropertyAttributes.None,
@@ -387,6 +385,5 @@ namespace AsmResolver.DotNet.Tests.Signatures
             Assert.Equal(context, context2);
             Assert.True(context.IsEmpty);
         }
-
     }
 }

--- a/test/AsmResolver.DotNet.Tests/Signatures/GenericContextTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Signatures/GenericContextTest.cs
@@ -107,6 +107,35 @@ namespace AsmResolver.DotNet.Tests.Signatures
             Assert.Equal(parameter, context.GetTypeArgument(parameter));
         }
 
+
+        [Fact]
+        public void ParseGenericFromTypeSignature()
+        {
+            var genericInstance = new GenericInstanceTypeSignature(_importer.ImportType(typeof(List<>)), false);
+            genericInstance.TypeArguments.Add(_importer.ImportTypeSignature(typeof(string)));
+
+            var context = GenericContext.FromType(genericInstance);
+            var context2 = GenericContext.FromMember(genericInstance);
+
+            Assert.Equal(context, context2);
+            Assert.False(context.IsEmpty);
+            Assert.Equal(genericInstance, context.Type);
+            Assert.Null(context.Method);
+        }
+
+        [Fact]
+        public void ParseGenericFromNonGenericTypeSignature()
+        {
+            var type = new TypeDefinition("","Test type", TypeAttributes.Public);
+            var notGenericSignature = new TypeDefOrRefSignature(type);
+
+            var context = GenericContext.FromType(notGenericSignature);
+            var context2 = GenericContext.FromMember(notGenericSignature);
+
+            Assert.Equal(context, context2);
+            Assert.True(context.IsEmpty);
+        }
+
         [Fact]
         public void ParseGenericFromTypeSpecification()
         {

--- a/test/AsmResolver.DotNet.Tests/Signatures/GenericContextTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Signatures/GenericContextTest.cs
@@ -114,11 +114,11 @@ namespace AsmResolver.DotNet.Tests.Signatures
             genericInstance.TypeArguments.Add(_importer.ImportTypeSignature(typeof(string)));
             var typeSpecification = new TypeSpecification(genericInstance);
 
-            var context = GenericContext.FromTypeSpecification(typeSpecification);
+            var context = GenericContext.FromType(typeSpecification);
 
-            Assert.True(context.HasValue);
-            Assert.Equal(genericInstance, context.Value.Type);
-            Assert.Null(context.Value.Method);
+            Assert.False(context.IsEmpty);
+            Assert.Equal(genericInstance, context.Type);
+            Assert.Null(context.Method);
         }
 
         [Fact]
@@ -131,11 +131,11 @@ namespace AsmResolver.DotNet.Tests.Signatures
             genericInstance.TypeArguments.Add(_importer.ImportTypeSignature(typeof(int)));
             var methodSpecification = new MethodSpecification(method, genericInstance);
 
-            var context = GenericContext.FromMethodSpecification(methodSpecification);
+            var context = GenericContext.FromMethod(methodSpecification);
 
-            Assert.True(context.HasValue);
-            Assert.Null(context.Value.Type);
-            Assert.Equal(genericInstance, context.Value.Method);
+            Assert.False(context.IsEmpty);
+            Assert.Null(context.Type);
+            Assert.Equal(genericInstance, context.Method);
         }
 
         [Fact]
@@ -154,11 +154,11 @@ namespace AsmResolver.DotNet.Tests.Signatures
             var methodSpecification = new MethodSpecification(method, genericMethodInstance);
 
 
-            var context = GenericContext.FromMethodSpecification(methodSpecification);
+            var context = GenericContext.FromMethod(methodSpecification);
 
-            Assert.True(context.HasValue);
-            Assert.Equal(genericTypeInstance, context.Value.Type);
-            Assert.Equal(genericMethodInstance, context.Value.Method);
+            Assert.False(context.IsEmpty);
+            Assert.Equal(genericTypeInstance, context.Type);
+            Assert.Equal(genericMethodInstance, context.Method);
         }
 
         [Fact]
@@ -169,9 +169,9 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
             var typeSpecification = new TypeSpecification(notGenericSignature);
 
-            var context = GenericContext.FromTypeSpecification(typeSpecification);
+            var context = GenericContext.FromType(typeSpecification);
 
-            Assert.False(context.HasValue);
+            Assert.True(context.IsEmpty);
         }
 
         [Fact]
@@ -184,9 +184,9 @@ namespace AsmResolver.DotNet.Tests.Signatures
                 MethodSignature.CreateStatic(notGenericSignature));
             var methodSpecification = new MethodSpecification(method, null);
 
-            var context = GenericContext.FromMethodSpecification(methodSpecification);
+            var context = GenericContext.FromMethod(methodSpecification);
 
-            Assert.False(context.HasValue);
+            Assert.True(context.IsEmpty);
         }
 
         [Fact]
@@ -203,11 +203,11 @@ namespace AsmResolver.DotNet.Tests.Signatures
                 MethodSignature.CreateStatic(notGenericSignature));
             var methodSpecification = new MethodSpecification(method, null);
 
-            var context = GenericContext.FromMethodSpecification(methodSpecification);
+            var context = GenericContext.FromMethod(methodSpecification);
 
-            Assert.True(context.HasValue);
-            Assert.Equal(genericTypeInstance, context.Value.Type);
-            Assert.Null(context.Value.Method);
+            Assert.False(context.IsEmpty);
+            Assert.Equal(genericTypeInstance, context.Type);
+            Assert.Null(context.Method);
         }
     }
 }

--- a/test/AsmResolver.DotNet.Tests/Signatures/GenericContextTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Signatures/GenericContextTest.cs
@@ -116,7 +116,9 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
             var context = GenericContext.FromType(genericInstance);
             var context2 = GenericContext.FromMember(genericInstance);
+            var context3 = GenericContext.FromType((ITypeDescriptor)genericInstance);
 
+            Assert.Equal(context, context3);
             Assert.Equal(context, context2);
             Assert.False(context.IsEmpty);
             Assert.Equal(genericInstance, context.Type);
@@ -145,7 +147,9 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
             var context = GenericContext.FromType(typeSpecification);
             var context2 = GenericContext.FromMember(typeSpecification);
+            var context3 = GenericContext.FromType((ITypeDescriptor)typeSpecification);
 
+            Assert.Equal(context, context3);
             Assert.Equal(context, context2);
             Assert.False(context.IsEmpty);
             Assert.Equal(genericInstance, context.Type);
@@ -164,7 +168,9 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
             var context = GenericContext.FromMethod(methodSpecification);
             var context2 = GenericContext.FromMember(methodSpecification);
+            var context3 = GenericContext.FromMethod((IMethodDescriptor)methodSpecification);
 
+            Assert.Equal(context, context3);
             Assert.Equal(context, context2);
             Assert.False(context.IsEmpty);
             Assert.Null(context.Type);
@@ -189,7 +195,9 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
             var context = GenericContext.FromMethod(methodSpecification);
             var context2 = GenericContext.FromMember(methodSpecification);
+            var context3 = GenericContext.FromMethod((IMethodDescriptor)methodSpecification);
 
+            Assert.Equal(context, context3);
             Assert.Equal(context, context2);
             Assert.False(context.IsEmpty);
             Assert.Equal(genericTypeInstance, context.Type);
@@ -206,7 +214,9 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
             var context = GenericContext.FromType(typeSpecification);
             var context2 = GenericContext.FromMember(typeSpecification);
+            var context3 = GenericContext.FromType((ITypeDescriptor)typeSpecification);
 
+            Assert.Equal(context, context3);
             Assert.Equal(context, context2);
             Assert.True(context.IsEmpty);
         }
@@ -223,7 +233,9 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
             var context = GenericContext.FromMethod(methodSpecification);
             var context2 = GenericContext.FromMember(methodSpecification);
+            var context3 = GenericContext.FromMethod((IMethodDescriptor)methodSpecification);
 
+            Assert.Equal(context, context3);
             Assert.Equal(context, context2);
             Assert.True(context.IsEmpty);
         }
@@ -244,7 +256,9 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
             var context = GenericContext.FromMethod(methodSpecification);
             var context2 = GenericContext.FromMember(methodSpecification);
+            var context3 = GenericContext.FromMethod((IMethodDescriptor)methodSpecification);
 
+            Assert.Equal(context, context3);
             Assert.Equal(context, context2);
             Assert.False(context.IsEmpty);
             Assert.Equal(genericTypeInstance, context.Type);
@@ -306,7 +320,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
             var member = new MemberReference(typeSpecification, method.Name, method.Signature);
 
-            var context = GenericContext.FromField(member);
+            var context = GenericContext.FromMethod(member);
             var context2 = GenericContext.FromMember(member);
 
             Assert.Equal(context, context2);
@@ -326,7 +340,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
             var member = new MemberReference(type, method.Name, method.Signature);
 
-            var context = GenericContext.FromField(member);
+            var context = GenericContext.FromMethod(member);
             var context2 = GenericContext.FromMember(member);
 
             Assert.Equal(context, context2);
@@ -347,7 +361,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
             var member = new MemberReference(typeSpecification, property.Name, property.Signature);
 
-            var context = GenericContext.FromField(member);
+            var context = GenericContext.FromMethod(member);
             var context2 = GenericContext.FromMember(member);
 
             Assert.Equal(context, context2);
@@ -367,7 +381,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
             var member = new MemberReference(type, property.Name, property.Signature);
 
-            var context = GenericContext.FromField(member);
+            var context = GenericContext.FromMethod(member);
             var context2 = GenericContext.FromMember(member);
 
             Assert.Equal(context, context2);

--- a/test/AsmResolver.DotNet.Tests/Signatures/GenericContextTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Signatures/GenericContextTest.cs
@@ -20,22 +20,22 @@ namespace AsmResolver.DotNet.Tests.Signatures
         [Theory]
         [InlineData(GenericParameterType.Type)]
         [InlineData(GenericParameterType.Method)]
-        public void ResolveGenericParameterWithEmptyTypeShouldThrow(GenericParameterType parameterType)
+        public void ResolveGenericParameterWithEmptyType(GenericParameterType parameterType)
         {
             var context = new GenericContext();
 
             var parameter = new GenericParameterSignature(parameterType, 0);
-            Assert.Throws<ArgumentOutOfRangeException>(() => context.GetTypeArgument(parameter));
+            Assert.Equal(parameter, context.GetTypeArgument(parameter));
         }
-        
+
         [Fact]
         public void ResolveMethodGenericParameterWithMethod()
         {
             var genericInstance = new GenericInstanceMethodSignature();
             genericInstance.TypeArguments.Add(_importer.ImportTypeSignature(typeof(string)));
-            
+
             var context = new GenericContext(null, genericInstance);
-            
+
             var parameter = new GenericParameterSignature(GenericParameterType.Method, 0);
             Assert.Equal("System.String", context.GetTypeArgument(parameter).FullName);
         }
@@ -45,9 +45,9 @@ namespace AsmResolver.DotNet.Tests.Signatures
         {
             var genericInstance = new GenericInstanceTypeSignature(_importer.ImportType(typeof(List<>)), false);
             genericInstance.TypeArguments.Add(_importer.ImportTypeSignature(typeof(string)));
-            
+
             var context = new GenericContext(genericInstance, null);
-            
+
             var parameter = new GenericParameterSignature(GenericParameterType.Type, 0);
             Assert.Equal("System.String", context.GetTypeArgument(parameter).FullName);
         }
@@ -57,12 +57,12 @@ namespace AsmResolver.DotNet.Tests.Signatures
         {
             var genericType = new GenericInstanceTypeSignature(_importer.ImportType(typeof(List<>)), false);
             genericType.TypeArguments.Add(_importer.ImportTypeSignature(typeof(string)));
-            
+
             var genericMethod = new GenericInstanceMethodSignature();
             genericMethod.TypeArguments.Add(_importer.ImportTypeSignature(typeof(int)));
-            
+
             var context = new GenericContext(genericType, genericMethod);
-            
+
             var parameter = new GenericParameterSignature(GenericParameterType.Type, 0);
             Assert.Equal("System.String", context.GetTypeArgument(parameter).FullName);
         }
@@ -72,38 +72,38 @@ namespace AsmResolver.DotNet.Tests.Signatures
         {
             var genericType = new GenericInstanceTypeSignature(_importer.ImportType(typeof(List<>)), false);
             genericType.TypeArguments.Add(_importer.ImportTypeSignature(typeof(string)));
-            
+
             var genericMethod = new GenericInstanceMethodSignature();
             genericMethod.TypeArguments.Add(_importer.ImportTypeSignature(typeof(int)));
-            
+
             var context = new GenericContext(genericType, genericMethod);
-            
+
             var parameter = new GenericParameterSignature(GenericParameterType.Method, 0);
             Assert.Equal("System.Int32", context.GetTypeArgument(parameter).FullName);
         }
 
         [Fact]
-        public void ResolveTypeGenericParameterWithOnlyMethodShouldThrow()
+        public void ResolveTypeGenericParameterWithOnlyMethod()
         {
             var genericInstance = new GenericInstanceMethodSignature();
             genericInstance.TypeArguments.Add(_importer.ImportTypeSignature(typeof(string)));
-            
+
             var context = new GenericContext(null, genericInstance);
-            
+
             var parameter = new GenericParameterSignature(GenericParameterType.Type, 0);
-            Assert.Throws<ArgumentOutOfRangeException>(() => context.GetTypeArgument(parameter));
+            Assert.Equal(parameter,context.GetTypeArgument(parameter));
         }
 
         [Fact]
-        public void ResolveMethodGenericParameterWithOnlyTypeShouldThrow()
+        public void ResolveMethodGenericParameterWithOnlyType()
         {
             var genericInstance = new GenericInstanceTypeSignature(_importer.ImportType(typeof(List<>)), false);
             genericInstance.TypeArguments.Add(_importer.ImportTypeSignature(typeof(string)));
-            
+
             var context = new GenericContext(genericInstance, null);
-            
+
             var parameter = new GenericParameterSignature(GenericParameterType.Method, 0);
-            Assert.Throws<ArgumentOutOfRangeException>(() => context.GetTypeArgument(parameter));
+            Assert.Equal(parameter, context.GetTypeArgument(parameter));
         }
     }
 }


### PR DESCRIPTION
In case when we want to partially replace generic values (only Vars, or only MVars) on methods that contains both, we don't want to throw error when second provider is missing