### PR TITLE
Feature/ Add Documentation for CilOpCodes

### DIFF
--- a/src/AsmResolver.PE/DotNet/Cil/CilCode.cs
+++ b/src/AsmResolver.PE/DotNet/Cil/CilCode.cs
@@ -1,239 +1,1819 @@
-// Disable missing XML doc warnings.
-#pragma warning disable 1591
-
 namespace AsmResolver.PE.DotNet.Cil
 {
     /// <summary>
     /// Provides members defining all possible numerical values for each CIL operation code.
     /// </summary>
+    /// <remarks>
+    /// See also: <seealso href="https://www.ecma-international.org/wp-content/uploads/ECMA-335_6th_edition_june_2012.pdf"/>
+    /// </remarks>
     public enum CilCode : ushort
     {
+        /// <summary>
+        /// Do nothing (No operation).
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.nop?view=net-6.0"/>
+        /// </remarks>
         Nop,
+
+        /// <summary>
+        /// Inform a debugger that a breakpoint has been reached.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.break?view=net-6.0"/>
+        /// </remarks>
         Break,
+
+        /// <summary>
+        /// Load argument 0 onto the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldarg_0?view=net-6.0"/>
+        /// </remarks>
         Ldarg_0,
+
+        /// <summary>
+        /// Load argument 1 onto the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldarg_1?view=net-6.0"/>
+        /// </remarks>
         Ldarg_1,
+
+        /// <summary>
+        /// Load argument 2 onto the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldarg_2?view=net-6.0"/>
+        /// </remarks>
         Ldarg_2,
+
+        /// <summary>
+        /// Load argument 3 onto the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldarg_3?view=net-6.0"/>
+        /// </remarks>
         Ldarg_3,
+
+        /// <summary>
+        /// Load local variable 0 onto stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldloc_0?view=net-6.0"/>
+        /// </remarks>
         Ldloc_0,
+
+        /// <summary>
+        /// Load local variable 1 onto stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldloc_1?view=net-6.0"/>
+        /// </remarks>
         Ldloc_1,
+
+        /// <summary>
+        /// Load local variable 2 onto stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldloc_2?view=net-6.0"/>
+        /// </remarks>
         Ldloc_2,
+
+        /// <summary>
+        /// Load local variable 3 onto stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldloc_3?view=net-6.0"/>
+        /// </remarks>
         Ldloc_3,
+
+        /// <summary>
+        /// Pop a value from stack into local variable 0.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stloc_0?view=net-6.0"/>
+        /// </remarks>
         Stloc_0,
+
+        /// <summary>
+        /// Pop a value from stack into local variable 1.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stloc_1?view=net-6.0"/>
+        /// </remarks>
         Stloc_1,
+
+        /// <summary>
+        /// Pop a value from stack into local variable 2.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stloc_2?view=net-6.0"/>
+        /// </remarks>
         Stloc_2,
+
+        /// <summary>
+        /// Pop a value from stack into local variable 3.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stloc_3?view=net-6.0"/>
+        /// </remarks>
         Stloc_3,
+
+        /// <summary>
+        /// Load argument onto the stack, short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldarg_s?view=net-6.0"/>
+        /// </remarks>
         Ldarg_S,
+
+        /// <summary>
+        /// Fetch the address of argument, short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldarga_s?view=net-6.0"/>
+        /// </remarks>
         Ldarga_S,
+
+        /// <summary>
+        /// Store value to the argument numbered, short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.starg_s?view=net-6.0"/>
+        /// </remarks>
         Starg_S,
+
+        /// <summary>
+        /// Load local variable of index onto stack, short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldloc_s?view=net-6.0"/>
+        /// </remarks>
         Ldloc_S,
+
+        /// <summary>
+        /// Load address of local variable with index, short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldloca_s?view=net-6.0"/>
+        /// </remarks>
         Ldloca_S,
+
+        /// <summary>
+        /// Pop a value from stack into local variable with index, short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stloc_s?view=net-6.0"/>
+        /// </remarks>
         Stloc_S,
+
+        /// <summary>
+        /// Push a null reference on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldnull?view=net-6.0"/>
+        /// </remarks>
         Ldnull,
+
+        /// <summary>
+        /// Push -1 onto the stack as int32.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_m1?view=net-6.0"/>
+        /// </remarks>
         Ldc_I4_M1,
+
+        /// <summary>
+        /// Push 0 onto the stack as int32.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_0?view=net-6.0"/>
+        /// </remarks>
         Ldc_I4_0,
+
+        /// <summary>
+        /// Push 1 onto the stack as int32.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_1?view=net-6.0"/>
+        /// </remarks>
         Ldc_I4_1,
+
+        /// <summary>
+        /// Push 2 onto the stack as int32.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_2?view=net-6.0"/>
+        /// </remarks>
         Ldc_I4_2,
+
+        /// <summary>
+        /// Push 3 onto the stack as int32.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_3?view=net-6.0"/>
+        /// </remarks>
         Ldc_I4_3,
+
+        /// <summary>
+        /// Push 4 onto the stack as int32.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_4?view=net-6.0"/>
+        /// </remarks>
         Ldc_I4_4,
+
+        /// <summary>
+        /// Push 5 onto the stack as int32.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_5?view=net-6.0"/>
+        /// </remarks>
         Ldc_I4_5,
+
+        /// <summary>
+        /// Push 6 onto the stack as int32.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_6?view=net-6.0"/>
+        /// </remarks>
         Ldc_I4_6,
+
+        /// <summary>
+        /// Push 7 onto the stack as int32.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_7?view=net-6.0"/>
+        /// </remarks>
         Ldc_I4_7,
+
+        /// <summary>
+        /// Push 8 onto the stack as int32.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_8?view=net-6.0"/>
+        /// </remarks>
         Ldc_I4_8,
+
+        /// <summary>
+        /// Push num onto the stack as int32, short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_s?view=net-6.0"/>
+        /// </remarks>
         Ldc_I4_S,
+
+        /// <summary>
+        /// Push num of type int32 onto the stack as int32.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4?view=net-6.0"/>
+        /// </remarks>
         Ldc_I4,
+
+        /// <summary>
+        /// Push num of type int64 onto the stack as int64.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i8?view=net-6.0"/>
+        /// </remarks>
         Ldc_I8,
+
+        /// <summary>
+        /// Push num of type float32 onto the stack as F.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_r4?view=net-6.0"/>
+        /// </remarks>
         Ldc_R4,
+
+        /// <summary>
+        /// Push num of type float64 onto the stack as F.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_r8?view=net-6.0"/>
+        /// </remarks>
         Ldc_R8,
+
+        /// <summary>
+        /// Duplicate the value on the top of the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.dup?view=net-6.0"/>
+        /// </remarks>
         Dup = 0x25,
+
+        /// <summary>
+        /// Pop value from the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.pop?view=net-6.0"/>
+        /// </remarks>
         Pop,
+
+        /// <summary>
+        /// Exit current method and jump to the specified method.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.jmp?view=net-6.0"/>
+        /// </remarks>
         Jmp,
+
+        /// <summary>
+        /// Call method described by method.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.call?view=net-6.0"/>
+        /// </remarks>
         Call,
+
+        /// <summary>
+        /// Call method indicated on the stack with arguments described by a calling convention.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.calli?view=net-6.0"/>
+        /// </remarks>
         Calli,
+
+        /// <summary>
+        /// Return from method, possibly with a value.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ret?view=net-6.0"/>
+        /// </remarks>
         Ret,
+
+        /// <summary>
+        /// Branch to target, short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.br_s?view=net-6.0"/>
+        /// </remarks>
         Br_S,
+
+        /// <summary>
+        /// Branch to target if value is zero (false), short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.brfalse_s?view=net-6.0"/>
+        /// </remarks>
         Brfalse_S,
+
+        /// <summary>
+        /// Branch to target if value is non-zero (true), short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.brtrue_s?view=net-6.0"/>
+        /// </remarks>
         Brtrue_S,
+
+        /// <summary>
+        /// Branch to target if equal, short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.beq_s?view=net-6.0"/>
+        /// </remarks>
         Beq_S,
+
+        /// <summary>
+        /// Branch to target if greater than or equal to, short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.bge_s?view=net-6.0"/>
+        /// </remarks>
         Bge_S,
+
+        /// <summary>
+        /// Branch to target if greater than, short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.bgt_s?view=net-6.0"/>
+        /// </remarks>
         Bgt_S,
+
+        /// <summary>
+        /// Branch to target if less than or equal to, short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ble_s?view=net-6.0"/>
+        /// </remarks>
         Ble_S,
+
+        /// <summary>
+        /// Branch to target if less than, short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.blt_s?view=net-6.0"/>
+        /// </remarks>
         Blt_S,
+
+        /// <summary>
+        /// Branch to target if unequal or unordered, short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.bne_un_s?view=net-6.0"/>
+        /// </remarks>
         Bne_Un_S,
+
+        /// <summary>
+        /// Branch to target if greater than or equal to (unsigned or unordered), short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.bge_un_s?view=net-6.0"/>
+        /// </remarks>
         Bge_Un_S,
+
+        /// <summary>
+        /// Branch to target if greater than (unsigned or unordered), short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.bgt_un_s?view=net-6.0"/>
+        /// </remarks>
         Bgt_Un_S,
+
+        /// <summary>
+        /// Branch to target if less than or equal to (unsigned or unordered), short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ble_un_s?view=net-6.0"/>
+        /// </remarks>
         Ble_Un_S,
+
+        /// <summary>
+        /// Branch to target if less than (unsigned or unordered), short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.blt_un_s?view=net-6.0"/>
+        /// </remarks>
         Blt_Un_S,
+
+        /// <summary>
+        /// Branch to target.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.br?view=net-6.0"/>
+        /// </remarks>
         Br,
+
+        /// <summary>
+        /// Branch to target if value is zero (false).
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.brfalse?view=net-6.0"/>
+        /// </remarks>
         Brfalse,
+
+        /// <summary>
+        /// Branch to target if value is non-zero (true).
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.brtrue?view=net-6.0"/>
+        /// </remarks>
         Brtrue,
+
+        /// <summary>
+        /// Branch to target if equal.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.beq?view=net-6.0"/>
+        /// </remarks>
         Beq,
+
+        /// <summary>
+        /// Branch to target if greater than or equal to.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.bge?view=net-6.0"/>
+        /// </remarks>
         Bge,
+
+        /// <summary>
+        /// Branch to target if greater than.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.bgt?view=net-6.0"/>
+        /// </remarks>
         Bgt,
+
+        /// <summary>
+        /// Branch to target if less than or equal to.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ble?view=net-6.0"/>
+        /// </remarks>
         Ble,
+
+        /// <summary>
+        /// Branch to target if less than.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.blt?view=net-6.0"/>
+        /// </remarks>
         Blt,
+
+        /// <summary>
+        /// Branch to target if unequal or unordered.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.bne_un?view=net-6.0"/>
+        /// </remarks>
         Bne_Un,
+
+        /// <summary>
+        /// Branch to target if greater than or equal to (unsigned or unordered).
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.bge_un?view=net-6.0"/>
+        /// </remarks>
         Bge_Un,
+
+        /// <summary>
+        /// Branch to target if greater than (unsigned or unordered).
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.bgt_un?view=net-6.0"/>
+        /// </remarks>
         Bgt_Un,
+
+        /// <summary>
+        /// Branch to target if less than or equal to (unsigned or unordered).
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ble_un?view=net-6.0"/>
+        /// </remarks>
         Ble_Un,
+
+        /// <summary>
+        /// Branch to target if less than (unsigned or unordered).
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.blt_un?view=net-6.0"/>
+        /// </remarks>
         Blt_Un,
+
+        /// <summary>
+        /// Jump to one of n values.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.switch?view=net-6.0"/>
+        /// </remarks>
         Switch,
+
+        /// <summary>
+        /// Indirect load value of type int8 as int32 on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_i1?view=net-6.0"/>
+        /// </remarks>
         Ldind_I1,
+
+        /// <summary>
+        /// Indirect load value of type unsigned int8 as int32 on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_u1?view=net-6.0"/>
+        /// </remarks>
         Ldind_U1,
+
+        /// <summary>
+        /// Indirect load value of type int16 as int32 on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_i2?view=net-6.0"/>
+        /// </remarks>
         Ldind_I2,
+
+        /// <summary>
+        /// Indirect load value of type unsigned int16 as int32 on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_u2?view=net-6.0"/>
+        /// </remarks>
         Ldind_U2,
+
+        /// <summary>
+        /// Indirect load value of type int32 as int32 on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_i4?view=net-6.0"/>
+        /// </remarks>
         Ldind_I4,
+
+        /// <summary>
+        /// Indirect load value of type unsigned int32 as int32 on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_u4?view=net-6.0"/>
+        /// </remarks>
         Ldind_U4,
+
+        /// <summary>
+        /// Indirect load value of type signed or unsigned int64 as signed int64 on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_i8?view=net-6.0"/>
+        /// </remarks>
         Ldind_I8,
+
+        /// <summary>
+        /// Indirect load value of type native int as native int on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_i?view=net-6.0"/>
+        /// </remarks>
         Ldind_I,
+
+        /// <summary>
+        /// Indirect load value of type float32 as F on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_r4?view=net-6.0"/>
+        /// </remarks>
         Ldind_R4,
+
+        /// <summary>
+        /// Indirect load value of type float64 as F on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_r8?view=net-6.0"/>
+        /// </remarks>
         Ldind_R8,
+
+        /// <summary>
+        /// Indirect load value of type object ref as O on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_ref?view=net-6.0"/>
+        /// </remarks>
         Ldind_Ref,
+
+        /// <summary>
+        /// Store value of type object ref (type O) into memory at address.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stind_ref?view=net-6.0"/>
+        /// </remarks>
         Stind_Ref,
+
+        /// <summary>
+        /// Store value of type int8 into memory at address.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stind_i1?view=net-6.0"/>
+        /// </remarks>
         Stind_I1,
+
+        /// <summary>
+        /// Store value of type int16 into memory at address.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stind_i2?view=net-6.0"/>
+        /// </remarks>
         Stind_I2,
+
+        /// <summary>
+        /// Store value of type int32 into memory at address.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stind_i4?view=net-6.0"/>
+        /// </remarks>
         Stind_I4,
+
+        /// <summary>
+        /// Store value of type int64 into memory at address.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stind_i8?view=net-6.0"/>
+        /// </remarks>
         Stind_I8,
+
+        /// <summary>
+        /// Store value of type float32 into memory at address.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stind_r4?view=net-6.0"/>
+        /// </remarks>
         Stind_R4,
+
+        /// <summary>
+        /// Store value of type float64 into memory at address.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stind_r8?view=net-6.0"/>
+        /// </remarks>
         Stind_R8,
+
+        /// <summary>
+        /// Add two values, returning a new value.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.add?view=net-6.0"/>
+        /// </remarks>
         Add,
+
+        /// <summary>
+        /// Subtract value2 from value1, returning a new value.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.sub?view=net-6.0"/>
+        /// </remarks>
         Sub,
+
+        /// <summary>
+        /// Multiply values.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.mul?view=net-6.0"/>
+        /// </remarks>
         Mul,
+
+        /// <summary>
+        /// Divide two values to return a quotient or floating-point result.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.div?view=net-6.0"/>
+        /// </remarks>
         Div,
+
+        /// <summary>
+        /// Divide two values, unsigned, returning a quotient.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.div_un?view=net-6.0"/>
+        /// </remarks>
         Div_Un,
+
+        /// <summary>
+        /// Remainder when dividing one value by another.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.rem?view=net-6.0"/>
+        /// </remarks>
         Rem,
+
+        /// <summary>
+        /// Remainder when dividing one unsigned value by another.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.rem_un?view=net-6.0"/>
+        /// </remarks>
         Rem_Un,
+
+        /// <summary>
+        /// Bitwise AND of two integral values, returns an integral value.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.and?view=net-6.0"/>
+        /// </remarks>
         And,
+
+        /// <summary>
+        /// Bitwise OR of two integer values, returns an integer.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.or?view=net-6.0"/>
+        /// </remarks>
         Or,
+
+        /// <summary>
+        /// Bitwise XOR of integer values, returns an integer.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.xor?view=net-6.0"/>
+        /// </remarks>
         Xor,
+
+        /// <summary>
+        /// Shift an integer left (shifting in zeros), return an integer.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.shl?view=net-6.0"/>
+        /// </remarks>
         Shl,
+
+        /// <summary>
+        /// Shift an integer right (shift in sign), return an integer.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.shr?view=net-6.0"/>
+        /// </remarks>
         Shr,
+
+        /// <summary>
+        /// Shift an integer right (shift in zero), return an integer.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.shr_un?view=net-6.0"/>
+        /// </remarks>
         Shr_Un,
+
+        /// <summary>
+        /// Negate value.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.neg?view=net-6.0"/>
+        /// </remarks>
         Neg,
+
+        /// <summary>
+        /// Bitwise complement (logical not).
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.not?view=net-6.0"/>
+        /// </remarks>
         Not,
+
+        /// <summary>
+        /// Convert to int8, pushing int32 on stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_i1?view=net-6.0"/>
+        /// </remarks>
         Conv_I1,
+
+        /// <summary>
+        /// Convert to int16, pushing int32 on stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_i2?view=net-6.0"/>
+        /// </remarks>
         Conv_I2,
+
+        /// <summary>
+        /// Convert to int32, pushing int32 on stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_i4?view=net-6.0"/>
+        /// </remarks>
         Conv_I4,
+
+        /// <summary>
+        /// Convert to int64, pushing int64 on stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_i8?view=net-6.0"/>
+        /// </remarks>
         Conv_I8,
+
+        /// <summary>
+        /// Convert to float32, pushing F on stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_r4?view=net-6.0"/>
+        /// </remarks>
         Conv_R4,
+
+        /// <summary>
+        /// Convert to float64, pushing F on stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_r8?view=net-6.0"/>
+        /// </remarks>
         Conv_R8,
+
+        /// <summary>
+        /// Convert to unsigned int32, pushing int32 on stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_u4?view=net-6.0"/>
+        /// </remarks>
         Conv_U4,
+
+        /// <summary>
+        /// Convert to unsigned int64, pushing int64 on stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_u8?view=net-6.0"/>
+        /// </remarks>
         Conv_U8,
+
+        /// <summary>
+        /// Call a method associated with an object.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.callvirt?view=net-6.0"/>
+        /// </remarks>
         Callvirt,
+
+        /// <summary>
+        /// Copy a value type from src to dest.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.cpobj?view=net-6.0"/>
+        /// </remarks>
         Cpobj,
+
+        /// <summary>
+        /// Copy the value stored at address src to the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldobj?view=net-6.0"/>
+        /// </remarks>
         Ldobj,
+
+        /// <summary>
+        /// Push a string object for the literal string.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldstr?view=net-6.0"/>
+        /// </remarks>
         Ldstr,
+
+        /// <summary>
+        /// Allocate an uninitialized object or value type and call ctor.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.newobj?view=net-6.0"/>
+        /// </remarks>
         Newobj,
+
+        /// <summary>
+        /// Cast obj to class.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.castclass?view=net-6.0"/>
+        /// </remarks>
         Castclass,
+
+        /// <summary>
+        /// Test if obj is an instance of class, returning null or an instance of that class or interface.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.isinst?view=net-6.0"/>
+        /// </remarks>
         Isinst,
+
+        /// <summary>
+        /// Convert unsigned integer to floating-point, pushing F on stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_r_un?view=net-6.0"/>
+        /// </remarks>
         Conv_R_Un,
+
+        /// <summary>
+        /// Extract a value-type from obj, its boxed representation, and push a controlled-mutability managed pointer to it to the top of the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.unbox?view=net-6.0"/>
+        /// </remarks>
         Unbox = 0x79,
+
+        /// <summary>
+        /// Throw an exception.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.throw?view=net-6.0"/>
+        /// </remarks>
         Throw,
+
+        /// <summary>
+        /// Push the value of field of object (or value type) obj, onto the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldfld?view=net-6.0"/>
+        /// </remarks>
         Ldfld,
+
+        /// <summary>
+        /// Push the address of field of object obj on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldflda?view=net-6.0"/>
+        /// </remarks>
         Ldflda,
+
+        /// <summary>
+        /// Replace the value of field of the object obj with value.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stfld?view=net-6.0"/>
+        /// </remarks>
         Stfld,
+
+        /// <summary>
+        /// Push the value of the static field on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldsfld?view=net-6.0"/>
+        /// </remarks>
         Ldsfld,
+
+        /// <summary>
+        /// Push the address of the static field, field, on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldsflda?view=net-6.0"/>
+        /// </remarks>
         Ldsflda,
+
+        /// <summary>
+        /// Replace the value of the static field.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stsfld?view=net-6.0"/>
+        /// </remarks>
         Stsfld,
+
+        /// <summary>
+        /// Store a value at an address.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stobj?view=net-6.0"/>
+        /// </remarks>
         Stobj,
+
+        /// <summary>
+        /// Convert unsigned to an int8 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_i1_un?view=net-6.0"/>
+        /// </remarks>
         Conv_Ovf_I1_Un,
+
+        /// <summary>
+        /// Convert unsigned to an int16 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_i2_un?view=net-6.0"/>
+        /// </remarks>
         Conv_Ovf_I2_Un,
+
+        /// <summary>
+        /// Convert unsigned to an int32 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_i4_un?view=net-6.0"/>
+        /// </remarks>
         Conv_Ovf_I4_Un,
+
+        /// <summary>
+        /// Convert unsigned to an int64 (on the stack as int64) and throw an exception on overflow.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_i8_un?view=net-6.0"/>
+        /// </remarks>
         Conv_Ovf_I8_Un,
+
+        /// <summary>
+        /// Convert unsigned to an unsigned int8 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_u1_un?view=net-6.0"/>
+        /// </remarks>
         Conv_Ovf_U1_Un,
+
+        /// <summary>
+        /// Convert unsigned to an unsigned int16 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_u2_un?view=net-6.0"/>
+        /// </remarks>
         Conv_Ovf_U2_Un,
+
+        /// <summary>
+        /// Convert unsigned to an unsigned int32 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_u4_un?view=net-6.0"/>
+        /// </remarks>
         Conv_Ovf_U4_Un,
+
+        /// <summary>
+        /// Convert unsigned to an unsigned int64 (on the stack as int64) and throw an exception on overflow.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_u8_un?view=net-6.0"/>
+        /// </remarks>
         Conv_Ovf_U8_Un,
+
+        /// <summary>
+        /// Convert unsigned to a native int (on the stack as native int) and throw an exception on overflow.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_i_un?view=net-6.0"/>
+        /// </remarks>
         Conv_Ovf_I_Un,
+
+        /// <summary>
+        /// Convert unsigned to a native unsigned int (on the stack as native int) and throw an exception on overflow.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_u_un?view=net-6.0"/>
+        /// </remarks>
         Conv_Ovf_U_Un,
+
+        /// <summary>
+        /// Convert a boxable value to its boxed form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.box?view=net-6.0"/>
+        /// </remarks>
         Box,
+
+        /// <summary>
+        /// Create a new array with elements of type etype.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.newarr?view=net-6.0"/>
+        /// </remarks>
         Newarr,
+
+        /// <summary>
+        /// Push the length (of type native unsigned int) of array on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldlen?view=net-6.0"/>
+        /// </remarks>
         Ldlen,
+
+        /// <summary>
+        /// Load the address of element at index onto the top of the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelema?view=net-6.0"/>
+        /// </remarks>
         Ldelema,
+
+        /// <summary>
+        /// Load the element with type int8 at index onto the top of the stack as an int32.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_i1?view=net-6.0"/>
+        /// </remarks>
         Ldelem_I1,
+
+        /// <summary>
+        /// Load the element with type unsigned int8 at index onto the top of the stack as an int32.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_u1?view=net-6.0"/>
+        /// </remarks>
         Ldelem_U1,
+
+        /// <summary>
+        /// Load the element with type int16 at index onto the top of the stack as an int32.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_i2?view=net-6.0"/>
+        /// </remarks>
         Ldelem_I2,
+
+        /// <summary>
+        /// Load the element with type unsigned int16 at index onto the top of the stack as an int32.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_u2?view=net-6.0"/>
+        /// </remarks>
         Ldelem_U2,
+
+        /// <summary>
+        /// Load the element with type int32 at index onto the top of the stack as an int32.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_i4?view=net-6.0"/>
+        /// </remarks>
         Ldelem_I4,
+
+        /// <summary>
+        /// Load the element with type unsigned int32 at index onto the top of the stack as an int32.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_u4?view=net-6.0"/>
+        /// </remarks>
         Ldelem_U4,
+
+        /// <summary>
+        /// Load the element with type signed or unsigned int64 at index onto the top of the stack as a signed int64.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_i8?view=net-6.0"/>
+        /// </remarks>
         Ldelem_I8,
+
+        /// <summary>
+        /// Load the element with type native int at index onto the top of the stack as a native int.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_i?view=net-6.0"/>
+        /// </remarks>
         Ldelem_I,
+
+        /// <summary>
+        /// Load the element with type float32 at index onto the top of the stack as an F.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_r4?view=net-6.0"/>
+        /// </remarks>
         Ldelem_R4,
+
+        /// <summary>
+        /// Load the element with type float64 at index onto the top of the stack as an F.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_r8?view=net-6.0"/>
+        /// </remarks>
         Ldelem_R8,
+
+        /// <summary>
+        /// Load the element at index onto the top of the stack as an O. The type of the O is the same as the element type of the array pushed on the CIL stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_ref?view=net-6.0"/>
+        /// </remarks>
         Ldelem_Ref,
+
+        /// <summary>
+        /// Replace array element at index with the i value on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_i?view=net-6.0"/>
+        /// </remarks>
         Stelem_I,
+
+        /// <summary>
+        /// Replace array element at index with the int8 value on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_i1?view=net-6.0"/>
+        /// </remarks>
         Stelem_I1,
+
+        /// <summary>
+        /// Replace array element at index with the int16 value on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_i2?view=net-6.0"/>
+        /// </remarks>
         Stelem_I2,
+
+        /// <summary>
+        /// Replace array element at index with the int32 value on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_i4?view=net-6.0"/>
+        /// </remarks>
         Stelem_I4,
+
+        /// <summary>
+        /// Replace array element at index with the int64 value on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_i8?view=net-6.0"/>
+        /// </remarks>
         Stelem_I8,
+
+        /// <summary>
+        /// Replace array element at index with the float32 value on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_r4?view=net-6.0"/>
+        /// </remarks>
         Stelem_R4,
+
+        /// <summary>
+        /// Replace array element at index with the float64 value on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_r8?view=net-6.0"/>
+        /// </remarks>
         Stelem_R8,
+
+        /// <summary>
+        /// Replace array element at index with the ref value on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_ref?view=net-6.0"/>
+        /// </remarks>
         Stelem_Ref,
+
+        /// <summary>
+        /// Load the element at index onto the top of the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem?view=net-6.0"/>
+        /// </remarks>
         Ldelem,
+
+        /// <summary>
+        /// Replace array element at index with the value on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem?view=net-6.0"/>
+        /// </remarks>
         Stelem,
+
+        /// <summary>
+        /// Extract a value-type from obj, its boxed representation, and copy to the top of the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.unbox_any?view=net-6.0"/>
+        /// </remarks>
         Unbox_Any,
+
+        /// <summary>
+        /// Convert to an int8 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_i1?view=net-6.0"/>
+        /// </remarks>
         Conv_Ovf_I1 = 0xB3,
+
+        /// <summary>
+        /// Convert to an unsigned int8 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_u1?view=net-6.0"/>
+        /// </remarks>
         Conv_Ovf_U1,
+
+        /// <summary>
+        /// Convert to an int16 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_i2?view=net-6.0"/>
+        /// </remarks>
         Conv_Ovf_I2,
+
+        /// <summary>
+        /// Convert to an unsigned int16 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_u2?view=net-6.0"/>
+        /// </remarks>
         Conv_Ovf_U2,
+
+        /// <summary>
+        /// Convert to an int32 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_i4?view=net-6.0"/>
+        /// </remarks>
         Conv_Ovf_I4,
+
+        /// <summary>
+        /// Convert to an unsigned int32 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_u4?view=net-6.0"/>
+        /// </remarks>
         Conv_Ovf_U4,
+
+        /// <summary>
+        /// Convert to an int64 (on the stack as int64) and throw an exception on overflow.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_i8?view=net-6.0"/>
+        /// </remarks>
         Conv_Ovf_I8,
+
+        /// <summary>
+        /// Convert to an unsigned int64 (on the stack as int64) and throw an exception on overflow.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_u8?view=net-6.0"/>
+        /// </remarks>
         Conv_Ovf_U8,
+
+        /// <summary>
+        /// Push the address stored in a typed reference.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.refanyval?view=net-6.0"/>
+        /// </remarks>
         Refanyval = 0xC2,
+
+        /// <summary>
+        /// Throw ArithmeticException if value is not a finite number.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ckfinite?view=net-6.0"/>
+        /// </remarks>
         Ckfinite,
+
+        /// <summary>
+        /// Push a typed reference to ptr of type class onto the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.mkrefany?view=net-6.0"/>
+        /// </remarks>
         Mkrefany = 0xC6,
+
+        /// <summary>
+        /// Convert metadata token to its runtime representation.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldtoken?view=net-6.0"/>
+        /// </remarks>
         Ldtoken = 0xD0,
+
+        /// <summary>
+        /// Convert to unsigned int16, pushing int32 on stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_u2?view=net-6.0"/>
+        /// </remarks>
         Conv_U2,
+
+        /// <summary>
+        /// Convert to unsigned int8, pushing int32 on stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_u1?view=net-6.0"/>
+        /// </remarks>
         Conv_U1,
+
+        /// <summary>
+        /// Convert to native int, pushing native int on stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_i?view=net-6.0"/>
+        /// </remarks>
         Conv_I,
+
+        /// <summary>
+        /// Convert to a native int (on the stack as native int) and throw an exception on overflow.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_i?view=net-6.0"/>
+        /// </remarks>
         Conv_Ovf_I,
+
+        /// <summary>
+        /// Convert to a native unsigned int (on the stack as native int) and throw an exception on overflow.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_u?view=net-6.0"/>
+        /// </remarks>
         Conv_Ovf_U,
+
+        /// <summary>
+        /// Add signed integer values with overflow check.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.add_ovf?view=net-6.0"/>
+        /// </remarks>
         Add_Ovf,
+
+        /// <summary>
+        /// Add unsigned integer values with overflow check.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.add_ovf_un?view=net-6.0"/>
+        /// </remarks>
         Add_Ovf_Un,
+
+        /// <summary>
+        /// Multiply signed integer values. Signed result shall fit in same size.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.mul_ovf?view=net-6.0"/>
+        /// </remarks>
         Mul_Ovf,
+
+        /// <summary>
+        /// Multiply unsigned integer values. Unsigned result shall fit in same size.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.mul_ovf_un?view=net-6.0"/>
+        /// </remarks>
         Mul_Ovf_Un,
+
+        /// <summary>
+        /// Subtract native int from a native int. Signed result shall fit in same size.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.sub_ovf?view=net-6.0"/>
+        /// </remarks>
         Sub_Ovf,
+
+        /// <summary>
+        /// Subtract native unsigned int from a native unsigned int. Unsigned result shall fit in same size.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.sub_ovf_un?view=net-6.0"/>
+        /// </remarks>
         Sub_Ovf_Un,
+
+        /// <summary>
+        /// End finally clause of an exception block.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.endfinally?view=net-6.0"/>
+        /// </remarks>
         Endfinally,
+
+        /// <summary>
+        /// Exit a protected region of code.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.leave?view=net-6.0"/>
+        /// </remarks>
         Leave,
+
+        /// <summary>
+        /// Exit a protected region of code, short form.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.leave_s?view=net-6.0"/>
+        /// </remarks>
         Leave_S,
+
+        /// <summary>
+        /// Store value of type native int into memory at address.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stind_i?view=net-6.0"/>
+        /// </remarks>
         Stind_I,
+
+        /// <summary>
+        /// Convert to native unsigned int, pushing native int on stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_u?view=net-6.0"/>
+        /// </remarks>
         Conv_U,
+
+        /// <summary>
+        /// This prefix opcode is reserved and currently not implemented in the runtime 
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.prefix7?view=net-6.0"/>
+        /// </remarks>
         Prefix7 = 0xF8,
+
+        /// <summary>
+        /// This prefix opcode is reserved and currently not implemented in the runtime 
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.prefix6?view=net-6.0"/>
+        /// </remarks>
         Prefix6,
+
+        /// <summary>
+        /// This prefix opcode is reserved and currently not implemented in the runtime 
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.prefix5?view=net-6.0"/>
+        /// </remarks>
         Prefix5,
+
+        /// <summary>
+        /// This prefix opcode is reserved and currently not implemented in the runtime 
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.prefix4?view=net-6.0"/>
+        /// </remarks>
         Prefix4,
+
+        /// <summary>
+        /// This prefix opcode is reserved and currently not implemented in the runtime 
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.prefix3?view=net-6.0"/>
+        /// </remarks>
         Prefix3,
+
+        /// <summary>
+        /// This prefix opcode is reserved and currently not implemented in the runtime 
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.prefix2?view=net-6.0"/>
+        /// </remarks>
         Prefix2,
+
+        /// <summary>
+        /// This prefix opcode is reserved and currently not implemented in the runtime 
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.prefix1?view=net-6.0"/>
+        /// </remarks>
         Prefix1,
+
+        /// <summary>
+        /// This prefix opcode is reserved and currently not implemented in the runtime 
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.prefixref?view=net-6.0"/>
+        /// </remarks>
         Prefixref,
-        
+
+        /// <summary>
+        /// Return argument list handle for the current method.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.arglist?view=net-6.0"/>
+        /// </remarks>
         Arglist = 0xFE00,
+
+        /// <summary>
+        /// Push 1 (of type int32) if value1 equals value2, else push 0.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ceq?view=net-6.0"/>
+        /// </remarks>
         Ceq,
+
+        /// <summary>
+        /// Push 1 (of type int32) if value1 greater that value2, else push 0.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.cgt?view=net-6.0"/>
+        /// </remarks>
         Cgt,
+
+        /// <summary>
+        /// Push 1 (of type int32) if value1 greater that value2, unsigned or unordered, else push 0.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.cgt_un?view=net-6.0"/>
+        /// </remarks>
         Cgt_Un,
+
+        /// <summary>
+        /// Push 1 (of type int32) if value1 lower than value2, else push 0.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.clt?view=net-6.0"/>
+        /// </remarks>
         Clt,
+
+        /// <summary>
+        /// Push 1 (of type int32) if value1 lower than value2, unsigned or unordered, else push 0.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.clt_un?view=net-6.0"/>
+        /// </remarks>
         Clt_Un,
+
+        /// <summary>
+        /// Push a pointer to a method referenced by method, on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldftn?view=net-6.0"/>
+        /// </remarks>
         Ldftn,
+
+        /// <summary>
+        /// Push address of virtual method on the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldvirtftn?view=net-6.0"/>
+        /// </remarks>
         Ldvirtftn,
+
+        /// <summary>
+        /// Load argument onto the stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldarg?view=net-6.0"/>
+        /// </remarks>
         Ldarg = 0xFE09,
+
+        /// <summary>
+        /// Fetch the address of the argument indexed.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldarga?view=net-6.0"/>
+        /// </remarks>
         Ldarga,
+
+        /// <summary>
+        /// Store value to the argument.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.starg?view=net-6.0"/>
+        /// </remarks>
         Starg,
+
+        /// <summary>
+        /// Load local variable of index onto stack.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldloc?view=net-6.0"/>
+        /// </remarks>
         Ldloc,
+
+        /// <summary>
+        /// Load address of local variable with index index.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldloca?view=net-6.0"/>
+        /// </remarks>
         Ldloca,
+
+        /// <summary>
+        /// Pop a value from stack into local variable index.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stloc?view=net-6.0"/>
+        /// </remarks>
         Stloc,
+
+        /// <summary>
+        /// Allocate space from the local memory pool.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.localloc?view=net-6.0"/>
+        /// </remarks>
         Localloc,
+
+        /// <summary>
+        /// End an exception handling filter clause.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.endfilter?view=net-6.0"/>
+        /// </remarks>
         Endfilter = 0xFE11,
+
+        /// <summary>
+        /// Subsequent pointer instruction might be unaligned.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.unaligned?view=net-6.0"/>
+        /// </remarks>
         Unaligned,
+
+        /// <summary>
+        /// Subsequent pointer reference is volatile.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.volatile?view=net-6.0"/>
+        /// </remarks>
         Volatile,
+
+        /// <summary>
+        /// Subsequent call terminates current method.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.tailcall?view=net-6.0"/>
+        /// </remarks>
         Tailcall,
+
+        /// <summary>
+        /// Initialize the value at address dest.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.initobj?view=net-6.0"/>
+        /// </remarks>
         Initobj,
+
+        /// <summary>
+        /// Call a virtual method on a type constrained to be type T.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.constrained?view=net-6.0"/>
+        /// </remarks>
         Constrained,
+
+        /// <summary>
+        /// Copy data from memory to memory.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.cpblk?view=net-6.0"/>
+        /// </remarks>
         Cpblk,
+
+        /// <summary>
+        /// Set all bytes in a block of memory to a given byte value.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.initblk?view=net-6.0"/>
+        /// </remarks>
         Initblk,
+
+        /// <summary>
+        /// Rethrow the current exception.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.rethrow?view=net-6.0"/>
+        /// </remarks>
         Rethrow = 0xFE1A,
+
+        /// <summary>
+        /// Push the size, in bytes, of a type as an unsigned int32.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.sizeof?view=net-6.0"/>
+        /// </remarks>
         Sizeof = 0xFE1C,
+
+        /// <summary>
+        /// Push the type token stored in a typed reference.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.refanytype?view=net-6.0"/>
+        /// </remarks>
         Refanytype,
+
+        /// <summary>
+        /// Specify that the subsequent array address operation performs no type check at runtime, and that it returns a controlled-mutability managed pointer.
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.readonly?view=net-6.0"/>
+        /// </remarks>
         Readonly
     }
 

--- a/src/AsmResolver.PE/DotNet/Cil/CilOpCodes.cs
+++ b/src/AsmResolver.PE/DotNet/Cil/CilOpCodes.cs
@@ -23,7 +23,10 @@ namespace AsmResolver.PE.DotNet.Cil
         /// Gets a sorted list of all multi-byte operation codes.
         /// </summary>
         public static readonly CilOpCode[] MultiByteOpCodes = new CilOpCode[256];
-       
+
+        /// <summary>
+        /// Do nothing (No operation).
+        /// </summary>
         public static readonly CilOpCode Nop = new CilOpCode(
             (((ushort) CilCode.Nop & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Nop >> 15) << TwoBytesOffset)
@@ -33,6 +36,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Inform a debugger that a breakpoint has been reached.
+        /// </summary>
         public static readonly CilOpCode Break = new CilOpCode(
             (((ushort) CilCode.Break & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Break >> 15) << TwoBytesOffset)
@@ -42,6 +48,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) CilFlowControl.Break << FlowControlOffset));
 
+        /// <summary>
+        /// Load argument 0 onto the stack.
+        /// </summary>
         public static readonly CilOpCode Ldarg_0 = new CilOpCode(
             (((ushort) CilCode.Ldarg_0 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldarg_0 >> 15) << TwoBytesOffset)
@@ -51,6 +60,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load argument 1 onto the stack.
+        /// </summary>
         public static readonly CilOpCode Ldarg_1 = new CilOpCode(
             (((ushort) CilCode.Ldarg_1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldarg_1 >> 15) << TwoBytesOffset)
@@ -60,6 +72,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load argument 2 onto the stack.
+        /// </summary>
         public static readonly CilOpCode Ldarg_2 = new CilOpCode(
             (((ushort) CilCode.Ldarg_2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldarg_2 >> 15) << TwoBytesOffset)
@@ -69,6 +84,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load argument 3 onto the stack.
+        /// </summary>
         public static readonly CilOpCode Ldarg_3 = new CilOpCode(
             (((ushort) CilCode.Ldarg_3 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldarg_3 >> 15) << TwoBytesOffset)
@@ -78,6 +96,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load local variable 0 onto stack.
+        /// </summary>
         public static readonly CilOpCode Ldloc_0 = new CilOpCode(
             (((ushort) CilCode.Ldloc_0 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldloc_0 >> 15) << TwoBytesOffset)
@@ -87,6 +108,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load local variable 1 onto stack.
+        /// </summary>
         public static readonly CilOpCode Ldloc_1 = new CilOpCode(
             (((ushort) CilCode.Ldloc_1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldloc_1 >> 15) << TwoBytesOffset)
@@ -96,6 +120,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load local variable 2 onto stack.
+        /// </summary>
         public static readonly CilOpCode Ldloc_2 = new CilOpCode(
             (((ushort) CilCode.Ldloc_2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldloc_2 >> 15) << TwoBytesOffset)
@@ -105,6 +132,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load local variable 3 onto stack.
+        /// </summary>
         public static readonly CilOpCode Ldloc_3 = new CilOpCode(
             (((ushort) CilCode.Ldloc_3 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldloc_3 >> 15) << TwoBytesOffset)
@@ -114,6 +144,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Pop a value from stack into local variable 0.
+        /// </summary>
         public static readonly CilOpCode Stloc_0 = new CilOpCode(
             (((ushort) CilCode.Stloc_0 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stloc_0 >> 15) << TwoBytesOffset)
@@ -123,6 +156,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Pop a value from stack into local variable 1.
+        /// </summary>
         public static readonly CilOpCode Stloc_1 = new CilOpCode(
             (((ushort) CilCode.Stloc_1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stloc_1 >> 15) << TwoBytesOffset)
@@ -132,6 +168,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Pop a value from stack into local variable 2.
+        /// </summary>
         public static readonly CilOpCode Stloc_2 = new CilOpCode(
             (((ushort) CilCode.Stloc_2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stloc_2 >> 15) << TwoBytesOffset)
@@ -141,6 +180,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Pop a value from stack into local variable 3.
+        /// </summary>
         public static readonly CilOpCode Stloc_3 = new CilOpCode(
             (((ushort) CilCode.Stloc_3 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stloc_3 >> 15) << TwoBytesOffset)
@@ -150,6 +192,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load argument onto the stack, short form.
+        /// </summary>
         public static readonly CilOpCode Ldarg_S = new CilOpCode(
             (((ushort) CilCode.Ldarg_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldarg_S >> 15) << TwoBytesOffset)
@@ -159,6 +204,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineArgument << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Fetch the address of argument, short form.
+        /// </summary>
         public static readonly CilOpCode Ldarga_S = new CilOpCode(
             (((ushort) CilCode.Ldarga_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldarga_S >> 15) << TwoBytesOffset)
@@ -168,6 +216,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineArgument << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Store value to the argument numbered, short form.
+        /// </summary>
         public static readonly CilOpCode Starg_S = new CilOpCode(
             (((ushort) CilCode.Starg_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Starg_S >> 15) << TwoBytesOffset)
@@ -177,6 +228,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineArgument << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load local variable of index onto stack, short form.
+        /// </summary>
         public static readonly CilOpCode Ldloc_S = new CilOpCode(
             (((ushort) CilCode.Ldloc_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldloc_S >> 15) << TwoBytesOffset)
@@ -186,6 +240,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineVar << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load address of local variable with index, short form.
+        /// </summary>
         public static readonly CilOpCode Ldloca_S = new CilOpCode(
             (((ushort) CilCode.Ldloca_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldloca_S >> 15) << TwoBytesOffset)
@@ -195,6 +252,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineVar << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Pop a value from stack into local variable with index, short form.
+        /// </summary>
         public static readonly CilOpCode Stloc_S = new CilOpCode(
             (((ushort) CilCode.Stloc_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stloc_S >> 15) << TwoBytesOffset)
@@ -204,6 +264,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineVar << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push a null reference on the stack.
+        /// </summary>
         public static readonly CilOpCode Ldnull = new CilOpCode(
             (((ushort) CilCode.Ldnull & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldnull >> 15) << TwoBytesOffset)
@@ -213,6 +276,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push -1 onto the stack as int32.
+        /// </summary>
         public static readonly CilOpCode Ldc_I4_M1 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_M1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_M1 >> 15) << TwoBytesOffset)
@@ -222,6 +288,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push 0 onto the stack as int32.
+        /// </summary>
         public static readonly CilOpCode Ldc_I4_0 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_0 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_0 >> 15) << TwoBytesOffset)
@@ -231,6 +300,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push 1 onto the stack as int32.
+        /// </summary>
         public static readonly CilOpCode Ldc_I4_1 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_1 >> 15) << TwoBytesOffset)
@@ -240,6 +312,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push 2 onto the stack as int32.
+        /// </summary>
         public static readonly CilOpCode Ldc_I4_2 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_2 >> 15) << TwoBytesOffset)
@@ -249,6 +324,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push 3 onto the stack as int32.
+        /// </summary>
         public static readonly CilOpCode Ldc_I4_3 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_3 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_3 >> 15) << TwoBytesOffset)
@@ -258,6 +336,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push 4 onto the stack as int32.
+        /// </summary>
         public static readonly CilOpCode Ldc_I4_4 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_4 >> 15) << TwoBytesOffset)
@@ -267,6 +348,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push 5 onto the stack as int32.
+        /// </summary>
         public static readonly CilOpCode Ldc_I4_5 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_5 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_5 >> 15) << TwoBytesOffset)
@@ -276,6 +360,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push 6 onto the stack as int32.
+        /// </summary>
         public static readonly CilOpCode Ldc_I4_6 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_6 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_6 >> 15) << TwoBytesOffset)
@@ -285,6 +372,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push 7 onto the stack as int32.
+        /// </summary>
         public static readonly CilOpCode Ldc_I4_7 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_7 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_7 >> 15) << TwoBytesOffset)
@@ -294,6 +384,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push 8 onto the stack as int32.
+        /// </summary>
         public static readonly CilOpCode Ldc_I4_8 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_8 >> 15) << TwoBytesOffset)
@@ -303,6 +396,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push num onto the stack as int32, short form.
+        /// </summary>
         public static readonly CilOpCode Ldc_I4_S = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_S >> 15) << TwoBytesOffset)
@@ -312,6 +408,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineI << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push num of type int32 onto the stack as int32.
+        /// </summary>
         public static readonly CilOpCode Ldc_I4 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4 >> 15) << TwoBytesOffset)
@@ -321,6 +420,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineI << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push num of type int64 onto the stack as int64.
+        /// </summary>
         public static readonly CilOpCode Ldc_I8 = new CilOpCode(
             (((ushort) CilCode.Ldc_I8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I8 >> 15) << TwoBytesOffset)
@@ -330,6 +432,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineI8 << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push num of type float32 onto the stack as F.
+        /// </summary>
         public static readonly CilOpCode Ldc_R4 = new CilOpCode(
             (((ushort) CilCode.Ldc_R4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_R4 >> 15) << TwoBytesOffset)
@@ -339,6 +444,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineR << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push num of type float64 onto the stack as F.
+        /// </summary>
         public static readonly CilOpCode Ldc_R8 = new CilOpCode(
             (((ushort) CilCode.Ldc_R8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_R8 >> 15) << TwoBytesOffset)
@@ -348,6 +456,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineR << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Duplicate the value on the top of the stack.
+        /// </summary>
         public static readonly CilOpCode Dup = new CilOpCode(
             (((ushort) CilCode.Dup & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Dup >> 15) << TwoBytesOffset)
@@ -357,6 +468,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Pop value from the stack.
+        /// </summary>
         public static readonly CilOpCode Pop = new CilOpCode(
             (((ushort) CilCode.Pop & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Pop >> 15) << TwoBytesOffset)
@@ -366,6 +480,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Exit current method and jump to the specified method.
+        /// </summary>
         public static readonly CilOpCode Jmp = new CilOpCode(
             (((ushort) CilCode.Jmp & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Jmp >> 15) << TwoBytesOffset)
@@ -375,6 +492,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineMethod << OperandTypeOffset)
             | ((byte) CilFlowControl.Call << FlowControlOffset));
 
+        /// <summary>
+        /// Call method described by method.
+        /// </summary>
         public static readonly CilOpCode Call = new CilOpCode(
             (((ushort) CilCode.Call & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Call >> 15) << TwoBytesOffset)
@@ -384,6 +504,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineMethod << OperandTypeOffset)
             | ((byte) CilFlowControl.Call << FlowControlOffset));
 
+        /// <summary>
+        /// Call method indicated on the stack with arguments described by callsitedescr.
+        /// </summary>
         public static readonly CilOpCode Calli = new CilOpCode(
             (((ushort) CilCode.Calli & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Calli >> 15) << TwoBytesOffset)
@@ -393,6 +516,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineSig << OperandTypeOffset)
             | ((byte) CilFlowControl.Call << FlowControlOffset));
 
+        /// <summary>
+        /// Return from method, possibly with a value.
+        /// </summary>
         public static readonly CilOpCode Ret = new CilOpCode(
             (((ushort) CilCode.Ret & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ret >> 15) << TwoBytesOffset)
@@ -402,6 +528,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Return << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target, short form.
+        /// </summary>
         public static readonly CilOpCode Br_S = new CilOpCode(
             (((ushort) CilCode.Br_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Br_S >> 15) << TwoBytesOffset)
@@ -411,6 +540,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineBrTarget << OperandTypeOffset)
             | ((byte) Branch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if value is zero (false), short form.
+        /// </summary>
         public static readonly CilOpCode Brfalse_S = new CilOpCode(
             (((ushort) CilCode.Brfalse_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Brfalse_S >> 15) << TwoBytesOffset)
@@ -420,6 +552,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if value is non-zero (true), short form.
+        /// </summary>
         public static readonly CilOpCode Brtrue_S = new CilOpCode(
             (((ushort) CilCode.Brtrue_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Brtrue_S >> 15) << TwoBytesOffset)
@@ -429,6 +564,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if equal, short form.
+        /// </summary>
         public static readonly CilOpCode Beq_S = new CilOpCode(
             (((ushort) CilCode.Beq_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Beq_S >> 15) << TwoBytesOffset)
@@ -438,6 +576,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if greater than or equal to, short form.
+        /// </summary>
         public static readonly CilOpCode Bge_S = new CilOpCode(
             (((ushort) CilCode.Bge_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Bge_S >> 15) << TwoBytesOffset)
@@ -447,6 +588,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if greater than, short form.
+        /// </summary>
         public static readonly CilOpCode Bgt_S = new CilOpCode(
             (((ushort) CilCode.Bgt_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Bgt_S >> 15) << TwoBytesOffset)
@@ -456,6 +600,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if less than or equal to, short form.
+        /// </summary>
         public static readonly CilOpCode Ble_S = new CilOpCode(
             (((ushort) CilCode.Ble_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ble_S >> 15) << TwoBytesOffset)
@@ -465,6 +612,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if less than, short form.
+        /// </summary>
         public static readonly CilOpCode Blt_S = new CilOpCode(
             (((ushort) CilCode.Blt_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Blt_S >> 15) << TwoBytesOffset)
@@ -474,6 +624,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if unequal or unordered, short form.
+        /// </summary>
         public static readonly CilOpCode Bne_Un_S = new CilOpCode(
             (((ushort) CilCode.Bne_Un_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Bne_Un_S >> 15) << TwoBytesOffset)
@@ -483,6 +636,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if greater than or equal to (unsigned or unordered), short form.
+        /// </summary>
         public static readonly CilOpCode Bge_Un_S = new CilOpCode(
             (((ushort) CilCode.Bge_Un_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Bge_Un_S >> 15) << TwoBytesOffset)
@@ -492,6 +648,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if greater than (unsigned or unordered), short form.
+        /// </summary>
         public static readonly CilOpCode Bgt_Un_S = new CilOpCode(
             (((ushort) CilCode.Bgt_Un_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Bgt_Un_S >> 15) << TwoBytesOffset)
@@ -501,6 +660,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if less than or equal to (unsigned or unordered), short form.
+        /// </summary>
         public static readonly CilOpCode Ble_Un_S = new CilOpCode(
             (((ushort) CilCode.Ble_Un_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ble_Un_S >> 15) << TwoBytesOffset)
@@ -510,6 +672,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if less than (unsigned or unordered), short form.
+        /// </summary>
         public static readonly CilOpCode Blt_Un_S = new CilOpCode(
             (((ushort) CilCode.Blt_Un_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Blt_Un_S >> 15) << TwoBytesOffset)
@@ -519,6 +684,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target.
+        /// </summary>
         public static readonly CilOpCode Br = new CilOpCode(
             (((ushort) CilCode.Br & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Br >> 15) << TwoBytesOffset)
@@ -528,6 +696,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineBrTarget << OperandTypeOffset)
             | ((byte) Branch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if value is zero (false).
+        /// </summary>
         public static readonly CilOpCode Brfalse = new CilOpCode(
             (((ushort) CilCode.Brfalse & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Brfalse >> 15) << TwoBytesOffset)
@@ -537,6 +708,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if value is non-zero (true).
+        /// </summary>
         public static readonly CilOpCode Brtrue = new CilOpCode(
             (((ushort) CilCode.Brtrue & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Brtrue >> 15) << TwoBytesOffset)
@@ -546,6 +720,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if equal.
+        /// </summary>
         public static readonly CilOpCode Beq = new CilOpCode(
             (((ushort) CilCode.Beq & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Beq >> 15) << TwoBytesOffset)
@@ -555,6 +732,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if greater than or equal to.
+        /// </summary>
         public static readonly CilOpCode Bge = new CilOpCode(
             (((ushort) CilCode.Bge & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Bge >> 15) << TwoBytesOffset)
@@ -564,6 +744,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if greater than.
+        /// </summary>
         public static readonly CilOpCode Bgt = new CilOpCode(
             (((ushort) CilCode.Bgt & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Bgt >> 15) << TwoBytesOffset)
@@ -573,6 +756,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if less than or equal to.
+        /// </summary>
         public static readonly CilOpCode Ble = new CilOpCode(
             (((ushort) CilCode.Ble & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ble >> 15) << TwoBytesOffset)
@@ -582,6 +768,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if less than.
+        /// </summary>
         public static readonly CilOpCode Blt = new CilOpCode(
             (((ushort) CilCode.Blt & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Blt >> 15) << TwoBytesOffset)
@@ -591,6 +780,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if unequal or unordered.
+        /// </summary>
         public static readonly CilOpCode Bne_Un = new CilOpCode(
             (((ushort) CilCode.Bne_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Bne_Un >> 15) << TwoBytesOffset)
@@ -600,6 +792,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if greater than or equal to (unsigned or unordered).
+        /// </summary>
         public static readonly CilOpCode Bge_Un = new CilOpCode(
             (((ushort) CilCode.Bge_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Bge_Un >> 15) << TwoBytesOffset)
@@ -609,6 +804,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if greater than (unsigned or unordered).
+        /// </summary>
         public static readonly CilOpCode Bgt_Un = new CilOpCode(
             (((ushort) CilCode.Bgt_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Bgt_Un >> 15) << TwoBytesOffset)
@@ -618,6 +816,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if less than or equal to (unsigned or unordered).
+        /// </summary>
         public static readonly CilOpCode Ble_Un = new CilOpCode(
             (((ushort) CilCode.Ble_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ble_Un >> 15) << TwoBytesOffset)
@@ -627,6 +828,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Branch to target if less than (unsigned or unordered).
+        /// </summary>
         public static readonly CilOpCode Blt_Un = new CilOpCode(
             (((ushort) CilCode.Blt_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Blt_Un >> 15) << TwoBytesOffset)
@@ -636,6 +840,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineBrTarget << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Jump to one of n values.
+        /// </summary>
         public static readonly CilOpCode Switch = new CilOpCode(
             (((ushort) CilCode.Switch & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Switch >> 15) << TwoBytesOffset)
@@ -645,6 +852,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineSwitch << OperandTypeOffset)
             | ((byte) ConditionalBranch << FlowControlOffset));
 
+        /// <summary>
+        /// Indirect load value of type int8 as int32 on the stack.
+        /// </summary>
         public static readonly CilOpCode Ldind_I1 = new CilOpCode(
             (((ushort) CilCode.Ldind_I1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_I1 >> 15) << TwoBytesOffset)
@@ -654,6 +864,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Indirect load value of type unsigned int8 as int32 on the stack.
+        /// </summary>
         public static readonly CilOpCode Ldind_U1 = new CilOpCode(
             (((ushort) CilCode.Ldind_U1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_U1 >> 15) << TwoBytesOffset)
@@ -663,6 +876,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Indirect load value of type int16 as int32 on the stack.
+        /// </summary>
         public static readonly CilOpCode Ldind_I2 = new CilOpCode(
             (((ushort) CilCode.Ldind_I2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_I2 >> 15) << TwoBytesOffset)
@@ -672,6 +888,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Indirect load value of type unsigned int16 as int32 on the stack.
+        /// </summary>
         public static readonly CilOpCode Ldind_U2 = new CilOpCode(
             (((ushort) CilCode.Ldind_U2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_U2 >> 15) << TwoBytesOffset)
@@ -681,6 +900,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Indirect load value of type int32 as int32 on the stack.
+        /// </summary>
         public static readonly CilOpCode Ldind_I4 = new CilOpCode(
             (((ushort) CilCode.Ldind_I4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_I4 >> 15) << TwoBytesOffset)
@@ -690,6 +912,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Indirect load value of type unsigned int32 as int32 on the stack.
+        /// </summary>
         public static readonly CilOpCode Ldind_U4 = new CilOpCode(
             (((ushort) CilCode.Ldind_U4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_U4 >> 15) << TwoBytesOffset)
@@ -699,6 +924,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Indirect load value of type int64 as int64 on the stack.
+        /// </summary>
         public static readonly CilOpCode Ldind_I8 = new CilOpCode(
             (((ushort) CilCode.Ldind_I8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_I8 >> 15) << TwoBytesOffset)
@@ -708,6 +936,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Indirect load value of type native int as native int on the stack.
+        /// </summary>
         public static readonly CilOpCode Ldind_I = new CilOpCode(
             (((ushort) CilCode.Ldind_I & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_I >> 15) << TwoBytesOffset)
@@ -717,6 +948,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Indirect load value of type float32 as F on the stack.
+        /// </summary>
         public static readonly CilOpCode Ldind_R4 = new CilOpCode(
             (((ushort) CilCode.Ldind_R4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_R4 >> 15) << TwoBytesOffset)
@@ -726,6 +960,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Indirect load value of type float64 as F on the stack.
+        /// </summary>
         public static readonly CilOpCode Ldind_R8 = new CilOpCode(
             (((ushort) CilCode.Ldind_R8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_R8 >> 15) << TwoBytesOffset)
@@ -735,6 +972,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Indirect load value of type object ref as O on the stack.
+        /// </summary>
         public static readonly CilOpCode Ldind_Ref = new CilOpCode(
             (((ushort) CilCode.Ldind_Ref & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_Ref >> 15) << TwoBytesOffset)
@@ -744,6 +984,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Store value of type object ref (type O) into memory at address.
+        /// </summary>
         public static readonly CilOpCode Stind_Ref = new CilOpCode(
             (((ushort) CilCode.Stind_Ref & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stind_Ref >> 15) << TwoBytesOffset)
@@ -753,6 +996,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Store value of type int8 into memory at address.
+        /// </summary>
         public static readonly CilOpCode Stind_I1 = new CilOpCode(
             (((ushort) CilCode.Stind_I1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stind_I1 >> 15) << TwoBytesOffset)
@@ -762,6 +1008,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Store value of type int16 into memory at address.
+        /// </summary>
         public static readonly CilOpCode Stind_I2 = new CilOpCode(
             (((ushort) CilCode.Stind_I2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stind_I2 >> 15) << TwoBytesOffset)
@@ -771,6 +1020,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Store value of type int32 into memory at address.
+        /// </summary>
         public static readonly CilOpCode Stind_I4 = new CilOpCode(
             (((ushort) CilCode.Stind_I4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stind_I4 >> 15) << TwoBytesOffset)
@@ -780,6 +1032,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Store value of type int64 into memory at address.
+        /// </summary>
         public static readonly CilOpCode Stind_I8 = new CilOpCode(
             (((ushort) CilCode.Stind_I8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stind_I8 >> 15) << TwoBytesOffset)
@@ -789,6 +1044,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Store value of type float32 into memory at address.
+        /// </summary>
         public static readonly CilOpCode Stind_R4 = new CilOpCode(
             (((ushort) CilCode.Stind_R4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stind_R4 >> 15) << TwoBytesOffset)
@@ -798,6 +1056,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Store value of type float64 into memory at address.
+        /// </summary>
         public static readonly CilOpCode Stind_R8 = new CilOpCode(
             (((ushort) CilCode.Stind_R8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stind_R8 >> 15) << TwoBytesOffset)
@@ -807,6 +1068,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Add two values, returning a new value.
+        /// </summary>
         public static readonly CilOpCode Add = new CilOpCode(
             (((ushort) CilCode.Add & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Add >> 15) << TwoBytesOffset)
@@ -816,6 +1080,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Subtract value2 from value1, returning a new value.
+        /// </summary>
         public static readonly CilOpCode Sub = new CilOpCode(
             (((ushort) CilCode.Sub & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Sub >> 15) << TwoBytesOffset)
@@ -825,6 +1092,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Multiply values.
+        /// </summary>
         public static readonly CilOpCode Mul = new CilOpCode(
             (((ushort) CilCode.Mul & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Mul >> 15) << TwoBytesOffset)
@@ -834,6 +1104,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Divide two values to return a quotient or floating-point result.
+        /// </summary>
         public static readonly CilOpCode Div = new CilOpCode(
             (((ushort) CilCode.Div & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Div >> 15) << TwoBytesOffset)
@@ -843,6 +1116,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Divide two values, unsigned, returning a quotient.
+        /// </summary>
         public static readonly CilOpCode Div_Un = new CilOpCode(
             (((ushort) CilCode.Div_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Div_Un >> 15) << TwoBytesOffset)
@@ -852,6 +1128,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Remainder when dividing one value by another.
+        /// </summary>
         public static readonly CilOpCode Rem = new CilOpCode(
             (((ushort) CilCode.Rem & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Rem >> 15) << TwoBytesOffset)
@@ -861,6 +1140,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Remainder when dividing one unsigned value by another.
+        /// </summary>
         public static readonly CilOpCode Rem_Un = new CilOpCode(
             (((ushort) CilCode.Rem_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Rem_Un >> 15) << TwoBytesOffset)
@@ -870,6 +1152,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Bitwise AND of two integral values, returns an integral value.
+        /// </summary>
         public static readonly CilOpCode And = new CilOpCode(
             (((ushort) CilCode.And & 0xFF) << ValueOffset)
             | (((ushort) CilCode.And >> 15) << TwoBytesOffset)
@@ -879,6 +1164,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Bitwise OR of two integer values, returns an integer.
+        /// </summary>
         public static readonly CilOpCode Or = new CilOpCode(
             (((ushort) CilCode.Or & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Or >> 15) << TwoBytesOffset)
@@ -888,6 +1176,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Bitwise XOR of integer values, returns an integer.
+        /// </summary>
         public static readonly CilOpCode Xor = new CilOpCode(
             (((ushort) CilCode.Xor & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Xor >> 15) << TwoBytesOffset)
@@ -897,6 +1188,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Shift an integer left (shifting in zeros), return an integer.
+        /// </summary>
         public static readonly CilOpCode Shl = new CilOpCode(
             (((ushort) CilCode.Shl & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Shl >> 15) << TwoBytesOffset)
@@ -906,6 +1200,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Shift an integer right (shift in sign), return an integer.
+        /// </summary>
         public static readonly CilOpCode Shr = new CilOpCode(
             (((ushort) CilCode.Shr & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Shr >> 15) << TwoBytesOffset)
@@ -915,6 +1212,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Shift an integer right (shift in zero), return an integer.
+        /// </summary>
         public static readonly CilOpCode Shr_Un = new CilOpCode(
             (((ushort) CilCode.Shr_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Shr_Un >> 15) << TwoBytesOffset)
@@ -924,6 +1224,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Negate value.
+        /// </summary>
         public static readonly CilOpCode Neg = new CilOpCode(
             (((ushort) CilCode.Neg & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Neg >> 15) << TwoBytesOffset)
@@ -933,6 +1236,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Bitwise complement (logical not).
+        /// </summary>
         public static readonly CilOpCode Not = new CilOpCode(
             (((ushort) CilCode.Not & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Not >> 15) << TwoBytesOffset)
@@ -942,6 +1248,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to int8, pushing int32 on stack.
+        /// </summary>
         public static readonly CilOpCode Conv_I1 = new CilOpCode(
             (((ushort) CilCode.Conv_I1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_I1 >> 15) << TwoBytesOffset)
@@ -951,6 +1260,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to int16, pushing int32 on stack.
+        /// </summary>
         public static readonly CilOpCode Conv_I2 = new CilOpCode(
             (((ushort) CilCode.Conv_I2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_I2 >> 15) << TwoBytesOffset)
@@ -960,6 +1272,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to int32, pushing int32 on stack.
+        /// </summary>
         public static readonly CilOpCode Conv_I4 = new CilOpCode(
             (((ushort) CilCode.Conv_I4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_I4 >> 15) << TwoBytesOffset)
@@ -969,6 +1284,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to int64, pushing int64 on stack.
+        /// </summary>
         public static readonly CilOpCode Conv_I8 = new CilOpCode(
             (((ushort) CilCode.Conv_I8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_I8 >> 15) << TwoBytesOffset)
@@ -978,6 +1296,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to float32, pushing F on stack.
+        /// </summary>
         public static readonly CilOpCode Conv_R4 = new CilOpCode(
             (((ushort) CilCode.Conv_R4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_R4 >> 15) << TwoBytesOffset)
@@ -987,6 +1308,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to float64, pushing F on stack.
+        /// </summary>
         public static readonly CilOpCode Conv_R8 = new CilOpCode(
             (((ushort) CilCode.Conv_R8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_R8 >> 15) << TwoBytesOffset)
@@ -996,6 +1320,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to unsigned int32, pushing int32 on stack.
+        /// </summary>
         public static readonly CilOpCode Conv_U4 = new CilOpCode(
             (((ushort) CilCode.Conv_U4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_U4 >> 15) << TwoBytesOffset)
@@ -1005,6 +1332,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to unsigned int64, pushing int64 on stack.
+        /// </summary>
         public static readonly CilOpCode Conv_U8 = new CilOpCode(
             (((ushort) CilCode.Conv_U8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_U8 >> 15) << TwoBytesOffset)
@@ -1014,6 +1344,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Call a method associated with an object.
+        /// </summary>
         public static readonly CilOpCode Callvirt = new CilOpCode(
             (((ushort) CilCode.Callvirt & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Callvirt >> 15) << TwoBytesOffset)
@@ -1023,6 +1356,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineMethod << OperandTypeOffset)
             | ((byte) CilFlowControl.Call << FlowControlOffset));
 
+        /// <summary>
+        /// Copy a value type from src to dest.
+        /// </summary>
         public static readonly CilOpCode Cpobj = new CilOpCode(
             (((ushort) CilCode.Cpobj & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Cpobj >> 15) << TwoBytesOffset)
@@ -1032,6 +1368,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineType << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Copy the value stored at address src to the stack.
+        /// </summary>
         public static readonly CilOpCode Ldobj = new CilOpCode(
             (((ushort) CilCode.Ldobj & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldobj >> 15) << TwoBytesOffset)
@@ -1041,6 +1380,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineType << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push a string object for the literal string.
+        /// </summary>
         public static readonly CilOpCode Ldstr = new CilOpCode(
             (((ushort) CilCode.Ldstr & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldstr >> 15) << TwoBytesOffset)
@@ -1050,6 +1392,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineString << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Allocate an uninitialized object or value type and call ctor.
+        /// </summary>
         public static readonly CilOpCode Newobj = new CilOpCode(
             (((ushort) CilCode.Newobj & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Newobj >> 15) << TwoBytesOffset)
@@ -1059,6 +1404,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineMethod << OperandTypeOffset)
             | ((byte) CilFlowControl.Call << FlowControlOffset));
 
+        /// <summary>
+        /// Cast obj to class.
+        /// </summary>
         public static readonly CilOpCode Castclass = new CilOpCode(
             (((ushort) CilCode.Castclass & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Castclass >> 15) << TwoBytesOffset)
@@ -1068,6 +1416,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineType << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Test if obj is an instance of class, returning null or an instance of that class or interface.
+        /// </summary>
         public static readonly CilOpCode Isinst = new CilOpCode(
             (((ushort) CilCode.Isinst & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Isinst >> 15) << TwoBytesOffset)
@@ -1077,6 +1428,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineType << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert unsigned integer to floating-point, pushing F on stack.
+        /// </summary>
         public static readonly CilOpCode Conv_R_Un = new CilOpCode(
             (((ushort) CilCode.Conv_R_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_R_Un >> 15) << TwoBytesOffset)
@@ -1086,6 +1440,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Extract a value-type from obj, its boxed representation, and push a controlled-mutability managed pointer to it to the top of the stack.
+        /// </summary>
         public static readonly CilOpCode Unbox = new CilOpCode(
             (((ushort) CilCode.Unbox & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Unbox >> 15) << TwoBytesOffset)
@@ -1095,6 +1452,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineType << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Throw an exception.
+        /// </summary>
         public static readonly CilOpCode Throw = new CilOpCode(
             (((ushort) CilCode.Throw & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Throw >> 15) << TwoBytesOffset)
@@ -1104,6 +1464,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) CilFlowControl.Throw << FlowControlOffset));
 
+        /// <summary>
+        /// Push the value of field of object (or value type) obj, onto the stack.
+        /// </summary>
         public static readonly CilOpCode Ldfld = new CilOpCode(
             (((ushort) CilCode.Ldfld & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldfld >> 15) << TwoBytesOffset)
@@ -1113,6 +1476,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineField << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push the address of field of object obj on the stack.
+        /// </summary>
         public static readonly CilOpCode Ldflda = new CilOpCode(
             (((ushort) CilCode.Ldflda & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldflda >> 15) << TwoBytesOffset)
@@ -1122,6 +1488,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineField << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Replace the value of field of the object obj with value.
+        /// </summary>
         public static readonly CilOpCode Stfld = new CilOpCode(
             (((ushort) CilCode.Stfld & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stfld >> 15) << TwoBytesOffset)
@@ -1131,6 +1500,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineField << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push the value of the static field on the stack.
+        /// </summary>
         public static readonly CilOpCode Ldsfld = new CilOpCode(
             (((ushort) CilCode.Ldsfld & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldsfld >> 15) << TwoBytesOffset)
@@ -1140,6 +1512,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineField << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push the address of the static field, field, on the stack.
+        /// </summary>
         public static readonly CilOpCode Ldsflda = new CilOpCode(
             (((ushort) CilCode.Ldsflda & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldsflda >> 15) << TwoBytesOffset)
@@ -1149,6 +1524,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineField << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Replace the value of the static field.
+        /// </summary>
         public static readonly CilOpCode Stsfld = new CilOpCode(
             (((ushort) CilCode.Stsfld & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stsfld >> 15) << TwoBytesOffset)
@@ -1158,6 +1536,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineField << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Store a value at an address.
+        /// </summary>
         public static readonly CilOpCode Stobj = new CilOpCode(
             (((ushort) CilCode.Stobj & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stobj >> 15) << TwoBytesOffset)
@@ -1167,6 +1548,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineType << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert unsigned to an int8 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
         public static readonly CilOpCode Conv_Ovf_I1_Un = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_I1_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_I1_Un >> 15) << TwoBytesOffset)
@@ -1176,6 +1560,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert unsigned to an int16 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
         public static readonly CilOpCode Conv_Ovf_I2_Un = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_I2_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_I2_Un >> 15) << TwoBytesOffset)
@@ -1185,6 +1572,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert unsigned to an int32 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
         public static readonly CilOpCode Conv_Ovf_I4_Un = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_I4_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_I4_Un >> 15) << TwoBytesOffset)
@@ -1194,6 +1584,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert unsigned to an int64 (on the stack as int64) and throw an exception on overflow.
+        /// </summary>
         public static readonly CilOpCode Conv_Ovf_I8_Un = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_I8_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_I8_Un >> 15) << TwoBytesOffset)
@@ -1203,6 +1596,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert unsigned to an unsigned int8 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
         public static readonly CilOpCode Conv_Ovf_U1_Un = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_U1_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_U1_Un >> 15) << TwoBytesOffset)
@@ -1212,6 +1608,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert unsigned to an unsigned int16 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
         public static readonly CilOpCode Conv_Ovf_U2_Un = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_U2_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_U2_Un >> 15) << TwoBytesOffset)
@@ -1221,6 +1620,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert unsigned to an unsigned int32 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
         public static readonly CilOpCode Conv_Ovf_U4_Un = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_U4_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_U4_Un >> 15) << TwoBytesOffset)
@@ -1230,6 +1632,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert unsigned to an unsigned int64 (on the stack as int64) and throw an exception on overflow.
+        /// </summary>
         public static readonly CilOpCode Conv_Ovf_U8_Un = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_U8_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_U8_Un >> 15) << TwoBytesOffset)
@@ -1239,6 +1644,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert unsigned to a native int (on the stack as native int) and throw an exception on overflow.
+        /// </summary>
         public static readonly CilOpCode Conv_Ovf_I_Un = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_I_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_I_Un >> 15) << TwoBytesOffset)
@@ -1248,6 +1656,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert unsigned to a native unsigned int (on the stack as native int) and throw an exception on overflow.
+        /// </summary>
         public static readonly CilOpCode Conv_Ovf_U_Un = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_U_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_U_Un >> 15) << TwoBytesOffset)
@@ -1257,6 +1668,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert a boxable value to its boxed form.
+        /// </summary>
         public static readonly CilOpCode Box = new CilOpCode(
             (((ushort) CilCode.Box & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Box >> 15) << TwoBytesOffset)
@@ -1266,6 +1680,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineType << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Create a new array with elements of type etype.
+        /// </summary>
         public static readonly CilOpCode Newarr = new CilOpCode(
             (((ushort) CilCode.Newarr & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Newarr >> 15) << TwoBytesOffset)
@@ -1275,6 +1692,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineType << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push the length (of type native unsigned int) of array on the stack.
+        /// </summary>
         public static readonly CilOpCode Ldlen = new CilOpCode(
             (((ushort) CilCode.Ldlen & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldlen >> 15) << TwoBytesOffset)
@@ -1284,6 +1704,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load the address of element at index onto the top of the stack.
+        /// </summary>
         public static readonly CilOpCode Ldelema = new CilOpCode(
             (((ushort) CilCode.Ldelema & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelema >> 15) << TwoBytesOffset)
@@ -1293,6 +1716,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineType << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load the element with type int8 at index onto the top of the stack as an int32.
+        /// </summary>
         public static readonly CilOpCode Ldelem_I1 = new CilOpCode(
             (((ushort) CilCode.Ldelem_I1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_I1 >> 15) << TwoBytesOffset)
@@ -1302,6 +1728,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load the element with type unsigned int8 at index onto the top of the stack as an int32.
+        /// </summary>
         public static readonly CilOpCode Ldelem_U1 = new CilOpCode(
             (((ushort) CilCode.Ldelem_U1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_U1 >> 15) << TwoBytesOffset)
@@ -1311,6 +1740,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load the element with type int16 at index onto the top of the stack as an int32.
+        /// </summary>
         public static readonly CilOpCode Ldelem_I2 = new CilOpCode(
             (((ushort) CilCode.Ldelem_I2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_I2 >> 15) << TwoBytesOffset)
@@ -1320,6 +1752,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load the element with type unsigned int16 at index onto the top of the stack as an int32.
+        /// </summary>
         public static readonly CilOpCode Ldelem_U2 = new CilOpCode(
             (((ushort) CilCode.Ldelem_U2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_U2 >> 15) << TwoBytesOffset)
@@ -1329,6 +1764,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load the element with type int32 at index onto the top of the stack as an int32.
+        /// </summary>
         public static readonly CilOpCode Ldelem_I4 = new CilOpCode(
             (((ushort) CilCode.Ldelem_I4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_I4 >> 15) << TwoBytesOffset)
@@ -1338,6 +1776,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load the element with type unsigned int32 at index onto the top of the stack as an int32.
+        /// </summary>
         public static readonly CilOpCode Ldelem_U4 = new CilOpCode(
             (((ushort) CilCode.Ldelem_U4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_U4 >> 15) << TwoBytesOffset)
@@ -1347,6 +1788,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load the element with type int64 at index onto the top of the stack as an int64.
+        /// </summary>
         public static readonly CilOpCode Ldelem_I8 = new CilOpCode(
             (((ushort) CilCode.Ldelem_I8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_I8 >> 15) << TwoBytesOffset)
@@ -1356,6 +1800,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load the element with type native int at index onto the top of the stack as a native int.
+        /// </summary>
         public static readonly CilOpCode Ldelem_I = new CilOpCode(
             (((ushort) CilCode.Ldelem_I & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_I >> 15) << TwoBytesOffset)
@@ -1365,6 +1812,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load the element with type float32 at index onto the top of the stack as an F.
+        /// </summary>
         public static readonly CilOpCode Ldelem_R4 = new CilOpCode(
             (((ushort) CilCode.Ldelem_R4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_R4 >> 15) << TwoBytesOffset)
@@ -1374,6 +1824,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load the element with type float64 at index onto the top of the stack as an F.
+        /// </summary>
         public static readonly CilOpCode Ldelem_R8 = new CilOpCode(
             (((ushort) CilCode.Ldelem_R8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_R8 >> 15) << TwoBytesOffset)
@@ -1383,6 +1836,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load the element at index onto the top of the stack as an O. The type of the O is the same as the element type of the array pushed on the CIL stack.
+        /// </summary>
         public static readonly CilOpCode Ldelem_Ref = new CilOpCode(
             (((ushort) CilCode.Ldelem_Ref & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_Ref >> 15) << TwoBytesOffset)
@@ -1392,6 +1848,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Replace array element at index with the i value on the stack.
+        /// </summary>
         public static readonly CilOpCode Stelem_I = new CilOpCode(
             (((ushort) CilCode.Stelem_I & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stelem_I >> 15) << TwoBytesOffset)
@@ -1401,6 +1860,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Replace array element at index with the int8 value on the stack.
+        /// </summary>
         public static readonly CilOpCode Stelem_I1 = new CilOpCode(
             (((ushort) CilCode.Stelem_I1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stelem_I1 >> 15) << TwoBytesOffset)
@@ -1410,6 +1872,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Replace array element at index with the int16 value on the stack.
+        /// </summary>
         public static readonly CilOpCode Stelem_I2 = new CilOpCode(
             (((ushort) CilCode.Stelem_I2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stelem_I2 >> 15) << TwoBytesOffset)
@@ -1419,6 +1884,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// 	Replace array element at index with the int32 value on the stack.
+        /// </summary>
         public static readonly CilOpCode Stelem_I4 = new CilOpCode(
             (((ushort) CilCode.Stelem_I4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stelem_I4 >> 15) << TwoBytesOffset)
@@ -1428,6 +1896,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Replace array element at index with the int64 value on the stack.
+        /// </summary>
         public static readonly CilOpCode Stelem_I8 = new CilOpCode(
             (((ushort) CilCode.Stelem_I8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stelem_I8 >> 15) << TwoBytesOffset)
@@ -1437,6 +1908,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Replace array element at index with the float32 value on the stack.
+        /// </summary>
         public static readonly CilOpCode Stelem_R4 = new CilOpCode(
             (((ushort) CilCode.Stelem_R4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stelem_R4 >> 15) << TwoBytesOffset)
@@ -1446,6 +1920,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Replace array element at index with the float64 value on the stack.
+        /// </summary>
         public static readonly CilOpCode Stelem_R8 = new CilOpCode(
             (((ushort) CilCode.Stelem_R8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stelem_R8 >> 15) << TwoBytesOffset)
@@ -1455,6 +1932,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Replace array element at index with the ref value on the stack.
+        /// </summary>
         public static readonly CilOpCode Stelem_Ref = new CilOpCode(
             (((ushort) CilCode.Stelem_Ref & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stelem_Ref >> 15) << TwoBytesOffset)
@@ -1464,6 +1944,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load the element at index onto the top of the stack.
+        /// </summary>
         public static readonly CilOpCode Ldelem = new CilOpCode(
             (((ushort) CilCode.Ldelem & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem >> 15) << TwoBytesOffset)
@@ -1473,6 +1956,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineType << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Replace array element at index with the value on the stack.
+        /// </summary>
         public static readonly CilOpCode Stelem = new CilOpCode(
             (((ushort) CilCode.Stelem & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stelem >> 15) << TwoBytesOffset)
@@ -1482,6 +1968,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineType << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Extract a value-type from obj, its boxed representation, and copy to the top of the stack.
+        /// </summary>
         public static readonly CilOpCode Unbox_Any = new CilOpCode(
             (((ushort) CilCode.Unbox_Any & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Unbox_Any >> 15) << TwoBytesOffset)
@@ -1491,6 +1980,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineType << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to an int8 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
         public static readonly CilOpCode Conv_Ovf_I1 = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_I1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_I1 >> 15) << TwoBytesOffset)
@@ -1500,6 +1992,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to an unsigned int8 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
         public static readonly CilOpCode Conv_Ovf_U1 = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_U1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_U1 >> 15) << TwoBytesOffset)
@@ -1509,6 +2004,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to an int16 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
         public static readonly CilOpCode Conv_Ovf_I2 = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_I2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_I2 >> 15) << TwoBytesOffset)
@@ -1518,6 +2016,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to an unsigned int16 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
         public static readonly CilOpCode Conv_Ovf_U2 = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_U2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_U2 >> 15) << TwoBytesOffset)
@@ -1527,6 +2028,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to an int32 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
         public static readonly CilOpCode Conv_Ovf_I4 = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_I4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_I4 >> 15) << TwoBytesOffset)
@@ -1536,6 +2040,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to an unsigned int32 (on the stack as int32) and throw an exception on overflow.
+        /// </summary>
         public static readonly CilOpCode Conv_Ovf_U4 = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_U4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_U4 >> 15) << TwoBytesOffset)
@@ -1545,6 +2052,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to an int64 (on the stack as int64) and throw an exception on overflow.
+        /// </summary>
         public static readonly CilOpCode Conv_Ovf_I8 = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_I8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_I8 >> 15) << TwoBytesOffset)
@@ -1554,6 +2064,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to an unsigned int64 (on the stack as int64) and throw an exception on overflow.
+        /// </summary>
         public static readonly CilOpCode Conv_Ovf_U8 = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_U8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_U8 >> 15) << TwoBytesOffset)
@@ -1563,6 +2076,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push the address stored in a typed reference.
+        /// </summary>
         public static readonly CilOpCode Refanyval = new CilOpCode(
             (((ushort) CilCode.Refanyval & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Refanyval >> 15) << TwoBytesOffset)
@@ -1572,6 +2088,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineType << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Throw ArithmeticException if value is not a finite number.
+        /// </summary>
         public static readonly CilOpCode Ckfinite = new CilOpCode(
             (((ushort) CilCode.Ckfinite & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ckfinite >> 15) << TwoBytesOffset)
@@ -1581,6 +2100,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push a typed reference to ptr of type class onto the stack.
+        /// </summary>
         public static readonly CilOpCode Mkrefany = new CilOpCode(
             (((ushort) CilCode.Mkrefany & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Mkrefany >> 15) << TwoBytesOffset)
@@ -1590,6 +2112,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineType << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert metadata token to its runtime representation.
+        /// </summary>
         public static readonly CilOpCode Ldtoken = new CilOpCode(
             (((ushort) CilCode.Ldtoken & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldtoken >> 15) << TwoBytesOffset)
@@ -1599,6 +2124,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineTok << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to unsigned int16, pushing int32 on stack.
+        /// </summary>
         public static readonly CilOpCode Conv_U2 = new CilOpCode(
             (((ushort) CilCode.Conv_U2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_U2 >> 15) << TwoBytesOffset)
@@ -1608,6 +2136,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to unsigned int8, pushing int32 on stack.
+        /// </summary>
         public static readonly CilOpCode Conv_U1 = new CilOpCode(
             (((ushort) CilCode.Conv_U1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_U1 >> 15) << TwoBytesOffset)
@@ -1617,6 +2148,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to native int, pushing native int on stack.
+        /// </summary>
         public static readonly CilOpCode Conv_I = new CilOpCode(
             (((ushort) CilCode.Conv_I & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_I >> 15) << TwoBytesOffset)
@@ -1626,6 +2160,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to a native int (on the stack as native int) and throw an exception on overflow.
+        /// </summary>
         public static readonly CilOpCode Conv_Ovf_I = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_I & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_I >> 15) << TwoBytesOffset)
@@ -1635,6 +2172,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to a native unsigned int (on the stack as native int) and throw an exception on overflow.
+        /// </summary>
         public static readonly CilOpCode Conv_Ovf_U = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_U & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_U >> 15) << TwoBytesOffset)
@@ -1644,6 +2184,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Add signed integer values with overflow check.
+        /// </summary>
         public static readonly CilOpCode Add_Ovf = new CilOpCode(
             (((ushort) CilCode.Add_Ovf & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Add_Ovf >> 15) << TwoBytesOffset)
@@ -1653,6 +2196,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Add unsigned integer values with overflow check.
+        /// </summary>
         public static readonly CilOpCode Add_Ovf_Un = new CilOpCode(
             (((ushort) CilCode.Add_Ovf_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Add_Ovf_Un >> 15) << TwoBytesOffset)
@@ -1662,6 +2208,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Multiply signed integer values. Signed result shall fit in same size.
+        /// </summary>
         public static readonly CilOpCode Mul_Ovf = new CilOpCode(
             (((ushort) CilCode.Mul_Ovf & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Mul_Ovf >> 15) << TwoBytesOffset)
@@ -1671,6 +2220,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Multiply unsigned integer values. Unsigned result shall fit in same size.
+        /// </summary>
         public static readonly CilOpCode Mul_Ovf_Un = new CilOpCode(
             (((ushort) CilCode.Mul_Ovf_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Mul_Ovf_Un >> 15) << TwoBytesOffset)
@@ -1680,6 +2232,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Subtract native int from a native int. Signed result shall fit in same size.
+        /// </summary>
         public static readonly CilOpCode Sub_Ovf = new CilOpCode(
             (((ushort) CilCode.Sub_Ovf & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Sub_Ovf >> 15) << TwoBytesOffset)
@@ -1689,6 +2244,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Subtract native unsigned int from a native unsigned int. Unsigned result shall fit in same size.
+        /// </summary>
         public static readonly CilOpCode Sub_Ovf_Un = new CilOpCode(
             (((ushort) CilCode.Sub_Ovf_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Sub_Ovf_Un >> 15) << TwoBytesOffset)
@@ -1698,6 +2256,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// End finally clause of an exception block.
+        /// </summary>
         public static readonly CilOpCode Endfinally = new CilOpCode(
             (((ushort) CilCode.Endfinally & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Endfinally >> 15) << TwoBytesOffset)
@@ -1707,6 +2268,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Return << FlowControlOffset));
 
+        /// <summary>
+        /// Exit a protected region of code.
+        /// </summary>
         public static readonly CilOpCode Leave = new CilOpCode(
             (((ushort) CilCode.Leave & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Leave >> 15) << TwoBytesOffset)
@@ -1716,6 +2280,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineBrTarget << OperandTypeOffset)
             | ((byte) Branch << FlowControlOffset));
 
+        /// <summary>
+        /// Exit a protected region of code, short form.
+        /// </summary>
         public static readonly CilOpCode Leave_S = new CilOpCode(
             (((ushort) CilCode.Leave_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Leave_S >> 15) << TwoBytesOffset)
@@ -1725,6 +2292,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineBrTarget << OperandTypeOffset)
             | ((byte) Branch << FlowControlOffset));
 
+        /// <summary>
+        /// Store value of type native int into memory at address.
+        /// </summary>
         public static readonly CilOpCode Stind_I = new CilOpCode(
             (((ushort) CilCode.Stind_I & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stind_I >> 15) << TwoBytesOffset)
@@ -1734,6 +2304,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Convert to native unsigned int, pushing native int on stack.
+        /// </summary>
         public static readonly CilOpCode Conv_U = new CilOpCode(
             (((ushort) CilCode.Conv_U & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_U >> 15) << TwoBytesOffset)
@@ -1815,6 +2388,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Meta << FlowControlOffset));
 
+        /// <summary>
+        /// Return argument list handle for the current method.
+        /// </summary>
         public static readonly CilOpCode Arglist = new CilOpCode(
             (((ushort) CilCode.Arglist & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Arglist >> 15) << TwoBytesOffset)
@@ -1824,6 +2400,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push 1 (of type int32) if value1 equals value2, else push 0.
+        /// </summary>
         public static readonly CilOpCode Ceq = new CilOpCode(
             (((ushort) CilCode.Ceq & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ceq >> 15) << TwoBytesOffset)
@@ -1833,6 +2412,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push 1 (of type int32) if value1 greater that value2, else push 0.
+        /// </summary>
         public static readonly CilOpCode Cgt = new CilOpCode(
             (((ushort) CilCode.Cgt & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Cgt >> 15) << TwoBytesOffset)
@@ -1842,6 +2424,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push 1 (of type int32) if value1 greater that value2, unsigned or unordered, else push 0.
+        /// </summary>
         public static readonly CilOpCode Cgt_Un = new CilOpCode(
             (((ushort) CilCode.Cgt_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Cgt_Un >> 15) << TwoBytesOffset)
@@ -1851,6 +2436,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push 1 (of type int32) if value1 lower than value2, else push 0.
+        /// </summary>
         public static readonly CilOpCode Clt = new CilOpCode(
             (((ushort) CilCode.Clt & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Clt >> 15) << TwoBytesOffset)
@@ -1860,6 +2448,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// 	Push 1 (of type int32) if value1 lower than value2, unsigned or unordered, else push 0.
+        /// </summary>
         public static readonly CilOpCode Clt_Un = new CilOpCode(
             (((ushort) CilCode.Clt_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Clt_Un >> 15) << TwoBytesOffset)
@@ -1869,6 +2460,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push a pointer to a method referenced by method, on the stack.
+        /// </summary>
         public static readonly CilOpCode Ldftn = new CilOpCode(
             (((ushort) CilCode.Ldftn & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldftn >> 15) << TwoBytesOffset)
@@ -1878,6 +2472,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineMethod << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// 	Push address of virtual method on the stack.
+        /// </summary>
         public static readonly CilOpCode Ldvirtftn = new CilOpCode(
             (((ushort) CilCode.Ldvirtftn & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldvirtftn >> 15) << TwoBytesOffset)
@@ -1887,6 +2484,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineMethod << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load argument onto the stack.
+        /// </summary>
         public static readonly CilOpCode Ldarg = new CilOpCode(
             (((ushort) CilCode.Ldarg & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldarg >> 15) << TwoBytesOffset)
@@ -1896,6 +2496,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineArgument << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Fetch the address of the argument indexed.
+        /// </summary>
         public static readonly CilOpCode Ldarga = new CilOpCode(
             (((ushort) CilCode.Ldarga & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldarga >> 15) << TwoBytesOffset)
@@ -1905,6 +2508,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineArgument << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Store value to the argument.
+        /// </summary>
         public static readonly CilOpCode Starg = new CilOpCode(
             (((ushort) CilCode.Starg & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Starg >> 15) << TwoBytesOffset)
@@ -1914,6 +2520,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineArgument << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load local variable of index onto stack.
+        /// </summary>
         public static readonly CilOpCode Ldloc = new CilOpCode(
             (((ushort) CilCode.Ldloc & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldloc >> 15) << TwoBytesOffset)
@@ -1923,6 +2532,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineVar << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Load address of local variable with index index.
+        /// </summary>
         public static readonly CilOpCode Ldloca = new CilOpCode(
             (((ushort) CilCode.Ldloca & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldloca >> 15) << TwoBytesOffset)
@@ -1932,6 +2544,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineVar << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Pop a value from stack into local variable index.
+        /// </summary>
         public static readonly CilOpCode Stloc = new CilOpCode(
             (((ushort) CilCode.Stloc & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stloc >> 15) << TwoBytesOffset)
@@ -1941,6 +2556,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineVar << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Allocate space from the local memory pool.
+        /// </summary>
         public static readonly CilOpCode Localloc = new CilOpCode(
             (((ushort) CilCode.Localloc & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Localloc >> 15) << TwoBytesOffset)
@@ -1950,6 +2568,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// End an exception handling filter clause.
+        /// </summary>
         public static readonly CilOpCode Endfilter = new CilOpCode(
             (((ushort) CilCode.Endfilter & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Endfilter >> 15) << TwoBytesOffset)
@@ -1959,6 +2580,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Return << FlowControlOffset));
 
+        /// <summary>
+        /// Subsequent pointer instruction might be unaligned.
+        /// </summary>
         public static readonly CilOpCode Unaligned = new CilOpCode(
             (((ushort) CilCode.Unaligned & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Unaligned >> 15) << TwoBytesOffset)
@@ -1968,6 +2592,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) ShortInlineI << OperandTypeOffset)
             | ((byte) Meta << FlowControlOffset));
 
+        /// <summary>
+        /// Subsequent pointer reference is volatile.
+        /// </summary>
         public static readonly CilOpCode Volatile = new CilOpCode(
             (((ushort) CilCode.Volatile & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Volatile >> 15) << TwoBytesOffset)
@@ -1977,6 +2604,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Meta << FlowControlOffset));
 
+        /// <summary>
+        /// Subsequent call terminates current method.
+        /// </summary>
         public static readonly CilOpCode Tailcall = new CilOpCode(
             (((ushort) CilCode.Tailcall & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Tailcall >> 15) << TwoBytesOffset)
@@ -1986,6 +2616,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Meta << FlowControlOffset));
 
+        /// <summary>
+        /// Initialize the value at address dest.
+        /// </summary>
         public static readonly CilOpCode Initobj = new CilOpCode(
             (((ushort) CilCode.Initobj & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Initobj >> 15) << TwoBytesOffset)
@@ -1995,6 +2628,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineType << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Call a virtual method on a type constrained to be type T.
+        /// </summary>
         public static readonly CilOpCode Constrained = new CilOpCode(
             (((ushort) CilCode.Constrained & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Constrained >> 15) << TwoBytesOffset)
@@ -2004,6 +2640,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineType << OperandTypeOffset)
             | ((byte) Meta << FlowControlOffset));
 
+        /// <summary>
+        /// Copy data from memory to memory.
+        /// </summary>
         public static readonly CilOpCode Cpblk = new CilOpCode(
             (((ushort) CilCode.Cpblk & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Cpblk >> 15) << TwoBytesOffset)
@@ -2013,6 +2652,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Set all bytes in a block of memory to a given byte value.
+        /// </summary>
         public static readonly CilOpCode Initblk = new CilOpCode(
             (((ushort) CilCode.Initblk & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Initblk >> 15) << TwoBytesOffset)
@@ -2022,6 +2664,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Rethrow the current exception.
+        /// </summary>
         public static readonly CilOpCode Rethrow = new CilOpCode(
             (((ushort) CilCode.Rethrow & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Rethrow >> 15) << TwoBytesOffset)
@@ -2031,6 +2676,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) CilFlowControl.Throw << FlowControlOffset));
 
+        /// <summary>
+        /// Push the size, in bytes, of a type as an unsigned int32.
+        /// </summary>
         public static readonly CilOpCode Sizeof = new CilOpCode(
             (((ushort) CilCode.Sizeof & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Sizeof >> 15) << TwoBytesOffset)
@@ -2040,6 +2688,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineType << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Push the type token stored in a typed reference.
+        /// </summary>
         public static readonly CilOpCode Refanytype = new CilOpCode(
             (((ushort) CilCode.Refanytype & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Refanytype >> 15) << TwoBytesOffset)
@@ -2049,6 +2700,9 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// Specify that the subsequent array address operation performs no type check at runtime, and that it returns a controlled-mutability managed pointer.
+        /// </summary>
         public static readonly CilOpCode Readonly = new CilOpCode(
             (((ushort) CilCode.Readonly & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Readonly >> 15) << TwoBytesOffset)

--- a/src/AsmResolver.PE/DotNet/Cil/CilOpCodes.cs
+++ b/src/AsmResolver.PE/DotNet/Cil/CilOpCodes.cs
@@ -4,14 +4,14 @@ using static AsmResolver.PE.DotNet.Cil.CilOpCodeType;
 using static AsmResolver.PE.DotNet.Cil.CilOperandType;
 using static AsmResolver.PE.DotNet.Cil.CilFlowControl;
 
-// Disable missing XML doc warnings.
-#pragma warning disable 1591
-
 namespace AsmResolver.PE.DotNet.Cil
 {
     /// <summary>
     /// Provides members defining the entire CIL instruction set.
     /// </summary>
+    /// <remarks>
+    /// See also: <seealso href="https://www.ecma-international.org/wp-content/uploads/ECMA-335_6th_edition_june_2012.pdf"/>
+    /// </remarks>
     public static class CilOpCodes
     {
         /// <summary>
@@ -27,6 +27,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Do nothing (No operation).
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.nop?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Nop = new CilOpCode(
             (((ushort) CilCode.Nop & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Nop >> 15) << TwoBytesOffset)
@@ -39,6 +42,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Inform a debugger that a breakpoint has been reached.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.break?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Break = new CilOpCode(
             (((ushort) CilCode.Break & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Break >> 15) << TwoBytesOffset)
@@ -51,6 +57,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load argument 0 onto the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldarg_0?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldarg_0 = new CilOpCode(
             (((ushort) CilCode.Ldarg_0 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldarg_0 >> 15) << TwoBytesOffset)
@@ -63,6 +72,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load argument 1 onto the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldarg_1?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldarg_1 = new CilOpCode(
             (((ushort) CilCode.Ldarg_1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldarg_1 >> 15) << TwoBytesOffset)
@@ -75,6 +87,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load argument 2 onto the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldarg_2?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldarg_2 = new CilOpCode(
             (((ushort) CilCode.Ldarg_2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldarg_2 >> 15) << TwoBytesOffset)
@@ -87,6 +102,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load argument 3 onto the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldarg_3?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldarg_3 = new CilOpCode(
             (((ushort) CilCode.Ldarg_3 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldarg_3 >> 15) << TwoBytesOffset)
@@ -99,6 +117,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load local variable 0 onto stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldloc_0?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldloc_0 = new CilOpCode(
             (((ushort) CilCode.Ldloc_0 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldloc_0 >> 15) << TwoBytesOffset)
@@ -111,6 +132,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load local variable 1 onto stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldloc_1?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldloc_1 = new CilOpCode(
             (((ushort) CilCode.Ldloc_1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldloc_1 >> 15) << TwoBytesOffset)
@@ -123,6 +147,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load local variable 2 onto stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldloc_2?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldloc_2 = new CilOpCode(
             (((ushort) CilCode.Ldloc_2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldloc_2 >> 15) << TwoBytesOffset)
@@ -135,6 +162,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load local variable 3 onto stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldloc_3?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldloc_3 = new CilOpCode(
             (((ushort) CilCode.Ldloc_3 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldloc_3 >> 15) << TwoBytesOffset)
@@ -147,6 +177,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Pop a value from stack into local variable 0.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stloc_0?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stloc_0 = new CilOpCode(
             (((ushort) CilCode.Stloc_0 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stloc_0 >> 15) << TwoBytesOffset)
@@ -159,6 +192,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Pop a value from stack into local variable 1.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stloc_1?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stloc_1 = new CilOpCode(
             (((ushort) CilCode.Stloc_1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stloc_1 >> 15) << TwoBytesOffset)
@@ -171,6 +207,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Pop a value from stack into local variable 2.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stloc_2?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stloc_2 = new CilOpCode(
             (((ushort) CilCode.Stloc_2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stloc_2 >> 15) << TwoBytesOffset)
@@ -183,6 +222,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Pop a value from stack into local variable 3.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stloc_3?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stloc_3 = new CilOpCode(
             (((ushort) CilCode.Stloc_3 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stloc_3 >> 15) << TwoBytesOffset)
@@ -195,6 +237,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load argument onto the stack, short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldarg_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldarg_S = new CilOpCode(
             (((ushort) CilCode.Ldarg_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldarg_S >> 15) << TwoBytesOffset)
@@ -207,6 +252,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Fetch the address of argument, short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldarga_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldarga_S = new CilOpCode(
             (((ushort) CilCode.Ldarga_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldarga_S >> 15) << TwoBytesOffset)
@@ -219,6 +267,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Store value to the argument numbered, short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.starg_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Starg_S = new CilOpCode(
             (((ushort) CilCode.Starg_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Starg_S >> 15) << TwoBytesOffset)
@@ -231,6 +282,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load local variable of index onto stack, short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldloc_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldloc_S = new CilOpCode(
             (((ushort) CilCode.Ldloc_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldloc_S >> 15) << TwoBytesOffset)
@@ -243,6 +297,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load address of local variable with index, short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldloca_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldloca_S = new CilOpCode(
             (((ushort) CilCode.Ldloca_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldloca_S >> 15) << TwoBytesOffset)
@@ -255,6 +312,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Pop a value from stack into local variable with index, short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stloc_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stloc_S = new CilOpCode(
             (((ushort) CilCode.Stloc_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stloc_S >> 15) << TwoBytesOffset)
@@ -267,6 +327,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push a null reference on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldnull?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldnull = new CilOpCode(
             (((ushort) CilCode.Ldnull & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldnull >> 15) << TwoBytesOffset)
@@ -279,6 +342,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push -1 onto the stack as int32.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_m1?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldc_I4_M1 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_M1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_M1 >> 15) << TwoBytesOffset)
@@ -291,6 +357,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push 0 onto the stack as int32.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_0?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldc_I4_0 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_0 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_0 >> 15) << TwoBytesOffset)
@@ -303,6 +372,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push 1 onto the stack as int32.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_1?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldc_I4_1 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_1 >> 15) << TwoBytesOffset)
@@ -315,6 +387,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push 2 onto the stack as int32.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_2?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldc_I4_2 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_2 >> 15) << TwoBytesOffset)
@@ -327,6 +402,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push 3 onto the stack as int32.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_3?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldc_I4_3 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_3 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_3 >> 15) << TwoBytesOffset)
@@ -339,6 +417,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push 4 onto the stack as int32.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_4?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldc_I4_4 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_4 >> 15) << TwoBytesOffset)
@@ -351,6 +432,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push 5 onto the stack as int32.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_5?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldc_I4_5 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_5 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_5 >> 15) << TwoBytesOffset)
@@ -363,6 +447,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push 6 onto the stack as int32.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_6?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldc_I4_6 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_6 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_6 >> 15) << TwoBytesOffset)
@@ -375,6 +462,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push 7 onto the stack as int32.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_7?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldc_I4_7 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_7 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_7 >> 15) << TwoBytesOffset)
@@ -387,6 +477,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push 8 onto the stack as int32.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_8?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldc_I4_8 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_8 >> 15) << TwoBytesOffset)
@@ -399,6 +492,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push num onto the stack as int32, short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldc_I4_S = new CilOpCode(
             (((ushort) CilCode.Ldc_I4_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4_S >> 15) << TwoBytesOffset)
@@ -411,6 +507,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push num of type int32 onto the stack as int32.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i4?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldc_I4 = new CilOpCode(
             (((ushort) CilCode.Ldc_I4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I4 >> 15) << TwoBytesOffset)
@@ -423,6 +522,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push num of type int64 onto the stack as int64.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_i8?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldc_I8 = new CilOpCode(
             (((ushort) CilCode.Ldc_I8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_I8 >> 15) << TwoBytesOffset)
@@ -435,6 +537,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push num of type float32 onto the stack as F.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_r4?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldc_R4 = new CilOpCode(
             (((ushort) CilCode.Ldc_R4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_R4 >> 15) << TwoBytesOffset)
@@ -447,6 +552,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push num of type float64 onto the stack as F.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldc_r8?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldc_R8 = new CilOpCode(
             (((ushort) CilCode.Ldc_R8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldc_R8 >> 15) << TwoBytesOffset)
@@ -459,6 +567,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Duplicate the value on the top of the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.dup?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Dup = new CilOpCode(
             (((ushort) CilCode.Dup & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Dup >> 15) << TwoBytesOffset)
@@ -471,6 +582,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Pop value from the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.pop?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Pop = new CilOpCode(
             (((ushort) CilCode.Pop & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Pop >> 15) << TwoBytesOffset)
@@ -483,6 +597,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Exit current method and jump to the specified method.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.jmp?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Jmp = new CilOpCode(
             (((ushort) CilCode.Jmp & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Jmp >> 15) << TwoBytesOffset)
@@ -495,6 +612,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Call method described by method.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.call?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Call = new CilOpCode(
             (((ushort) CilCode.Call & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Call >> 15) << TwoBytesOffset)
@@ -505,8 +625,11 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) CilFlowControl.Call << FlowControlOffset));
 
         /// <summary>
-        /// Call method indicated on the stack with arguments described by callsitedescr.
+        /// Call method indicated on the stack with arguments described by a calling convention.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.calli?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Calli = new CilOpCode(
             (((ushort) CilCode.Calli & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Calli >> 15) << TwoBytesOffset)
@@ -519,6 +642,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Return from method, possibly with a value.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ret?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ret = new CilOpCode(
             (((ushort) CilCode.Ret & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ret >> 15) << TwoBytesOffset)
@@ -531,6 +657,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target, short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.br_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Br_S = new CilOpCode(
             (((ushort) CilCode.Br_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Br_S >> 15) << TwoBytesOffset)
@@ -543,6 +672,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if value is zero (false), short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.brfalse_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Brfalse_S = new CilOpCode(
             (((ushort) CilCode.Brfalse_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Brfalse_S >> 15) << TwoBytesOffset)
@@ -555,6 +687,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if value is non-zero (true), short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.brtrue_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Brtrue_S = new CilOpCode(
             (((ushort) CilCode.Brtrue_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Brtrue_S >> 15) << TwoBytesOffset)
@@ -567,6 +702,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if equal, short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.beq_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Beq_S = new CilOpCode(
             (((ushort) CilCode.Beq_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Beq_S >> 15) << TwoBytesOffset)
@@ -579,6 +717,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if greater than or equal to, short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.bge_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Bge_S = new CilOpCode(
             (((ushort) CilCode.Bge_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Bge_S >> 15) << TwoBytesOffset)
@@ -591,6 +732,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if greater than, short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.bgt_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Bgt_S = new CilOpCode(
             (((ushort) CilCode.Bgt_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Bgt_S >> 15) << TwoBytesOffset)
@@ -603,6 +747,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if less than or equal to, short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ble_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ble_S = new CilOpCode(
             (((ushort) CilCode.Ble_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ble_S >> 15) << TwoBytesOffset)
@@ -615,6 +762,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if less than, short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.blt_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Blt_S = new CilOpCode(
             (((ushort) CilCode.Blt_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Blt_S >> 15) << TwoBytesOffset)
@@ -627,6 +777,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if unequal or unordered, short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.bne_un_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Bne_Un_S = new CilOpCode(
             (((ushort) CilCode.Bne_Un_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Bne_Un_S >> 15) << TwoBytesOffset)
@@ -639,6 +792,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if greater than or equal to (unsigned or unordered), short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.bge_un_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Bge_Un_S = new CilOpCode(
             (((ushort) CilCode.Bge_Un_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Bge_Un_S >> 15) << TwoBytesOffset)
@@ -651,6 +807,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if greater than (unsigned or unordered), short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.bgt_un_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Bgt_Un_S = new CilOpCode(
             (((ushort) CilCode.Bgt_Un_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Bgt_Un_S >> 15) << TwoBytesOffset)
@@ -663,6 +822,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if less than or equal to (unsigned or unordered), short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ble_un_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ble_Un_S = new CilOpCode(
             (((ushort) CilCode.Ble_Un_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ble_Un_S >> 15) << TwoBytesOffset)
@@ -675,6 +837,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if less than (unsigned or unordered), short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.blt_un_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Blt_Un_S = new CilOpCode(
             (((ushort) CilCode.Blt_Un_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Blt_Un_S >> 15) << TwoBytesOffset)
@@ -687,6 +852,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.br?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Br = new CilOpCode(
             (((ushort) CilCode.Br & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Br >> 15) << TwoBytesOffset)
@@ -699,6 +867,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if value is zero (false).
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.brfalse?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Brfalse = new CilOpCode(
             (((ushort) CilCode.Brfalse & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Brfalse >> 15) << TwoBytesOffset)
@@ -711,6 +882,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if value is non-zero (true).
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.brtrue?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Brtrue = new CilOpCode(
             (((ushort) CilCode.Brtrue & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Brtrue >> 15) << TwoBytesOffset)
@@ -723,6 +897,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if equal.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.beq?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Beq = new CilOpCode(
             (((ushort) CilCode.Beq & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Beq >> 15) << TwoBytesOffset)
@@ -735,6 +912,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if greater than or equal to.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.bge?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Bge = new CilOpCode(
             (((ushort) CilCode.Bge & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Bge >> 15) << TwoBytesOffset)
@@ -747,6 +927,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if greater than.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.bgt?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Bgt = new CilOpCode(
             (((ushort) CilCode.Bgt & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Bgt >> 15) << TwoBytesOffset)
@@ -759,6 +942,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if less than or equal to.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ble?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ble = new CilOpCode(
             (((ushort) CilCode.Ble & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ble >> 15) << TwoBytesOffset)
@@ -771,6 +957,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if less than.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.blt?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Blt = new CilOpCode(
             (((ushort) CilCode.Blt & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Blt >> 15) << TwoBytesOffset)
@@ -783,6 +972,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if unequal or unordered.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.bne_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Bne_Un = new CilOpCode(
             (((ushort) CilCode.Bne_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Bne_Un >> 15) << TwoBytesOffset)
@@ -795,6 +987,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if greater than or equal to (unsigned or unordered).
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.bge_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Bge_Un = new CilOpCode(
             (((ushort) CilCode.Bge_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Bge_Un >> 15) << TwoBytesOffset)
@@ -807,6 +1002,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if greater than (unsigned or unordered).
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.bgt_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Bgt_Un = new CilOpCode(
             (((ushort) CilCode.Bgt_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Bgt_Un >> 15) << TwoBytesOffset)
@@ -819,6 +1017,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if less than or equal to (unsigned or unordered).
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ble_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ble_Un = new CilOpCode(
             (((ushort) CilCode.Ble_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ble_Un >> 15) << TwoBytesOffset)
@@ -831,6 +1032,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Branch to target if less than (unsigned or unordered).
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.blt_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Blt_Un = new CilOpCode(
             (((ushort) CilCode.Blt_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Blt_Un >> 15) << TwoBytesOffset)
@@ -843,6 +1047,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Jump to one of n values.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.switch?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Switch = new CilOpCode(
             (((ushort) CilCode.Switch & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Switch >> 15) << TwoBytesOffset)
@@ -855,6 +1062,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Indirect load value of type int8 as int32 on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_i1?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldind_I1 = new CilOpCode(
             (((ushort) CilCode.Ldind_I1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_I1 >> 15) << TwoBytesOffset)
@@ -867,6 +1077,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Indirect load value of type unsigned int8 as int32 on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_u1?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldind_U1 = new CilOpCode(
             (((ushort) CilCode.Ldind_U1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_U1 >> 15) << TwoBytesOffset)
@@ -879,6 +1092,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Indirect load value of type int16 as int32 on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_i2?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldind_I2 = new CilOpCode(
             (((ushort) CilCode.Ldind_I2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_I2 >> 15) << TwoBytesOffset)
@@ -891,6 +1107,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Indirect load value of type unsigned int16 as int32 on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_u2?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldind_U2 = new CilOpCode(
             (((ushort) CilCode.Ldind_U2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_U2 >> 15) << TwoBytesOffset)
@@ -903,6 +1122,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Indirect load value of type int32 as int32 on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_i4?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldind_I4 = new CilOpCode(
             (((ushort) CilCode.Ldind_I4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_I4 >> 15) << TwoBytesOffset)
@@ -915,6 +1137,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Indirect load value of type unsigned int32 as int32 on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_u4?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldind_U4 = new CilOpCode(
             (((ushort) CilCode.Ldind_U4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_U4 >> 15) << TwoBytesOffset)
@@ -925,8 +1150,11 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) Next << FlowControlOffset));
 
         /// <summary>
-        /// Indirect load value of type int64 as int64 on the stack.
+        /// Indirect load value of type signed or unsigned int64 as signed int64 on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_i8?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldind_I8 = new CilOpCode(
             (((ushort) CilCode.Ldind_I8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_I8 >> 15) << TwoBytesOffset)
@@ -939,6 +1167,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Indirect load value of type native int as native int on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_i?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldind_I = new CilOpCode(
             (((ushort) CilCode.Ldind_I & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_I >> 15) << TwoBytesOffset)
@@ -951,6 +1182,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Indirect load value of type float32 as F on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_r4?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldind_R4 = new CilOpCode(
             (((ushort) CilCode.Ldind_R4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_R4 >> 15) << TwoBytesOffset)
@@ -963,6 +1197,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Indirect load value of type float64 as F on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_r8?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldind_R8 = new CilOpCode(
             (((ushort) CilCode.Ldind_R8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_R8 >> 15) << TwoBytesOffset)
@@ -975,6 +1212,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Indirect load value of type object ref as O on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldind_ref?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldind_Ref = new CilOpCode(
             (((ushort) CilCode.Ldind_Ref & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldind_Ref >> 15) << TwoBytesOffset)
@@ -987,6 +1227,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Store value of type object ref (type O) into memory at address.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stind_ref?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stind_Ref = new CilOpCode(
             (((ushort) CilCode.Stind_Ref & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stind_Ref >> 15) << TwoBytesOffset)
@@ -999,6 +1242,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Store value of type int8 into memory at address.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stind_i1?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stind_I1 = new CilOpCode(
             (((ushort) CilCode.Stind_I1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stind_I1 >> 15) << TwoBytesOffset)
@@ -1011,6 +1257,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Store value of type int16 into memory at address.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stind_i2?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stind_I2 = new CilOpCode(
             (((ushort) CilCode.Stind_I2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stind_I2 >> 15) << TwoBytesOffset)
@@ -1023,6 +1272,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Store value of type int32 into memory at address.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stind_i4?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stind_I4 = new CilOpCode(
             (((ushort) CilCode.Stind_I4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stind_I4 >> 15) << TwoBytesOffset)
@@ -1035,6 +1287,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Store value of type int64 into memory at address.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stind_i8?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stind_I8 = new CilOpCode(
             (((ushort) CilCode.Stind_I8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stind_I8 >> 15) << TwoBytesOffset)
@@ -1047,6 +1302,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Store value of type float32 into memory at address.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stind_r4?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stind_R4 = new CilOpCode(
             (((ushort) CilCode.Stind_R4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stind_R4 >> 15) << TwoBytesOffset)
@@ -1059,6 +1317,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Store value of type float64 into memory at address.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stind_r8?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stind_R8 = new CilOpCode(
             (((ushort) CilCode.Stind_R8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stind_R8 >> 15) << TwoBytesOffset)
@@ -1071,6 +1332,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Add two values, returning a new value.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.add?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Add = new CilOpCode(
             (((ushort) CilCode.Add & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Add >> 15) << TwoBytesOffset)
@@ -1083,6 +1347,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Subtract value2 from value1, returning a new value.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.sub?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Sub = new CilOpCode(
             (((ushort) CilCode.Sub & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Sub >> 15) << TwoBytesOffset)
@@ -1095,6 +1362,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Multiply values.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.mul?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Mul = new CilOpCode(
             (((ushort) CilCode.Mul & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Mul >> 15) << TwoBytesOffset)
@@ -1107,6 +1377,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Divide two values to return a quotient or floating-point result.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.div?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Div = new CilOpCode(
             (((ushort) CilCode.Div & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Div >> 15) << TwoBytesOffset)
@@ -1119,6 +1392,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Divide two values, unsigned, returning a quotient.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.div_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Div_Un = new CilOpCode(
             (((ushort) CilCode.Div_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Div_Un >> 15) << TwoBytesOffset)
@@ -1131,6 +1407,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Remainder when dividing one value by another.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.rem?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Rem = new CilOpCode(
             (((ushort) CilCode.Rem & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Rem >> 15) << TwoBytesOffset)
@@ -1143,6 +1422,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Remainder when dividing one unsigned value by another.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.rem_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Rem_Un = new CilOpCode(
             (((ushort) CilCode.Rem_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Rem_Un >> 15) << TwoBytesOffset)
@@ -1155,6 +1437,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Bitwise AND of two integral values, returns an integral value.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.and?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode And = new CilOpCode(
             (((ushort) CilCode.And & 0xFF) << ValueOffset)
             | (((ushort) CilCode.And >> 15) << TwoBytesOffset)
@@ -1167,6 +1452,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Bitwise OR of two integer values, returns an integer.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.or?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Or = new CilOpCode(
             (((ushort) CilCode.Or & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Or >> 15) << TwoBytesOffset)
@@ -1179,6 +1467,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Bitwise XOR of integer values, returns an integer.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.xor?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Xor = new CilOpCode(
             (((ushort) CilCode.Xor & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Xor >> 15) << TwoBytesOffset)
@@ -1191,6 +1482,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Shift an integer left (shifting in zeros), return an integer.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.shl?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Shl = new CilOpCode(
             (((ushort) CilCode.Shl & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Shl >> 15) << TwoBytesOffset)
@@ -1203,6 +1497,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Shift an integer right (shift in sign), return an integer.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.shr?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Shr = new CilOpCode(
             (((ushort) CilCode.Shr & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Shr >> 15) << TwoBytesOffset)
@@ -1215,6 +1512,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Shift an integer right (shift in zero), return an integer.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.shr_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Shr_Un = new CilOpCode(
             (((ushort) CilCode.Shr_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Shr_Un >> 15) << TwoBytesOffset)
@@ -1227,6 +1527,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Negate value.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.neg?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Neg = new CilOpCode(
             (((ushort) CilCode.Neg & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Neg >> 15) << TwoBytesOffset)
@@ -1239,6 +1542,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Bitwise complement (logical not).
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.not?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Not = new CilOpCode(
             (((ushort) CilCode.Not & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Not >> 15) << TwoBytesOffset)
@@ -1251,6 +1557,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to int8, pushing int32 on stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_i1?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_I1 = new CilOpCode(
             (((ushort) CilCode.Conv_I1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_I1 >> 15) << TwoBytesOffset)
@@ -1263,6 +1572,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to int16, pushing int32 on stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_i2?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_I2 = new CilOpCode(
             (((ushort) CilCode.Conv_I2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_I2 >> 15) << TwoBytesOffset)
@@ -1275,6 +1587,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to int32, pushing int32 on stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_i4?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_I4 = new CilOpCode(
             (((ushort) CilCode.Conv_I4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_I4 >> 15) << TwoBytesOffset)
@@ -1287,6 +1602,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to int64, pushing int64 on stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_i8?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_I8 = new CilOpCode(
             (((ushort) CilCode.Conv_I8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_I8 >> 15) << TwoBytesOffset)
@@ -1299,6 +1617,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to float32, pushing F on stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_r4?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_R4 = new CilOpCode(
             (((ushort) CilCode.Conv_R4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_R4 >> 15) << TwoBytesOffset)
@@ -1311,6 +1632,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to float64, pushing F on stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_r8?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_R8 = new CilOpCode(
             (((ushort) CilCode.Conv_R8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_R8 >> 15) << TwoBytesOffset)
@@ -1323,6 +1647,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to unsigned int32, pushing int32 on stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_u4?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_U4 = new CilOpCode(
             (((ushort) CilCode.Conv_U4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_U4 >> 15) << TwoBytesOffset)
@@ -1335,6 +1662,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to unsigned int64, pushing int64 on stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_u8?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_U8 = new CilOpCode(
             (((ushort) CilCode.Conv_U8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_U8 >> 15) << TwoBytesOffset)
@@ -1347,6 +1677,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Call a method associated with an object.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.callvirt?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Callvirt = new CilOpCode(
             (((ushort) CilCode.Callvirt & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Callvirt >> 15) << TwoBytesOffset)
@@ -1359,6 +1692,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Copy a value type from src to dest.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.cpobj?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Cpobj = new CilOpCode(
             (((ushort) CilCode.Cpobj & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Cpobj >> 15) << TwoBytesOffset)
@@ -1371,6 +1707,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Copy the value stored at address src to the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldobj?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldobj = new CilOpCode(
             (((ushort) CilCode.Ldobj & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldobj >> 15) << TwoBytesOffset)
@@ -1383,6 +1722,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push a string object for the literal string.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldstr?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldstr = new CilOpCode(
             (((ushort) CilCode.Ldstr & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldstr >> 15) << TwoBytesOffset)
@@ -1395,6 +1737,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Allocate an uninitialized object or value type and call ctor.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.newobj?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Newobj = new CilOpCode(
             (((ushort) CilCode.Newobj & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Newobj >> 15) << TwoBytesOffset)
@@ -1407,6 +1752,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Cast obj to class.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.castclass?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Castclass = new CilOpCode(
             (((ushort) CilCode.Castclass & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Castclass >> 15) << TwoBytesOffset)
@@ -1419,6 +1767,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Test if obj is an instance of class, returning null or an instance of that class or interface.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.isinst?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Isinst = new CilOpCode(
             (((ushort) CilCode.Isinst & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Isinst >> 15) << TwoBytesOffset)
@@ -1431,6 +1782,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert unsigned integer to floating-point, pushing F on stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_r_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_R_Un = new CilOpCode(
             (((ushort) CilCode.Conv_R_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_R_Un >> 15) << TwoBytesOffset)
@@ -1443,6 +1797,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Extract a value-type from obj, its boxed representation, and push a controlled-mutability managed pointer to it to the top of the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.unbox?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Unbox = new CilOpCode(
             (((ushort) CilCode.Unbox & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Unbox >> 15) << TwoBytesOffset)
@@ -1455,6 +1812,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Throw an exception.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.throw?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Throw = new CilOpCode(
             (((ushort) CilCode.Throw & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Throw >> 15) << TwoBytesOffset)
@@ -1467,6 +1827,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push the value of field of object (or value type) obj, onto the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldfld?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldfld = new CilOpCode(
             (((ushort) CilCode.Ldfld & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldfld >> 15) << TwoBytesOffset)
@@ -1479,6 +1842,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push the address of field of object obj on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldflda?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldflda = new CilOpCode(
             (((ushort) CilCode.Ldflda & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldflda >> 15) << TwoBytesOffset)
@@ -1491,6 +1857,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Replace the value of field of the object obj with value.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stfld?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stfld = new CilOpCode(
             (((ushort) CilCode.Stfld & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stfld >> 15) << TwoBytesOffset)
@@ -1503,6 +1872,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push the value of the static field on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldsfld?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldsfld = new CilOpCode(
             (((ushort) CilCode.Ldsfld & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldsfld >> 15) << TwoBytesOffset)
@@ -1515,6 +1887,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push the address of the static field, field, on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldsflda?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldsflda = new CilOpCode(
             (((ushort) CilCode.Ldsflda & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldsflda >> 15) << TwoBytesOffset)
@@ -1527,6 +1902,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Replace the value of the static field.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stsfld?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stsfld = new CilOpCode(
             (((ushort) CilCode.Stsfld & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stsfld >> 15) << TwoBytesOffset)
@@ -1539,6 +1917,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Store a value at an address.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stobj?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stobj = new CilOpCode(
             (((ushort) CilCode.Stobj & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stobj >> 15) << TwoBytesOffset)
@@ -1551,6 +1932,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert unsigned to an int8 (on the stack as int32) and throw an exception on overflow.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_i1_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_Ovf_I1_Un = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_I1_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_I1_Un >> 15) << TwoBytesOffset)
@@ -1563,6 +1947,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert unsigned to an int16 (on the stack as int32) and throw an exception on overflow.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_i2_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_Ovf_I2_Un = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_I2_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_I2_Un >> 15) << TwoBytesOffset)
@@ -1575,6 +1962,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert unsigned to an int32 (on the stack as int32) and throw an exception on overflow.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_i4_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_Ovf_I4_Un = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_I4_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_I4_Un >> 15) << TwoBytesOffset)
@@ -1587,6 +1977,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert unsigned to an int64 (on the stack as int64) and throw an exception on overflow.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_i8_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_Ovf_I8_Un = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_I8_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_I8_Un >> 15) << TwoBytesOffset)
@@ -1599,6 +1992,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert unsigned to an unsigned int8 (on the stack as int32) and throw an exception on overflow.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_u1_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_Ovf_U1_Un = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_U1_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_U1_Un >> 15) << TwoBytesOffset)
@@ -1611,6 +2007,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert unsigned to an unsigned int16 (on the stack as int32) and throw an exception on overflow.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_u2_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_Ovf_U2_Un = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_U2_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_U2_Un >> 15) << TwoBytesOffset)
@@ -1623,6 +2022,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert unsigned to an unsigned int32 (on the stack as int32) and throw an exception on overflow.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_u4_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_Ovf_U4_Un = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_U4_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_U4_Un >> 15) << TwoBytesOffset)
@@ -1635,6 +2037,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert unsigned to an unsigned int64 (on the stack as int64) and throw an exception on overflow.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_u8_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_Ovf_U8_Un = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_U8_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_U8_Un >> 15) << TwoBytesOffset)
@@ -1647,6 +2052,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert unsigned to a native int (on the stack as native int) and throw an exception on overflow.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_i_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_Ovf_I_Un = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_I_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_I_Un >> 15) << TwoBytesOffset)
@@ -1659,6 +2067,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert unsigned to a native unsigned int (on the stack as native int) and throw an exception on overflow.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_u_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_Ovf_U_Un = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_U_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_U_Un >> 15) << TwoBytesOffset)
@@ -1671,6 +2082,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert a boxable value to its boxed form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.box?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Box = new CilOpCode(
             (((ushort) CilCode.Box & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Box >> 15) << TwoBytesOffset)
@@ -1683,6 +2097,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Create a new array with elements of type etype.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.newarr?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Newarr = new CilOpCode(
             (((ushort) CilCode.Newarr & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Newarr >> 15) << TwoBytesOffset)
@@ -1695,6 +2112,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push the length (of type native unsigned int) of array on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldlen?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldlen = new CilOpCode(
             (((ushort) CilCode.Ldlen & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldlen >> 15) << TwoBytesOffset)
@@ -1707,6 +2127,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load the address of element at index onto the top of the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelema?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldelema = new CilOpCode(
             (((ushort) CilCode.Ldelema & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelema >> 15) << TwoBytesOffset)
@@ -1719,6 +2142,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load the element with type int8 at index onto the top of the stack as an int32.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_i1?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldelem_I1 = new CilOpCode(
             (((ushort) CilCode.Ldelem_I1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_I1 >> 15) << TwoBytesOffset)
@@ -1731,6 +2157,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load the element with type unsigned int8 at index onto the top of the stack as an int32.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_u1?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldelem_U1 = new CilOpCode(
             (((ushort) CilCode.Ldelem_U1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_U1 >> 15) << TwoBytesOffset)
@@ -1743,6 +2172,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load the element with type int16 at index onto the top of the stack as an int32.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_i2?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldelem_I2 = new CilOpCode(
             (((ushort) CilCode.Ldelem_I2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_I2 >> 15) << TwoBytesOffset)
@@ -1755,6 +2187,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load the element with type unsigned int16 at index onto the top of the stack as an int32.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_u2?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldelem_U2 = new CilOpCode(
             (((ushort) CilCode.Ldelem_U2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_U2 >> 15) << TwoBytesOffset)
@@ -1767,6 +2202,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load the element with type int32 at index onto the top of the stack as an int32.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_i4?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldelem_I4 = new CilOpCode(
             (((ushort) CilCode.Ldelem_I4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_I4 >> 15) << TwoBytesOffset)
@@ -1779,6 +2217,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load the element with type unsigned int32 at index onto the top of the stack as an int32.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_u4?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldelem_U4 = new CilOpCode(
             (((ushort) CilCode.Ldelem_U4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_U4 >> 15) << TwoBytesOffset)
@@ -1789,8 +2230,11 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) Next << FlowControlOffset));
 
         /// <summary>
-        /// Load the element with type int64 at index onto the top of the stack as an int64.
+        /// Load the element with type signed or unsigned int64 at index onto the top of the stack as a signed int64.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_i8?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldelem_I8 = new CilOpCode(
             (((ushort) CilCode.Ldelem_I8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_I8 >> 15) << TwoBytesOffset)
@@ -1803,6 +2247,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load the element with type native int at index onto the top of the stack as a native int.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_i?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldelem_I = new CilOpCode(
             (((ushort) CilCode.Ldelem_I & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_I >> 15) << TwoBytesOffset)
@@ -1815,6 +2262,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load the element with type float32 at index onto the top of the stack as an F.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_r4?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldelem_R4 = new CilOpCode(
             (((ushort) CilCode.Ldelem_R4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_R4 >> 15) << TwoBytesOffset)
@@ -1827,6 +2277,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load the element with type float64 at index onto the top of the stack as an F.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_r8?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldelem_R8 = new CilOpCode(
             (((ushort) CilCode.Ldelem_R8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_R8 >> 15) << TwoBytesOffset)
@@ -1839,6 +2292,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load the element at index onto the top of the stack as an O. The type of the O is the same as the element type of the array pushed on the CIL stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem_ref?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldelem_Ref = new CilOpCode(
             (((ushort) CilCode.Ldelem_Ref & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem_Ref >> 15) << TwoBytesOffset)
@@ -1851,6 +2307,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Replace array element at index with the i value on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_i?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stelem_I = new CilOpCode(
             (((ushort) CilCode.Stelem_I & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stelem_I >> 15) << TwoBytesOffset)
@@ -1863,6 +2322,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Replace array element at index with the int8 value on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_i1?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stelem_I1 = new CilOpCode(
             (((ushort) CilCode.Stelem_I1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stelem_I1 >> 15) << TwoBytesOffset)
@@ -1875,6 +2337,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Replace array element at index with the int16 value on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_i2?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stelem_I2 = new CilOpCode(
             (((ushort) CilCode.Stelem_I2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stelem_I2 >> 15) << TwoBytesOffset)
@@ -1885,8 +2350,11 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) Next << FlowControlOffset));
 
         /// <summary>
-        /// 	Replace array element at index with the int32 value on the stack.
+        /// Replace array element at index with the int32 value on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_i4?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stelem_I4 = new CilOpCode(
             (((ushort) CilCode.Stelem_I4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stelem_I4 >> 15) << TwoBytesOffset)
@@ -1899,6 +2367,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Replace array element at index with the int64 value on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_i8?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stelem_I8 = new CilOpCode(
             (((ushort) CilCode.Stelem_I8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stelem_I8 >> 15) << TwoBytesOffset)
@@ -1911,6 +2382,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Replace array element at index with the float32 value on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_r4?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stelem_R4 = new CilOpCode(
             (((ushort) CilCode.Stelem_R4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stelem_R4 >> 15) << TwoBytesOffset)
@@ -1923,6 +2397,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Replace array element at index with the float64 value on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_r8?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stelem_R8 = new CilOpCode(
             (((ushort) CilCode.Stelem_R8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stelem_R8 >> 15) << TwoBytesOffset)
@@ -1935,6 +2412,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Replace array element at index with the ref value on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_ref?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stelem_Ref = new CilOpCode(
             (((ushort) CilCode.Stelem_Ref & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stelem_Ref >> 15) << TwoBytesOffset)
@@ -1947,6 +2427,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load the element at index onto the top of the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelem?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldelem = new CilOpCode(
             (((ushort) CilCode.Ldelem & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldelem >> 15) << TwoBytesOffset)
@@ -1959,6 +2442,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Replace array element at index with the value on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stelem = new CilOpCode(
             (((ushort) CilCode.Stelem & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stelem >> 15) << TwoBytesOffset)
@@ -1971,6 +2457,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Extract a value-type from obj, its boxed representation, and copy to the top of the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.unbox_any?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Unbox_Any = new CilOpCode(
             (((ushort) CilCode.Unbox_Any & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Unbox_Any >> 15) << TwoBytesOffset)
@@ -1983,6 +2472,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to an int8 (on the stack as int32) and throw an exception on overflow.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_i1?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_Ovf_I1 = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_I1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_I1 >> 15) << TwoBytesOffset)
@@ -1995,6 +2487,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to an unsigned int8 (on the stack as int32) and throw an exception on overflow.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_u1?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_Ovf_U1 = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_U1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_U1 >> 15) << TwoBytesOffset)
@@ -2007,6 +2502,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to an int16 (on the stack as int32) and throw an exception on overflow.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_i2?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_Ovf_I2 = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_I2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_I2 >> 15) << TwoBytesOffset)
@@ -2019,6 +2517,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to an unsigned int16 (on the stack as int32) and throw an exception on overflow.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_u2?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_Ovf_U2 = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_U2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_U2 >> 15) << TwoBytesOffset)
@@ -2031,6 +2532,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to an int32 (on the stack as int32) and throw an exception on overflow.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_i4?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_Ovf_I4 = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_I4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_I4 >> 15) << TwoBytesOffset)
@@ -2043,6 +2547,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to an unsigned int32 (on the stack as int32) and throw an exception on overflow.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_u4?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_Ovf_U4 = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_U4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_U4 >> 15) << TwoBytesOffset)
@@ -2055,6 +2562,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to an int64 (on the stack as int64) and throw an exception on overflow.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_i8?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_Ovf_I8 = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_I8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_I8 >> 15) << TwoBytesOffset)
@@ -2067,6 +2577,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to an unsigned int64 (on the stack as int64) and throw an exception on overflow.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_u8?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_Ovf_U8 = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_U8 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_U8 >> 15) << TwoBytesOffset)
@@ -2079,6 +2592,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push the address stored in a typed reference.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.refanyval?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Refanyval = new CilOpCode(
             (((ushort) CilCode.Refanyval & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Refanyval >> 15) << TwoBytesOffset)
@@ -2091,6 +2607,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Throw ArithmeticException if value is not a finite number.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ckfinite?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ckfinite = new CilOpCode(
             (((ushort) CilCode.Ckfinite & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ckfinite >> 15) << TwoBytesOffset)
@@ -2103,6 +2622,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push a typed reference to ptr of type class onto the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.mkrefany?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Mkrefany = new CilOpCode(
             (((ushort) CilCode.Mkrefany & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Mkrefany >> 15) << TwoBytesOffset)
@@ -2115,6 +2637,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert metadata token to its runtime representation.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldtoken?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldtoken = new CilOpCode(
             (((ushort) CilCode.Ldtoken & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldtoken >> 15) << TwoBytesOffset)
@@ -2127,6 +2652,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to unsigned int16, pushing int32 on stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_u2?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_U2 = new CilOpCode(
             (((ushort) CilCode.Conv_U2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_U2 >> 15) << TwoBytesOffset)
@@ -2139,6 +2667,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to unsigned int8, pushing int32 on stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_u1?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_U1 = new CilOpCode(
             (((ushort) CilCode.Conv_U1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_U1 >> 15) << TwoBytesOffset)
@@ -2151,6 +2682,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to native int, pushing native int on stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_i?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_I = new CilOpCode(
             (((ushort) CilCode.Conv_I & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_I >> 15) << TwoBytesOffset)
@@ -2163,6 +2697,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to a native int (on the stack as native int) and throw an exception on overflow.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_i?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_Ovf_I = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_I & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_I >> 15) << TwoBytesOffset)
@@ -2175,6 +2712,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to a native unsigned int (on the stack as native int) and throw an exception on overflow.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_ovf_u?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_Ovf_U = new CilOpCode(
             (((ushort) CilCode.Conv_Ovf_U & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_Ovf_U >> 15) << TwoBytesOffset)
@@ -2187,6 +2727,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Add signed integer values with overflow check.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.add_ovf?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Add_Ovf = new CilOpCode(
             (((ushort) CilCode.Add_Ovf & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Add_Ovf >> 15) << TwoBytesOffset)
@@ -2199,6 +2742,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Add unsigned integer values with overflow check.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.add_ovf_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Add_Ovf_Un = new CilOpCode(
             (((ushort) CilCode.Add_Ovf_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Add_Ovf_Un >> 15) << TwoBytesOffset)
@@ -2211,6 +2757,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Multiply signed integer values. Signed result shall fit in same size.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.mul_ovf?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Mul_Ovf = new CilOpCode(
             (((ushort) CilCode.Mul_Ovf & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Mul_Ovf >> 15) << TwoBytesOffset)
@@ -2223,6 +2772,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Multiply unsigned integer values. Unsigned result shall fit in same size.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.mul_ovf_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Mul_Ovf_Un = new CilOpCode(
             (((ushort) CilCode.Mul_Ovf_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Mul_Ovf_Un >> 15) << TwoBytesOffset)
@@ -2235,6 +2787,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Subtract native int from a native int. Signed result shall fit in same size.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.sub_ovf?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Sub_Ovf = new CilOpCode(
             (((ushort) CilCode.Sub_Ovf & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Sub_Ovf >> 15) << TwoBytesOffset)
@@ -2247,6 +2802,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Subtract native unsigned int from a native unsigned int. Unsigned result shall fit in same size.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.sub_ovf_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Sub_Ovf_Un = new CilOpCode(
             (((ushort) CilCode.Sub_Ovf_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Sub_Ovf_Un >> 15) << TwoBytesOffset)
@@ -2259,6 +2817,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// End finally clause of an exception block.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.endfinally?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Endfinally = new CilOpCode(
             (((ushort) CilCode.Endfinally & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Endfinally >> 15) << TwoBytesOffset)
@@ -2271,6 +2832,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Exit a protected region of code.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.leave?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Leave = new CilOpCode(
             (((ushort) CilCode.Leave & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Leave >> 15) << TwoBytesOffset)
@@ -2283,6 +2847,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Exit a protected region of code, short form.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.leave_s?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Leave_S = new CilOpCode(
             (((ushort) CilCode.Leave_S & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Leave_S >> 15) << TwoBytesOffset)
@@ -2295,6 +2862,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Store value of type native int into memory at address.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stind_i?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stind_I = new CilOpCode(
             (((ushort) CilCode.Stind_I & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stind_I >> 15) << TwoBytesOffset)
@@ -2307,6 +2877,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Convert to native unsigned int, pushing native int on stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_u?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Conv_U = new CilOpCode(
             (((ushort) CilCode.Conv_U & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Conv_U >> 15) << TwoBytesOffset)
@@ -2316,6 +2889,12 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Next << FlowControlOffset));
 
+        /// <summary>
+        /// This prefix opcode is reserved and currently not implemented in the runtime 
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.prefix7?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Prefix7 = new CilOpCode(
             (((ushort) CilCode.Prefix7 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Prefix7 >> 15) << TwoBytesOffset)
@@ -2325,6 +2904,12 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Meta << FlowControlOffset));
 
+        /// <summary>
+        /// This prefix opcode is reserved and currently not implemented in the runtime 
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.prefix6?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Prefix6 = new CilOpCode(
             (((ushort) CilCode.Prefix6 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Prefix6 >> 15) << TwoBytesOffset)
@@ -2334,6 +2919,12 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Meta << FlowControlOffset));
 
+        /// <summary>
+        /// This prefix opcode is reserved and currently not implemented in the runtime 
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.prefix5?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Prefix5 = new CilOpCode(
             (((ushort) CilCode.Prefix5 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Prefix5 >> 15) << TwoBytesOffset)
@@ -2343,6 +2934,12 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Meta << FlowControlOffset));
 
+        /// <summary>
+        /// This prefix opcode is reserved and currently not implemented in the runtime 
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.prefix4?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Prefix4 = new CilOpCode(
             (((ushort) CilCode.Prefix4 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Prefix4 >> 15) << TwoBytesOffset)
@@ -2352,6 +2949,12 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Meta << FlowControlOffset));
 
+        /// <summary>
+        /// This prefix opcode is reserved and currently not implemented in the runtime 
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.prefix3?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Prefix3 = new CilOpCode(
             (((ushort) CilCode.Prefix3 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Prefix3 >> 15) << TwoBytesOffset)
@@ -2361,6 +2964,12 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Meta << FlowControlOffset));
 
+        /// <summary>
+        /// This prefix opcode is reserved and currently not implemented in the runtime 
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.prefix2?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Prefix2 = new CilOpCode(
             (((ushort) CilCode.Prefix2 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Prefix2 >> 15) << TwoBytesOffset)
@@ -2370,6 +2979,12 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Meta << FlowControlOffset));
 
+        /// <summary>
+        /// This prefix opcode is reserved and currently not implemented in the runtime 
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.prefix1?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Prefix1 = new CilOpCode(
             (((ushort) CilCode.Prefix1 & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Prefix1 >> 15) << TwoBytesOffset)
@@ -2379,6 +2994,12 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) InlineNone << OperandTypeOffset)
             | ((byte) Meta << FlowControlOffset));
 
+        /// <summary>
+        /// This prefix opcode is reserved and currently not implemented in the runtime 
+        /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.prefixref?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Prefixref = new CilOpCode(
             (((ushort) CilCode.Prefixref & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Prefixref >> 15) << TwoBytesOffset)
@@ -2391,6 +3012,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Return argument list handle for the current method.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.arglist?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Arglist = new CilOpCode(
             (((ushort) CilCode.Arglist & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Arglist >> 15) << TwoBytesOffset)
@@ -2403,6 +3027,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push 1 (of type int32) if value1 equals value2, else push 0.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ceq?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ceq = new CilOpCode(
             (((ushort) CilCode.Ceq & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ceq >> 15) << TwoBytesOffset)
@@ -2415,6 +3042,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push 1 (of type int32) if value1 greater that value2, else push 0.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.cgt?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Cgt = new CilOpCode(
             (((ushort) CilCode.Cgt & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Cgt >> 15) << TwoBytesOffset)
@@ -2427,6 +3057,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push 1 (of type int32) if value1 greater that value2, unsigned or unordered, else push 0.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.cgt_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Cgt_Un = new CilOpCode(
             (((ushort) CilCode.Cgt_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Cgt_Un >> 15) << TwoBytesOffset)
@@ -2439,6 +3072,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push 1 (of type int32) if value1 lower than value2, else push 0.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.clt?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Clt = new CilOpCode(
             (((ushort) CilCode.Clt & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Clt >> 15) << TwoBytesOffset)
@@ -2449,8 +3085,11 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) Next << FlowControlOffset));
 
         /// <summary>
-        /// 	Push 1 (of type int32) if value1 lower than value2, unsigned or unordered, else push 0.
+        /// Push 1 (of type int32) if value1 lower than value2, unsigned or unordered, else push 0.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.clt_un?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Clt_Un = new CilOpCode(
             (((ushort) CilCode.Clt_Un & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Clt_Un >> 15) << TwoBytesOffset)
@@ -2463,6 +3102,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push a pointer to a method referenced by method, on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldftn?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldftn = new CilOpCode(
             (((ushort) CilCode.Ldftn & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldftn >> 15) << TwoBytesOffset)
@@ -2473,8 +3115,11 @@ namespace AsmResolver.PE.DotNet.Cil
             | ((byte) Next << FlowControlOffset));
 
         /// <summary>
-        /// 	Push address of virtual method on the stack.
+        /// Push address of virtual method on the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldvirtftn?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldvirtftn = new CilOpCode(
             (((ushort) CilCode.Ldvirtftn & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldvirtftn >> 15) << TwoBytesOffset)
@@ -2487,6 +3132,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load argument onto the stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldarg?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldarg = new CilOpCode(
             (((ushort) CilCode.Ldarg & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldarg >> 15) << TwoBytesOffset)
@@ -2499,6 +3147,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Fetch the address of the argument indexed.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldarga?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldarga = new CilOpCode(
             (((ushort) CilCode.Ldarga & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldarga >> 15) << TwoBytesOffset)
@@ -2511,6 +3162,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Store value to the argument.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.starg?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Starg = new CilOpCode(
             (((ushort) CilCode.Starg & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Starg >> 15) << TwoBytesOffset)
@@ -2523,6 +3177,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load local variable of index onto stack.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldloc?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldloc = new CilOpCode(
             (((ushort) CilCode.Ldloc & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldloc >> 15) << TwoBytesOffset)
@@ -2535,6 +3192,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Load address of local variable with index index.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldloca?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Ldloca = new CilOpCode(
             (((ushort) CilCode.Ldloca & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Ldloca >> 15) << TwoBytesOffset)
@@ -2547,6 +3207,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Pop a value from stack into local variable index.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stloc?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Stloc = new CilOpCode(
             (((ushort) CilCode.Stloc & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Stloc >> 15) << TwoBytesOffset)
@@ -2559,6 +3222,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Allocate space from the local memory pool.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.localloc?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Localloc = new CilOpCode(
             (((ushort) CilCode.Localloc & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Localloc >> 15) << TwoBytesOffset)
@@ -2571,6 +3237,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// End an exception handling filter clause.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.endfilter?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Endfilter = new CilOpCode(
             (((ushort) CilCode.Endfilter & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Endfilter >> 15) << TwoBytesOffset)
@@ -2583,6 +3252,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Subsequent pointer instruction might be unaligned.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.unaligned?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Unaligned = new CilOpCode(
             (((ushort) CilCode.Unaligned & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Unaligned >> 15) << TwoBytesOffset)
@@ -2595,6 +3267,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Subsequent pointer reference is volatile.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.volatile?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Volatile = new CilOpCode(
             (((ushort) CilCode.Volatile & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Volatile >> 15) << TwoBytesOffset)
@@ -2607,6 +3282,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Subsequent call terminates current method.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.tailcall?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Tailcall = new CilOpCode(
             (((ushort) CilCode.Tailcall & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Tailcall >> 15) << TwoBytesOffset)
@@ -2619,6 +3297,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Initialize the value at address dest.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.initobj?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Initobj = new CilOpCode(
             (((ushort) CilCode.Initobj & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Initobj >> 15) << TwoBytesOffset)
@@ -2631,6 +3312,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Call a virtual method on a type constrained to be type T.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.constrained?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Constrained = new CilOpCode(
             (((ushort) CilCode.Constrained & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Constrained >> 15) << TwoBytesOffset)
@@ -2643,6 +3327,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Copy data from memory to memory.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.cpblk?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Cpblk = new CilOpCode(
             (((ushort) CilCode.Cpblk & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Cpblk >> 15) << TwoBytesOffset)
@@ -2655,6 +3342,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Set all bytes in a block of memory to a given byte value.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.initblk?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Initblk = new CilOpCode(
             (((ushort) CilCode.Initblk & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Initblk >> 15) << TwoBytesOffset)
@@ -2667,6 +3357,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Rethrow the current exception.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.rethrow?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Rethrow = new CilOpCode(
             (((ushort) CilCode.Rethrow & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Rethrow >> 15) << TwoBytesOffset)
@@ -2679,6 +3372,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push the size, in bytes, of a type as an unsigned int32.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.sizeof?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Sizeof = new CilOpCode(
             (((ushort) CilCode.Sizeof & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Sizeof >> 15) << TwoBytesOffset)
@@ -2691,6 +3387,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Push the type token stored in a typed reference.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.refanytype?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Refanytype = new CilOpCode(
             (((ushort) CilCode.Refanytype & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Refanytype >> 15) << TwoBytesOffset)
@@ -2703,6 +3402,9 @@ namespace AsmResolver.PE.DotNet.Cil
         /// <summary>
         /// Specify that the subsequent array address operation performs no type check at runtime, and that it returns a controlled-mutability managed pointer.
         /// </summary>
+        /// <remarks>
+        /// See also: <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.readonly?view=net-6.0"/>
+        /// </remarks>
         public static readonly CilOpCode Readonly = new CilOpCode(
             (((ushort) CilCode.Readonly & 0xFF) << ValueOffset)
             | (((ushort) CilCode.Readonly >> 15) << TwoBytesOffset)


### PR DESCRIPTION
This pull request adds documentation for the CilOpCodes class.

The lines for this were pulled from https://en.wikipedia.org/wiki/List_of_CIL_instructions

The only ones I couldn't find information for was the Prefix OpCodes.