### PR TITLE
Fix/ AssemblyDefinition Write to relative path

### DIFF
--- a/src/AsmResolver.DotNet/AssemblyDefinition.cs
+++ b/src/AsmResolver.DotNet/AssemblyDefinition.cs
@@ -274,7 +274,7 @@ namespace AsmResolver.DotNet
         /// <param name="fileBuilder">The engine to use for reconstructing a PE file.</param>
         public void Write(string filePath, IPEImageBuilder imageBuilder, IPEFileBuilder fileBuilder)
         {
-            string? directory = Path.GetDirectoryName(filePath);
+            string? directory = Path.GetDirectoryName(Path.GetFullPath(filePath));
             if (directory is null || !Directory.Exists(directory))
                 throw new DirectoryNotFoundException();
 


### PR DESCRIPTION
Previously, `AssemblyDefinition.Write` would throw a `DirectoryNotFoundException` if provided a relative path without any directories, such as `output.dll`. This pull request make it use the full path instead, avoiding this issue.