### PR TITLE
Feature/Minor Performance Improvement

### DIFF
--- a/src/AsmResolver.DotNet/Code/Cil/StackImbalanceException.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/StackImbalanceException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace AsmResolver.DotNet.Code.Cil
 {
@@ -13,8 +13,7 @@ namespace AsmResolver.DotNet.Code.Cil
         /// <param name="body">The method body in which the inconsistency was detected.</param>
         /// <param name="offset">The offset at which the inconsistency was detected.</param>
         public StackImbalanceException(CilMethodBody body, int offset)
-            : base(string.Format("Stack imbalance was detected at offset IL_{0:X4} in method body of {1}",
-                offset, body.Owner))
+            : base($"Stack imbalance was detected at offset IL_{offset:X4} in method body of {body.Owner}")
         {
             Body = body;
             Offset = offset;

--- a/src/AsmResolver.DotNet/Memory/TypeMemoryLayoutDetector.cs
+++ b/src/AsmResolver.DotNet/Memory/TypeMemoryLayoutDetector.cs
@@ -251,10 +251,8 @@ namespace AsmResolver.DotNet.Memory
                 // All fields in an explicitly laid out structure need to have a field offset assigned.
                 if (!field.FieldOffset.HasValue)
                 {
-                    throw new ArgumentException(string.Format(
-                        "{0} ({1}) is defined in a type with explicit layout, but does not have a field offset assigned.",
-                        field.FullName,
-                        field.MetadataToken.ToString()));
+                    throw new ArgumentException(
+                        $"{field.FullName} ({field.MetadataToken}) is defined in a type with explicit layout, but does not have a field offset assigned.");
                 }
 
                 uint offset = (uint) field.FieldOffset.Value;

--- a/src/AsmResolver.DotNet/Signatures/MemberSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/MemberSignature.cs
@@ -30,9 +30,9 @@ namespace AsmResolver.DotNet.Signatures
         /// <inheritdoc />
         public override string ToString()
         {
-            return string.Format("{0}{1}",
-                HasThis ? "instance " : string.Empty,
-                MemberReturnType?.FullName ?? TypeSignature.NullTypeToString);
+            string prefix = HasThis ? "instance " : string.Empty;
+            string fullName = MemberReturnType?.FullName ?? TypeSignature.NullTypeToString;
+            return $"{prefix}{fullName}";
         }
     }
 }

--- a/src/AsmResolver.DotNet/Signatures/MethodSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/MethodSignature.cs
@@ -207,16 +207,13 @@ namespace AsmResolver.DotNet.Signatures
         public override string ToString()
         {
             string prefix = HasThis ? "instance " : string.Empty;
+            string fullName = ReturnType?.FullName ?? TypeSignature.NullTypeToString;
             string genericsString = GenericParameterCount > 0
                 ? $"<{string.Join(", ", new string('?', GenericParameterCount))}>"
                 : string.Empty;
             string parameterTypesString = string.Join(", ", ParameterTypes) + (IsSentinel ? ", ..." : string.Empty);
 
-            return string.Format("{0}{1} *{2}({3})",
-                prefix,
-                ReturnType?.FullName ?? TypeSignature.NullTypeToString,
-                genericsString,
-                parameterTypesString);
+            return $"{prefix}{fullName} *{genericsString}({parameterTypesString})";
         }
     }
 }

--- a/src/AsmResolver.DotNet/Signatures/PropertySignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/PropertySignature.cs
@@ -126,10 +126,7 @@ namespace AsmResolver.DotNet.Signatures
                 ? $"[{string.Join(", ", ParameterTypes)}]"
                 : string.Empty;
 
-            return string.Format("{0}{1} *{2}",
-                prefix,
-                ReturnType.FullName,
-                parameterTypesString);
+            return $"{prefix}{ReturnType.FullName} *{parameterTypesString}";
         }
     }
 }

--- a/src/AsmResolver.DotNet/Signatures/Security/SecurityAttribute.cs
+++ b/src/AsmResolver.DotNet/Signatures/Security/SecurityAttribute.cs
@@ -107,7 +107,6 @@ namespace AsmResolver.DotNet.Signatures.Security
 
 
         /// <inheritdoc />
-        public override string ToString() =>
-            string.Format("{0}({1})", AttributeType, string.Join(", ", NamedArguments));
+        public override string ToString() => $"{AttributeType}({string.Join(", ", NamedArguments)})";
     }
 }


### PR DESCRIPTION
This pull request replaces a few uses of `string.Format` with string interpolation.

I also did some performance testing on the potential benefits of having .NET 6 targets.

### Testing code:
```cs
using System;
using System.Diagnostics;
using System.IO;
using AsmResolver.DotNet;

namespace SpeedTestNet6
{
    internal class Program
    {
        private const string OutputPath = "output.dll";
        private const int NumTests = 100;
        private static Stopwatch stopwatch = new Stopwatch();

        static void Main(string[] args)
        {
            long[] results = RunTests();
            PrintStatistics(results);
            Console.ReadLine();
        }

        private static void PrintStatistics(long[] data)
        {
            Console.WriteLine();
            double mean = Average(data);
            Console.WriteLine($"Mean: {mean}");
            double stddev = StandardDeviation(data, mean);
            Console.WriteLine($"StdDev: {stddev}");
        }

        private static double Average(long[] data)
        {
            double sum = 0;
            for (int i = 0; i < data.Length; i++)
            {
                sum += data[i];
            }
            return sum / data.Length;
        }

        private static double StandardDeviation(long[] data, double mean)
        {
            double sum = 0;
            for(int i = 0; i < data.Length; i++)
            {
                sum += System.Math.Pow(data[i] - mean, 2);
            }
            double variance = sum / (data.Length - 1);
            return System.Math.Sqrt(variance);
        }

        private static long[] RunTests()
        {
            RunTest();
            Console.WriteLine("Discarded initial test"); //first test was always significantly longer than the others
            long[] testResults = new long[NumTests];
            for(int i = 0; i < NumTests; i++)
            {
                testResults[i] = RunTest();
                Console.WriteLine($"Test {i + 1}: {testResults[i]} ms");
            }
            return testResults;
        }

        private static long RunTest()
        {
            if (File.Exists(OutputPath))
                File.Delete(OutputPath);
            stopwatch.Restart();
            AssemblyDefinition assembly = AssemblyDefinition.FromFile(@"C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.22\System.Private.CoreLib.dll");
            assembly.Write(OutputPath);
            stopwatch.Stop();
            return stopwatch.ElapsedMilliseconds;
        }
    }
}
```

### Results:

|  | NET Standard | NET 6 |
| --------- | --------------- | ------ |
| Mean | 1329.66 | 1303.27 |
| Standard Deviation | 48.86 | 40.06 |

Do you consider this significant enough to justify .NET 6 targets? I excluded them from the commit for this pull request because I thought the justification was dubious.