### PR TITLE
Unresolved method bodies

### DIFF
--- a/src/AsmResolver.DotNet/Code/MethodBody.cs
+++ b/src/AsmResolver.DotNet/Code/MethodBody.cs
@@ -3,7 +3,7 @@ using System;
 namespace AsmResolver.DotNet.Code
 {
     /// <summary>
-    /// Represents a body of a method defined in a .NET assembly. 
+    /// Represents a body of a method defined in a .NET assembly.
     /// </summary>
     public abstract class MethodBody
     {
@@ -13,15 +13,25 @@ namespace AsmResolver.DotNet.Code
         /// <param name="owner">The owner of the method body.</param>
         protected MethodBody(MethodDefinition owner)
         {
-            Owner = owner ?? throw new ArgumentNullException(nameof(owner));            
+            Owner = owner ?? throw new ArgumentNullException(nameof(owner));
         }
-        
+
         /// <summary>
         /// Gets the method that owns the method body.
         /// </summary>
         public MethodDefinition Owner
         {
             get;
+        }
+
+        /// <summary>
+        /// When this method is stored in a serialized module, gets or sets the reference to the beginning of the
+        /// raw contents of the body.
+        /// </summary>
+        public ISegmentReference? Address
+        {
+            get;
+            set;
         }
     }
 }

--- a/src/AsmResolver.DotNet/Code/UnresolvedMethodBody.cs
+++ b/src/AsmResolver.DotNet/Code/UnresolvedMethodBody.cs
@@ -1,7 +1,8 @@
 namespace AsmResolver.DotNet.Code
 {
     /// <summary>
-    /// Represents a method body that was not resolved into
+    /// Provides a wrapper around a <see cref="ISegmentReference"/>, pointing to the beginning of a method body.
+    /// The interpretation of the data behind the pointer was left to the user.
     /// </summary>
     public class UnresolvedMethodBody : MethodBody
     {

--- a/src/AsmResolver.DotNet/Code/UnresolvedMethodBody.cs
+++ b/src/AsmResolver.DotNet/Code/UnresolvedMethodBody.cs
@@ -1,0 +1,19 @@
+namespace AsmResolver.DotNet.Code
+{
+    /// <summary>
+    /// Represents a method body that was not resolved into
+    /// </summary>
+    public class UnresolvedMethodBody : MethodBody
+    {
+        /// <summary>
+        /// Creates a new unresolved method body stub.
+        /// </summary>
+        /// <param name="owner">The owner of the method body.</param>
+        /// <param name="address">The reference to the start of the method body.</param>
+        public UnresolvedMethodBody(MethodDefinition owner, ISegmentReference address)
+            : base(owner)
+        {
+            Address = address;
+        }
+    }
+}

--- a/src/AsmResolver.DotNet/Serialized/DefaultMethodBodyReader.cs
+++ b/src/AsmResolver.DotNet/Serialized/DefaultMethodBodyReader.cs
@@ -23,17 +23,18 @@ namespace AsmResolver.DotNet.Serialized
 
             try
             {
-                if (bodyReference.IsBounded)
-                {
-                    if (bodyReference.GetSegment() is CilRawMethodBody rawMethodBody)
-                        result = CilMethodBody.FromRawMethodBody(context, owner, rawMethodBody);
-                }
-                else if (bodyReference.CanRead && owner.IsIL)
+                if (bodyReference.CanRead && owner.IsIL)
                 {
                     var reader = bodyReference.CreateReader();
                     var rawBody = CilRawMethodBody.FromReader(context, ref reader);
                     if (rawBody is not null)
                         result = CilMethodBody.FromRawMethodBody(context, owner, rawBody);
+                }
+
+                if (result is null && bodyReference.IsBounded)
+                {
+                    if (bodyReference.GetSegment() is CilRawMethodBody rawMethodBody)
+                        result = CilMethodBody.FromRawMethodBody(context, owner, rawMethodBody);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
- Add `MethodBody.Address`, containing the reference within the input file if the method came from a serialized module.
- Fixes exceptions being thrown upon trying to read native method bodies from serialized modules.
- Replaces any unrecognized method body type with an instance of `UnresolvedMethodBody`.