### PR TITLE
Deprecate FieldSignature.CreateXXX Factory methods

### DIFF
--- a/src/AsmResolver.DotNet/Builder/Discovery/MemberDiscoverer.cs
+++ b/src/AsmResolver.DotNet/Builder/Discovery/MemberDiscoverer.cs
@@ -343,7 +343,7 @@ namespace AsmResolver.DotNet.Builder.Discovery
             var placeHolderField = new FieldDefinition(
                 $"PlaceHolderField_{token.Rid.ToString()}",
                 FieldPlaceHolderAttributes,
-                FieldSignature.CreateStatic(_module.CorLibTypeFactory.Object));
+                _module.CorLibTypeFactory.Object);
 
             // Add the field to the type.
             placeHolderType.Fields.Add(placeHolderField);

--- a/src/AsmResolver.DotNet/FieldDefinition.cs
+++ b/src/AsmResolver.DotNet/FieldDefinition.cs
@@ -70,14 +70,14 @@ namespace AsmResolver.DotNet
         /// </summary>
         /// <param name="name">The name of the field.</param>
         /// <param name="attributes">The attributes.</param>
-        /// <param name="signature">The type of values the field contains.</param>
-        public FieldDefinition(string? name, FieldAttributes attributes, TypeSignature? signature)
+        /// <param name="fieldType">The type of values the field contains.</param>
+        public FieldDefinition(string? name, FieldAttributes attributes, TypeSignature? fieldType)
             : this(new MetadataToken(TableIndex.Field, 0))
         {
             Name = name;
             Attributes = attributes;
-            Signature = signature is not null
-                ? new FieldSignature(signature)
+            Signature = fieldType is not null
+                ? new FieldSignature(fieldType)
                 : null;
         }
 

--- a/src/AsmResolver.DotNet/FieldDefinition.cs
+++ b/src/AsmResolver.DotNet/FieldDefinition.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Marshal;
+using AsmResolver.DotNet.Signatures.Types;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
@@ -56,17 +57,28 @@ namespace AsmResolver.DotNet
         /// <param name="name">The name of the field.</param>
         /// <param name="attributes">The attributes.</param>
         /// <param name="signature">The signature of the field.</param>
-        /// <remarks>
-        /// For a valid .NET image, if <see cref="CallingConventionSignature.HasThis"/> of the signature referenced by
-        /// <paramref name="signature"/> is set, the <see cref="FieldAttributes.Static"/> bit should be unset in
-        /// <paramref name="attributes"/> and vice versa.
-        /// </remarks>
         public FieldDefinition(string? name, FieldAttributes attributes, FieldSignature? signature)
             : this(new MetadataToken(TableIndex.Field, 0))
         {
             Name = name;
             Attributes = attributes;
             Signature = signature;
+        }
+
+        /// <summary>
+        /// Creates a new field definition.
+        /// </summary>
+        /// <param name="name">The name of the field.</param>
+        /// <param name="attributes">The attributes.</param>
+        /// <param name="signature">The type of values the field contains.</param>
+        public FieldDefinition(string? name, FieldAttributes attributes, TypeSignature? signature)
+            : this(new MetadataToken(TableIndex.Field, 0))
+        {
+            Name = name;
+            Attributes = attributes;
+            Signature = signature is not null
+                ? new FieldSignature(signature)
+                : null;
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/Signatures/FieldSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/FieldSignature.cs
@@ -1,6 +1,6 @@
+using System;
 using AsmResolver.DotNet.Signatures.Types;
 using AsmResolver.IO;
-using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
 namespace AsmResolver.DotNet.Signatures
 {
@@ -14,6 +14,9 @@ namespace AsmResolver.DotNet.Signatures
         /// </summary>
         /// <param name="fieldType">The value type of the field.</param>
         /// <returns>The signature.</returns>
+        [Obsolete("The HasThis bit in field signatures is ignored by the CLR. Use the constructor instead, or"
+                  + " when this call is used in an argument of a FieldDefinition constructor, use the overload taking "
+                  + "a TypeSignature instead.")]
         public static FieldSignature CreateStatic(TypeSignature fieldType)
             => new(CallingConventionAttributes.Field, fieldType);
 
@@ -22,6 +25,9 @@ namespace AsmResolver.DotNet.Signatures
         /// </summary>
         /// <param name="fieldType">The value type of the field.</param>
         /// <returns>The signature.</returns>
+        [Obsolete("The HasThis bit in field signatures is ignored by the CLR. Use the constructor instead, or"
+                  + " when this call is used in an argument of a FieldDefinition constructor, use the overload taking "
+                  + "a TypeSignature instead.")]
         public static FieldSignature CreateInstance(TypeSignature fieldType)
             => new(CallingConventionAttributes.Field | CallingConventionAttributes.HasThis, fieldType);
 
@@ -61,7 +67,7 @@ namespace AsmResolver.DotNet.Signatures
         }
 
         /// <summary>
-        /// Gets the type of the object that the field stores.
+        /// Gets the type of the value that the field contains.
         /// </summary>
         public TypeSignature FieldType
         {

--- a/src/AsmResolver.DotNet/Signatures/FieldSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/FieldSignature.cs
@@ -14,9 +14,9 @@ namespace AsmResolver.DotNet.Signatures
         /// </summary>
         /// <param name="fieldType">The value type of the field.</param>
         /// <returns>The signature.</returns>
-        [Obsolete("The HasThis bit in field signatures is ignored by the CLR. Use the constructor instead, or"
-                  + " when this call is used in an argument of a FieldDefinition constructor, use the overload taking "
-                  + "a TypeSignature instead.")]
+        [Obsolete("The HasThis bit in field signatures is ignored by the CLR. Use the constructor instead,"
+                  + " or when this call is used in an argument of a FieldDefinition constructor, use the overload"
+                  + " taking TypeSignature instead.")]
         public static FieldSignature CreateStatic(TypeSignature fieldType)
             => new(CallingConventionAttributes.Field, fieldType);
 
@@ -25,9 +25,9 @@ namespace AsmResolver.DotNet.Signatures
         /// </summary>
         /// <param name="fieldType">The value type of the field.</param>
         /// <returns>The signature.</returns>
-        [Obsolete("The HasThis bit in field signatures is ignored by the CLR. Use the constructor instead, or"
-                  + " when this call is used in an argument of a FieldDefinition constructor, use the overload taking "
-                  + "a TypeSignature instead.")]
+        [Obsolete("The HasThis bit in field signatures is ignored by the CLR. Use the constructor instead,"
+                  + " or when this call is used in an argument of a FieldDefinition constructor, use the overload"
+                  + " taking TypeSignature instead.")]
         public static FieldSignature CreateInstance(TypeSignature fieldType)
             => new(CallingConventionAttributes.Field | CallingConventionAttributes.HasThis, fieldType);
 

--- a/test/AsmResolver.DotNet.Tests/Builder/TokenMappingTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Builder/TokenMappingTest.cs
@@ -44,7 +44,7 @@ namespace AsmResolver.DotNet.Tests.Builder
             var field = new FieldDefinition(
                 "MyField",
                 FieldAttributes.Public | FieldAttributes.Static,
-                FieldSignature.CreateStatic(module.CorLibTypeFactory.Object));
+                module.CorLibTypeFactory.Object);
             module.GetOrCreateModuleType().Fields.Add(field);
 
             // Rebuild.
@@ -107,7 +107,7 @@ namespace AsmResolver.DotNet.Tests.Builder
             module.GetOrCreateModuleType().Fields.Add(new FieldDefinition(
                 "MyField",
                 FieldAttributes.Public | FieldAttributes.Static,
-                FieldSignature.CreateStatic(reference.ToTypeSignature())));
+                reference.ToTypeSignature()));
 
             // Rebuild.
             var builder = new ManagedPEImageBuilder();

--- a/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/FieldTokenPreservationTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/FieldTokenPreservationTest.cs
@@ -14,12 +14,12 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
         private static ModuleDefinition CreateSampleFieldDefsModule(int typeCount, int fieldsPerType)
         {
             var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld_NetCore);
-            
+
             for (int i = 0; i < typeCount; i++)
             {
                 var dummyType = new TypeDefinition("Namespace", $"Type{i.ToString()}",
                     TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed);
-                
+
                 module.TopLevelTypes.Add(dummyType);
                 for (int j = 0; j < fieldsPerType; j++)
                     dummyType.Fields.Add(CreateDummyField(module, $"Field{j}"));
@@ -28,18 +28,16 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
             return RebuildAndReloadModule(module, MetadataBuilderFlags.None);
         }
 
-        private static FieldDefinition CreateDummyField(ModuleDefinition module, string name)
-        {
-            return new FieldDefinition(name,
-                FieldAttributes.Public | FieldAttributes.Static,
-                FieldSignature.CreateStatic(module.CorLibTypeFactory.Int32));
-        }
-        
+        private static FieldDefinition CreateDummyField(ModuleDefinition module, string name) => new(
+            name,
+            FieldAttributes.Public | FieldAttributes.Static,
+            module.CorLibTypeFactory.Int32);
+
         [Fact]
         public void PreserveFieldDefsNoChange()
         {
             var module = CreateSampleFieldDefsModule(10, 10);
-            
+
             var newModule = RebuildAndReloadModule(module,MetadataBuilderFlags.PreserveFieldDefinitionIndices);
 
             AssertSameTokens(module, newModule, t => t.Fields);
@@ -49,12 +47,12 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
         public void PreserveFieldDefsChangeOrderOfTypes()
         {
             var module = CreateSampleFieldDefsModule(10, 10);
-            
+
             const int swapIndex = 3;
             var type = module.TopLevelTypes[swapIndex];
             module.TopLevelTypes.RemoveAt(swapIndex);
             module.TopLevelTypes.Insert(swapIndex + 1, type);
-            
+
             var newModule = RebuildAndReloadModule(module,MetadataBuilderFlags.PreserveFieldDefinitionIndices);
 
             AssertSameTokens(module, newModule, t => t.Fields);
@@ -70,7 +68,7 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
             var field = type.Fields[swapIndex];
             type.Fields.RemoveAt(swapIndex);
             type.Fields.Insert(swapIndex + 1, field);
-            
+
             var newModule = RebuildAndReloadModule(module,MetadataBuilderFlags.PreserveFieldDefinitionIndices);
 
             AssertSameTokens(module, newModule, t => t.Fields);
@@ -84,7 +82,7 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
             var type = module.TopLevelTypes[2];
             var field = CreateDummyField(module, "ExtraField");
             type.Fields.Insert(3, field);
-            
+
             var newModule = RebuildAndReloadModule(module,MetadataBuilderFlags.PreserveFieldDefinitionIndices);
 
             AssertSameTokens(module, newModule, t => t.Fields);
@@ -99,7 +97,7 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
             const int indexToRemove = 3;
             var field = type.Fields[indexToRemove];
             type.Fields.RemoveAt(indexToRemove);
-            
+
             var newModule = RebuildAndReloadModule(module,MetadataBuilderFlags.PreserveFieldDefinitionIndices);
 
             AssertSameTokens(module, newModule, t => t.Fields, field.MetadataToken);

--- a/test/AsmResolver.DotNet.Tests/FieldDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/FieldDefinitionTest.cs
@@ -73,7 +73,7 @@ namespace AsmResolver.DotNet.Tests
             var field = (FieldDefinition) module.LookupMember(
                 typeof(SingleField).GetField(nameof(SingleField.IntField)).MetadataToken);
 
-            field.Signature = FieldSignature.CreateInstance(module.CorLibTypeFactory.Byte);
+            field.Signature = new FieldSignature(module.CorLibTypeFactory.Byte);
 
             var newField = RebuildAndLookup(field);
 

--- a/test/AsmResolver.DotNet.Tests/MetadataResolverTest.cs
+++ b/test/AsmResolver.DotNet.Tests/MetadataResolverTest.cs
@@ -161,8 +161,10 @@ namespace AsmResolver.DotNet.Tests
             var module = new ModuleDefinition("SomeModule.dll");
 
             var stringType = new TypeReference(module.CorLibTypeFactory.CorLibScope, "System", "String");
-            var emptyField = new MemberReference(stringType, "Empty",
-                FieldSignature.CreateStatic(module.CorLibTypeFactory.String));
+            var emptyField = new MemberReference(
+                stringType,
+                "Empty",
+                new FieldSignature(module.CorLibTypeFactory.String));
 
             var definition = _fwResolver.ResolveField(emptyField);
 

--- a/test/AsmResolver.DotNet.Tests/ReferenceImporterTest.cs
+++ b/test/AsmResolver.DotNet.Tests/ReferenceImporterTest.cs
@@ -224,7 +224,9 @@ namespace AsmResolver.DotNet.Tests
         public void ImportFieldFromExternalModuleShouldResultInMemberRef()
         {
             var type = new TypeReference(_dummyAssembly, null, "Type");
-            var field = new MemberReference(type, "Field",
+            var field = new MemberReference(
+                type,
+                "Field",
                 new FieldSignature(_module.CorLibTypeFactory.String));
 
             var result = _importer.ImportField(field);
@@ -239,8 +241,11 @@ namespace AsmResolver.DotNet.Tests
             var type = new TypeDefinition(null, "Type", TypeAttributes.Public);
             _module.TopLevelTypes.Add(type);
 
-            var field = new FieldDefinition("Field", FieldAttributes.Public | FieldAttributes.Static,
-                new FieldSignature(_module.CorLibTypeFactory.Int32));
+            var field = new FieldDefinition(
+                "Field",
+                FieldAttributes.Public | FieldAttributes.Static,
+                _module.CorLibTypeFactory.Int32);
+
             type.Fields.Add(field);
 
             var result = _importer.ImportField(field);

--- a/test/AsmResolver.DotNet.Tests/ReferenceImporterTest.cs
+++ b/test/AsmResolver.DotNet.Tests/ReferenceImporterTest.cs
@@ -16,18 +16,18 @@ namespace AsmResolver.DotNet.Tests
         private readonly AssemblyReference _dummyAssembly = new AssemblyReference("SomeAssembly", new Version(1, 2, 3, 4));
         private readonly ModuleDefinition _module;
         private readonly ReferenceImporter _importer;
-        
+
         public ReferenceImporterTest()
         {
             _module = new ModuleDefinition("SomeModule.dll");
             _importer = new ReferenceImporter(_module);
         }
-        
+
         [Fact]
         public void ImportNewAssemblyShouldAddToModule()
         {
             var result = _importer.ImportScope(_dummyAssembly);
-            
+
             Assert.Equal(_dummyAssembly, result, _comparer);
             Assert.Contains(result, _module.AssemblyReferences);
         }
@@ -38,10 +38,10 @@ namespace AsmResolver.DotNet.Tests
             _module.AssemblyReferences.Add(_dummyAssembly);
 
             int count = _module.AssemblyReferences.Count;
-            
+
             var copy = new AssemblyReference(_dummyAssembly);
             var result = _importer.ImportScope(copy);
-            
+
             Assert.Same(_dummyAssembly, result);
             Assert.Equal(count, _module.AssemblyReferences.Count);
         }
@@ -61,7 +61,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var type = new TypeReference(_dummyAssembly, "SomeNamespace", "SomeName");
             var importedType = _importer.ImportType(type);
-            
+
             var result = _importer.ImportType(importedType);
 
             Assert.Same(importedType, result);
@@ -80,13 +80,13 @@ namespace AsmResolver.DotNet.Tests
             Assert.IsAssignableFrom<TypeReference>(result);
             Assert.Equal(definition, result, _comparer);
         }
-        
+
         [Fact]
         public void ImportTypeDefInSameModuleShouldReturnSameInstance()
         {
             var definition = new TypeDefinition("SomeNamespace", "SomeName", TypeAttributes.Public);
             _module.TopLevelTypes.Add(definition);
-            
+
             var importedType = _importer.ImportType(definition);
 
             Assert.Same(definition, importedType);
@@ -127,7 +127,7 @@ namespace AsmResolver.DotNet.Tests
             Assert.IsAssignableFrom<TypeSpecification>(result);
             Assert.IsAssignableFrom<SzArrayTypeSignature>(((TypeSpecification) result).Signature);
         }
-        
+
         [Fact]
         public void ImportCorLibTypeAsSignatureShouldResultInCorLibTypeSignature()
         {
@@ -179,7 +179,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var type = new TypeDefinition(null, "Type", TypeAttributes.Public);
             _module.TopLevelTypes.Add(type);
-            
+
             var method = new MethodDefinition("Method", MethodAttributes.Public | MethodAttributes.Static,
                 MethodSignature.CreateStatic(_module.CorLibTypeFactory.Void));
             type.Methods.Add(method);
@@ -225,7 +225,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var type = new TypeReference(_dummyAssembly, null, "Type");
             var field = new MemberReference(type, "Field",
-                FieldSignature.CreateStatic(_module.CorLibTypeFactory.String));
+                new FieldSignature(_module.CorLibTypeFactory.String));
 
             var result = _importer.ImportField(field);
 
@@ -238,9 +238,9 @@ namespace AsmResolver.DotNet.Tests
         {
             var type = new TypeDefinition(null, "Type", TypeAttributes.Public);
             _module.TopLevelTypes.Add(type);
-            
-            var field = new FieldDefinition("Method", FieldAttributes.Public | FieldAttributes.Static,
-                FieldSignature.CreateStatic(_module.CorLibTypeFactory.Void));
+
+            var field = new FieldDefinition("Field", FieldAttributes.Public | FieldAttributes.Static,
+                new FieldSignature(_module.CorLibTypeFactory.Int32));
             type.Fields.Add(field);
 
             var result = _importer.ImportField(field);
@@ -254,7 +254,7 @@ namespace AsmResolver.DotNet.Tests
             var field = typeof(string).GetField("Empty");
 
             var result = _importer.ImportField(field);
-            
+
             Assert.Equal(field.Name, result.Name);
             Assert.Equal(field.DeclaringType.FullName, result.DeclaringType.FullName);
             Assert.Equal(field.FieldType.FullName, ((FieldSignature) result.Signature).FieldType.FullName);

--- a/test/AsmResolver.DotNet.Tests/Signatures/GenericContextTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Signatures/GenericContextTest.cs
@@ -272,8 +272,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
             var genericParameter = new GenericParameterSignature(GenericParameterType.Type, 0);
 
-            var field = new FieldDefinition("Field", FieldAttributes.Private,
-                FieldSignature.CreateStatic(genericParameter));
+            var field = new FieldDefinition("Field", FieldAttributes.Private, genericParameter);
 
             var member = new MemberReference(typeSpecification, field.Name, field.Signature);
 
@@ -292,8 +291,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
             var type = new TypeDefinition("", "Test type", TypeAttributes.Public);
             var notGenericSignature = new TypeDefOrRefSignature(type);
 
-            var field = new FieldDefinition("Field", FieldAttributes.Private,
-                FieldSignature.CreateStatic(notGenericSignature));
+            var field = new FieldDefinition("Field", FieldAttributes.Private, notGenericSignature);
 
             var member = new MemberReference(type, field.Name, field.Signature);
 

--- a/test/AsmResolver.DotNet.Tests/TokenAllocatorTest.cs
+++ b/test/AsmResolver.DotNet.Tests/TokenAllocatorTest.cs
@@ -98,14 +98,8 @@ namespace AsmResolver.DotNet.Tests
 
             // Create two dummy fields.
             var fieldType = module.CorLibTypeFactory.Object;
-            var field1 = new FieldDefinition(
-                "NonAssignedField",
-                FieldAttributes.Static,
-                new FieldSignature(fieldType));
-            var field2 = new FieldDefinition(
-                "AssignedField",
-                FieldAttributes.Static,
-                new FieldSignature(fieldType));
+            var field1 = new FieldDefinition("NonAssignedField", FieldAttributes.Static, fieldType);
+            var field2 = new FieldDefinition("AssignedField", FieldAttributes.Static, fieldType);
 
             // Add both.
             var moduleType = module.GetOrCreateModuleType();

--- a/test/AsmResolver.DotNet.Tests/TokenAllocatorTest.cs
+++ b/test/AsmResolver.DotNet.Tests/TokenAllocatorTest.cs
@@ -98,10 +98,14 @@ namespace AsmResolver.DotNet.Tests
 
             // Create two dummy fields.
             var fieldType = module.CorLibTypeFactory.Object;
-            var field1 = new FieldDefinition("NonAssignedField", FieldAttributes.Static,
-                FieldSignature.CreateStatic(fieldType));
-            var field2 = new FieldDefinition("AssignedField", FieldAttributes.Static,
-                FieldSignature.CreateStatic(fieldType));
+            var field1 = new FieldDefinition(
+                "NonAssignedField",
+                FieldAttributes.Static,
+                new FieldSignature(fieldType));
+            var field2 = new FieldDefinition(
+                "AssignedField",
+                FieldAttributes.Static,
+                new FieldSignature(fieldType));
 
             // Add both.
             var moduleType = module.GetOrCreateModuleType();


### PR DESCRIPTION
The HasThis bit is ignored by the CLR. It is therefore not a good representation of whether a field is static or not, and it should therefore not be promoted to be used either.