### PR TITLE
Preserve duplicate metadata members when required

### DIFF
--- a/src/AsmResolver.DotNet/Builder/DotNetDirectoryFactory.cs
+++ b/src/AsmResolver.DotNet/Builder/DotNetDirectoryFactory.cs
@@ -84,7 +84,7 @@ namespace AsmResolver.DotNet.Builder
 
             // When specified, import existing AssemblyRef, ModuleRef, TypeRef and MemberRef prior to adding any other
             // member reference or definition, to ensure that they are assigned their original RIDs.
-            ImportBasicTablesIntoTableBuffersIfSpecified(module, buffer);
+            ImportBasicTablesIfSpecified(module, buffer);
 
             // Define all types defined in the module.
             buffer.DefineTypes(discoveryResult.Types);
@@ -102,7 +102,7 @@ namespace AsmResolver.DotNet.Builder
 
             // Import remaining preservable tables (Type specs, method specs, signatures etc).
             // We do this before finalizing any member to ensure that they are assigned their original RIDs.
-            ImportRemainingTablesIntoTableBuffersIfSpecified(module, buffer);
+            ImportRemainingTablesIfSpecified(module, buffer);
 
             // Finalize member definitions.
             buffer.FinalizeTypes();
@@ -197,7 +197,7 @@ namespace AsmResolver.DotNet.Builder
             return metadataBuffer;
         }
 
-        private void ImportBasicTablesIntoTableBuffersIfSpecified(ModuleDefinition module, DotNetDirectoryBuffer buffer)
+        private void ImportBasicTablesIfSpecified(ModuleDefinition module, DotNetDirectoryBuffer buffer)
         {
             if (module.DotNetDirectory is null)
                 return;
@@ -210,37 +210,58 @@ namespace AsmResolver.DotNet.Builder
             // and type reference tokens are still preserved, we need to prioritize these.
 
             if ((MetadataBuilderFlags & MetadataBuilderFlags.PreserveAssemblyReferenceIndices) != 0)
-                ImportTableIntoTableBuffers<AssemblyReference>(module, TableIndex.AssemblyRef, buffer.GetAssemblyReferenceToken);
+            {
+                ImportTables<AssemblyReference>(module, TableIndex.AssemblyRef,
+                    r => buffer.AddAssemblyReference(r, true));
+            }
 
             if ((MetadataBuilderFlags & MetadataBuilderFlags.PreserveModuleReferenceIndices) != 0)
-                ImportTableIntoTableBuffers<ModuleReference>(module, TableIndex.ModuleRef, buffer.GetModuleReferenceToken);
+            {
+                ImportTables<ModuleReference>(module, TableIndex.ModuleRef,
+                    r => buffer.AddModuleReference(r, true));
+            }
 
             if ((MetadataBuilderFlags & MetadataBuilderFlags.PreserveTypeReferenceIndices) != 0)
-                ImportTableIntoTableBuffers<TypeReference>(module, TableIndex.TypeRef, buffer.GetTypeReferenceToken);
+            {
+                ImportTables<TypeReference>(module, TableIndex.TypeRef,
+                    r => buffer.AddTypeReference(r, true));
+            }
         }
 
         private void ImportTypeSpecsAndMemberRefsIfSpecified(ModuleDefinition module, DotNetDirectoryBuffer buffer)
         {
             if ((MetadataBuilderFlags & MetadataBuilderFlags.PreserveTypeSpecificationIndices) != 0)
-                ImportTableIntoTableBuffers<TypeSpecification>(module, TableIndex.TypeSpec, buffer.GetTypeSpecificationToken);
+            {
+                ImportTables<TypeSpecification>(module, TableIndex.TypeSpec,
+                    s => buffer.AddTypeSpecification(s, true));
+            }
 
             if ((MetadataBuilderFlags & MetadataBuilderFlags.PreserveMemberReferenceIndices) != 0)
-                ImportTableIntoTableBuffers<MemberReference>(module, TableIndex.MemberRef, buffer.GetMemberReferenceToken);
+            {
+                ImportTables<MemberReference>(module, TableIndex.MemberRef,
+                    r => buffer.AddMemberReference(r, true));
+            }
         }
 
-        private void ImportRemainingTablesIntoTableBuffersIfSpecified(ModuleDefinition module, DotNetDirectoryBuffer buffer)
+        private void ImportRemainingTablesIfSpecified(ModuleDefinition module, DotNetDirectoryBuffer buffer)
         {
             if (module.DotNetDirectory is null)
                 return;
 
             if ((MetadataBuilderFlags & MetadataBuilderFlags.PreserveStandAloneSignatureIndices) != 0)
-                ImportTableIntoTableBuffers<StandAloneSignature>(module, TableIndex.StandAloneSig, buffer.GetStandAloneSignatureToken);
+            {
+                ImportTables<StandAloneSignature>(module, TableIndex.StandAloneSig,
+                    s => buffer.AddStandAloneSignature(s, true));
+            }
 
             if ((MetadataBuilderFlags & MetadataBuilderFlags.PreserveMethodSpecificationIndices) != 0)
-                ImportTableIntoTableBuffers<MethodSpecification>(module, TableIndex.MethodSpec, buffer.GetMethodSpecificationToken);
+            {
+                ImportTables<MethodSpecification>(module, TableIndex.MethodSpec,
+                    s => buffer.AddMethodSpecification(s, true));
+            }
         }
 
-        private static void ImportTableIntoTableBuffers<TMember>(ModuleDefinition module, TableIndex tableIndex,
+        private static void ImportTables<TMember>(ModuleDefinition module, TableIndex tableIndex,
             Func<TMember, MetadataToken> importAction)
         {
             int count = module.DotNetDirectory!.Metadata

--- a/src/AsmResolver.DotNet/Builder/Metadata/Tables/DistinctMetadataTableBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Tables/DistinctMetadataTableBuffer.cs
@@ -48,12 +48,26 @@ namespace AsmResolver.DotNet.Builder.Metadata.Tables
         public ref TRow GetRowRef(uint rid) => ref _underlyingBuffer.GetRowRef(rid);
 
         /// <inheritdoc />
-        public MetadataToken Add(in TRow row)
+        public MetadataToken Add(in TRow row) => Add(row, false);
+
+        /// <summary>
+        /// Adds a row to the metadata table buffer.
+        /// </summary>
+        /// <param name="row">The row to add.</param>
+        /// <param name="allowDuplicates">
+        /// <c>true</c> if the row is always to be added to the end of the buffer, <c>false</c> if a duplicated row
+        /// is supposed to be removed and the token of the original should be returned instead.</param>
+        /// <returns>The metadata token that this row was assigned to.</returns>
+        public MetadataToken Add(in TRow row, bool allowDuplicates)
         {
             if (!_entries.TryGetValue(row, out var token))
             {
                 token = _underlyingBuffer.Add(in row);
                 _entries.Add(row, token);
+            }
+            else if (allowDuplicates)
+            {
+                token = _underlyingBuffer.Add(in row);
             }
 
             return token;

--- a/src/AsmResolver.DotNet/Builder/Metadata/Tables/TablesStreamBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Tables/TablesStreamBuffer.cs
@@ -124,6 +124,18 @@ namespace AsmResolver.DotNet.Builder.Metadata.Tables
         /// Gets a table buffer by its table index.
         /// </summary>
         /// <param name="table">The index of the table to get.</param>
+        /// <typeparam name="TRow">The type of rows the table stores.</typeparam>
+        /// <returns>The metadata table.</returns>
+        public DistinctMetadataTableBuffer<TRow> GetDistinctTable<TRow>(TableIndex table)
+            where TRow : struct, IMetadataRow
+        {
+            return (DistinctMetadataTableBuffer<TRow>) _tableBuffers[(int) table];
+        }
+
+        /// <summary>
+        /// Gets a table buffer by its table index.
+        /// </summary>
+        /// <param name="table">The index of the table to get.</param>
         /// <typeparam name="TKey">The type of members that are assigned new metadata rows.</typeparam>
         /// <typeparam name="TRow">The type of rows the table stores.</typeparam>
         /// <returns>The metadata table.</returns>

--- a/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/AssemblyRefTokenPreservationTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/AssemblyRefTokenPreservationTest.cs
@@ -1,8 +1,11 @@
 using System.IO;
 using System.Linq;
 using AsmResolver.DotNet.Builder;
+using AsmResolver.PE;
 using AsmResolver.PE.DotNet.Cil;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
+using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 using Xunit;
 
 namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
@@ -14,10 +17,10 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
         {
             var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld_NetCore);
             var originalAssemblyRefs = GetMembers<AssemblyReference>(module, TableIndex.AssemblyRef);
-            
+
             var newModule = RebuildAndReloadModule(module, MetadataBuilderFlags.PreserveAssemblyReferenceIndices);
             var newAssemblyRefs = GetMembers<AssemblyReference>(newModule, TableIndex.AssemblyRef);
-            
+
             Assert.Equal(originalAssemblyRefs, newAssemblyRefs.Take(originalAssemblyRefs.Count), Comparer);
         }
 
@@ -26,14 +29,14 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
         {
             var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld_NetCore);
             var originalAssemblyRefs = GetMembers<AssemblyReference>(module, TableIndex.AssemblyRef);
-            
-            var instructions = module.ManagedEntrypointMethod.CilMethodBody.Instructions;
+
+            var instructions = module.ManagedEntrypointMethod!.CilMethodBody!.Instructions;
             instructions.Clear();
             instructions.Add(CilOpCodes.Ret);
-            
+
             var newModule = RebuildAndReloadModule(module, MetadataBuilderFlags.PreserveAssemblyReferenceIndices);
             var newAssemblyRefs = GetMembers<AssemblyReference>(newModule, TableIndex.AssemblyRef);
-            
+
             Assert.Equal(originalAssemblyRefs, newAssemblyRefs.Take(originalAssemblyRefs.Count), Comparer);
         }
 
@@ -42,22 +45,58 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
         {
             var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld_NetCore);
             var originalAssemblyRefs = GetMembers<AssemblyReference>(module, TableIndex.AssemblyRef);
-            
-            var importer = new ReferenceImporter(module);
-            var exists = importer.ImportMethod(typeof(File).GetMethod("Exists", new[] {typeof(string)}));
 
-            var instructions = module.ManagedEntrypointMethod.CilMethodBody.Instructions;
+            var importer = new ReferenceImporter(module);
+            var exists = importer.ImportMethod(typeof(File).GetMethod("Exists", new[] {typeof(string)})!);
+
+            var instructions = module.ManagedEntrypointMethod!.CilMethodBody!.Instructions;
             instructions.RemoveAt(instructions.Count - 1);
             instructions.Add(CilOpCodes.Ldstr, "file.txt");
             instructions.Add(CilOpCodes.Call, exists);
             instructions.Add(CilOpCodes.Pop);
             instructions.Add(CilOpCodes.Ret);
-            
+
             var newModule = RebuildAndReloadModule(module, MetadataBuilderFlags.PreserveAssemblyReferenceIndices);
             var newAssemblyRefs = GetMembers<AssemblyReference>(newModule, TableIndex.AssemblyRef);
-            
+
             Assert.Equal(originalAssemblyRefs, newAssemblyRefs.Take(originalAssemblyRefs.Count), Comparer);
         }
 
+        [Fact]
+        public void PreserveDuplicatedAssemblyRefs()
+        {
+            var image = PEImage.FromBytes(Properties.Resources.HelloWorld);
+            var metadata = image.DotNetDirectory!.Metadata!;
+            var strings = metadata.GetStream<StringsStream>();
+            var table = metadata
+                .GetStream<TablesStream>()
+                .GetTable<AssemblyReferenceRow>();
+
+            // Duplicate mscorlib row.
+            var corlibRow = table.First(a => strings.GetStringByIndex(a.Name) == "mscorlib");
+            table.Add(corlibRow);
+
+            // Open module from modified image.
+            var module = ModuleDefinition.FromImage(image);
+
+            // Obtain references to mscorlib.
+            var references = module.AssemblyReferences
+                .Where(t => t.Name == "mscorlib")
+                .ToArray();
+
+            Assert.Equal(2, references.Length);
+
+            // Rebuild with preservation.
+            var newModule = RebuildAndReloadModule(module, MetadataBuilderFlags.PreserveAssemblyReferenceIndices);
+
+            var newReferences = newModule
+                .AssemblyReferences
+                .Where(t => t.Name == "mscorlib")
+                .ToArray();
+
+            Assert.Equal(
+                references.Select(r => r.MetadataToken).ToHashSet(),
+                newReferences.Select(r => r.MetadataToken).ToHashSet());
+        }
     }
 }

--- a/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/TokenPreservationTestBase.cs
+++ b/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/TokenPreservationTestBase.cs
@@ -19,7 +19,7 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
 
         protected static List<TMember> GetMembers<TMember>(ModuleDefinition module, TableIndex tableIndex)
         {
-            int count = module.DotNetDirectory.Metadata
+            int count = module.DotNetDirectory!.Metadata!
                 .GetStream<TablesStream>()
                 .GetTable(tableIndex)
                 .Count;
@@ -38,10 +38,11 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
             };
 
             var result = builder.CreateImage(module);
-            if (result.DiagnosticBag.HasErrors)
+            if (result.HasFailed)
                 throw new AggregateException(result.DiagnosticBag.Exceptions);
 
             var newImage = result.ConstructedImage;
+
             return ModuleDefinition.FromImage(newImage);
         }
 

--- a/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/TypeRefTokenPreservationTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/TypeRefTokenPreservationTest.cs
@@ -31,7 +31,7 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
             var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld_NetCore);
             var originalTypeRefs = GetMembers<TypeReference>(module, TableIndex.TypeRef);
 
-            var instructions = module.ManagedEntrypointMethod.CilMethodBody.Instructions;
+            var instructions = module.ManagedEntrypointMethod!.CilMethodBody!.Instructions;
             instructions.Clear();
             instructions.Add(CilOpCodes.Ret);
 
@@ -48,9 +48,9 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
             var originalTypeRefs = GetMembers<TypeReference>(module, TableIndex.TypeRef);
 
             var importer = new ReferenceImporter(module);
-            var readKey = importer.ImportMethod(typeof(Console).GetMethod("ReadKey", Type.EmptyTypes));
+            var readKey = importer.ImportMethod(typeof(Console).GetMethod("ReadKey", Type.EmptyTypes)!);
 
-            var instructions = module.ManagedEntrypointMethod.CilMethodBody.Instructions;
+            var instructions = module.ManagedEntrypointMethod!.CilMethodBody!.Instructions;
             instructions.RemoveAt(instructions.Count - 1);
             instructions.Add(CilOpCodes.Call, readKey);
             instructions.Add(CilOpCodes.Pop);
@@ -65,7 +65,7 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
         [Fact]
         public void PreserveDuplicatedTypeRefs()
         {
-            var image = PEImage.FromBytes(Properties.Resources.HelloWorld_NetCore);
+            var image = PEImage.FromBytes(Properties.Resources.HelloWorld);
             var metadata = image.DotNetDirectory!.Metadata!;
             var strings = metadata.GetStream<StringsStream>();
             var table = metadata
@@ -80,12 +80,12 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
             var module = ModuleDefinition.FromImage(image);
 
             // Obtain references to Object.
-            var objectReferences = module
+            var references = module
                 .GetImportedTypeReferences()
                 .Where(t => t.Name == "Object")
                 .ToArray();
 
-            Assert.Equal(2, objectReferences.Length);
+            Assert.Equal(2, references.Length);
 
             // Rebuild with preservation.
             var newModule = RebuildAndReloadModule(module, MetadataBuilderFlags.PreserveTypeReferenceIndices);
@@ -96,7 +96,7 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
                 .ToArray();
 
             Assert.Equal(
-                objectReferences.Select(r => r.MetadataToken).ToHashSet(),
+                references.Select(r => r.MetadataToken).ToHashSet(),
                 newObjectReferences.Select(r => r.MetadataToken).ToHashSet());
         }
     }

--- a/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/TypeRefTokenPreservationTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/TypeRefTokenPreservationTest.cs
@@ -1,8 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using AsmResolver.DotNet.Builder;
+using AsmResolver.PE;
 using AsmResolver.PE.DotNet.Cil;
+using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
+using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 using Xunit;
 
 namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
@@ -14,10 +18,10 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
         {
             var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld_NetCore);
             var originalTypeRefs = GetMembers<TypeReference>(module, TableIndex.TypeRef);
-            
+
             var newModule = RebuildAndReloadModule(module, MetadataBuilderFlags.PreserveTypeReferenceIndices);
             var newTypeRefs = GetMembers<TypeReference>(newModule, TableIndex.TypeRef);
-            
+
             Assert.Equal(originalTypeRefs, newTypeRefs.Take(originalTypeRefs.Count), Comparer);
         }
 
@@ -26,14 +30,14 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
         {
             var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld_NetCore);
             var originalTypeRefs = GetMembers<TypeReference>(module, TableIndex.TypeRef);
-            
+
             var instructions = module.ManagedEntrypointMethod.CilMethodBody.Instructions;
             instructions.Clear();
             instructions.Add(CilOpCodes.Ret);
-            
+
             var newModule = RebuildAndReloadModule(module, MetadataBuilderFlags.PreserveTypeReferenceIndices);
             var newTypeRefs = GetMembers<TypeReference>(newModule, TableIndex.TypeRef);
-            
+
             Assert.Equal(originalTypeRefs, newTypeRefs.Take(originalTypeRefs.Count), Comparer);
         }
 
@@ -42,7 +46,7 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
         {
             var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld_NetCore);
             var originalTypeRefs = GetMembers<TypeReference>(module, TableIndex.TypeRef);
-            
+
             var importer = new ReferenceImporter(module);
             var readKey = importer.ImportMethod(typeof(Console).GetMethod("ReadKey", Type.EmptyTypes));
 
@@ -51,12 +55,49 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
             instructions.Add(CilOpCodes.Call, readKey);
             instructions.Add(CilOpCodes.Pop);
             instructions.Add(CilOpCodes.Ret);
-            
+
             var newModule = RebuildAndReloadModule(module, MetadataBuilderFlags.PreserveTypeReferenceIndices);
             var newTypeRefs = GetMembers<TypeReference>(newModule, TableIndex.TypeRef);
-            
+
             Assert.Equal(originalTypeRefs, newTypeRefs.Take(originalTypeRefs.Count), Comparer);
         }
 
+        [Fact]
+        public void PreserveDuplicatedTypeRefs()
+        {
+            var image = PEImage.FromBytes(Properties.Resources.HelloWorld_NetCore);
+            var metadata = image.DotNetDirectory!.Metadata!;
+            var strings = metadata.GetStream<StringsStream>();
+            var table = metadata
+                .GetStream<TablesStream>()
+                .GetTable<TypeReferenceRow>();
+
+            // Duplicate Object row.
+            var objectRow = table.First(t => strings.GetStringByIndex(t.Name) == "Object");
+            table.Add(objectRow);
+
+            // Open module from modified image.
+            var module = ModuleDefinition.FromImage(image);
+
+            // Obtain references to Object.
+            var objectReferences = module
+                .GetImportedTypeReferences()
+                .Where(t => t.Name == "Object")
+                .ToArray();
+
+            Assert.Equal(2, objectReferences.Length);
+
+            // Rebuild with preservation.
+            var newModule = RebuildAndReloadModule(module, MetadataBuilderFlags.PreserveTypeReferenceIndices);
+
+            var newObjectReferences = newModule
+                .GetImportedTypeReferences()
+                .Where(t => t.Name == "Object")
+                .ToArray();
+
+            Assert.Equal(
+                objectReferences.Select(r => r.MetadataToken).ToHashSet(),
+                newObjectReferences.Select(r => r.MetadataToken).ToHashSet());
+        }
     }
 }

--- a/test/AsmResolver.DotNet.Tests/TokenAllocatorTest.cs
+++ b/test/AsmResolver.DotNet.Tests/TokenAllocatorTest.cs
@@ -141,7 +141,34 @@ namespace AsmResolver.DotNet.Tests
             allocator.AssignNextAvailableToken(method);
 
             targetModule.GetOrCreateModuleConstructor();
-            var image = targetModule.ToPEImage(new ManagedPEImageBuilder(MetadataBuilderFlags.PreserveAll));
+            _ = targetModule.ToPEImage(new ManagedPEImageBuilder(MetadataBuilderFlags.PreserveAll));
         }
+
+        [Fact]
+        public void Issue252()
+        {
+            // https://github.com/Washi1337/AsmResolver/issues/252
+
+            var module = ModuleDefinition.FromFile(typeof(TokenAllocatorTest).Assembly.Location);
+            var asmResRef = module.AssemblyReferences.First(a => a.Name == "AsmResolver.DotNet");
+
+            var reference  = new TypeReference(module, asmResRef, "AsmResolver.DotNet", "MethodDefinition");
+            var reference2 = new TypeReference(module, asmResRef, "AsmResolver.DotNet", "ModuleDefinition");
+
+            module.TokenAllocator.AssignNextAvailableToken(reference);
+            module.TokenAllocator.AssignNextAvailableToken(reference2);
+
+            var image = module.ToPEImage(new ManagedPEImageBuilder(MetadataBuilderFlags.PreserveAll));
+            var newModule = ModuleDefinition.FromImage(image);
+
+            var newReference = (TypeReference) newModule.LookupMember(reference.MetadataToken);
+            var newReference2 = (TypeReference) newModule.LookupMember(reference2.MetadataToken);
+
+            Assert.Equal(reference.Namespace, newReference.Namespace);
+            Assert.Equal(reference.Name, newReference.Name);
+            Assert.Equal(reference2.Namespace, newReference2.Namespace);
+            Assert.Equal(reference2.Name, newReference2.Name);
+        }
+
     }
 }


### PR DESCRIPTION
Fixes a bug related to token preservation of metadata members within `DistinctMetadataTableBuffer`s. 

Closes #252