### PR TITLE
Other .NET Runtime Build Targets

### DIFF
--- a/src/AsmResolver.DotNet/AsmResolver.DotNet.csproj
+++ b/src/AsmResolver.DotNet/AsmResolver.DotNet.csproj
@@ -4,11 +4,11 @@
         <Title>AsmResolver.DotNet</Title>
         <Description>High level .NET image models for the AsmResolver executable file inspection toolsuite.</Description>
         <PackageTags>exe pe directories imports exports resources dotnet cil inspection manipulation assembly disassembly</PackageTags>
-        <TargetFramework>netstandard2.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <NoWarn>1701;1702;NU5105</NoWarn>
         <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
+        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/AsmResolver.DotNet/AssemblyDefinition.cs
+++ b/src/AsmResolver.DotNet/AssemblyDefinition.cs
@@ -280,11 +280,14 @@ namespace AsmResolver.DotNet
             if (directory is null || !Directory.Exists(directory))
                 throw new DirectoryNotFoundException();
 
-            foreach (var module in Modules)
+            for (int i = 0; i < Modules.Count; i++)
             {
-                string modulePath = module == ManifestModule
-                    ? filePath
-                    : Path.Combine(directory, module.Name);
+                var module = Modules[i];
+                string modulePath;
+                if (module == ManifestModule)
+                    modulePath = filePath;
+                else
+                    modulePath = Path.Combine(directory, module.Name ?? $"module{i}.bin");
 
                 module.Write(modulePath, imageBuilder, fileBuilder);
             }

--- a/src/AsmResolver.DotNet/Builder/DotNetDirectoryBuffer.MemberTree.cs
+++ b/src/AsmResolver.DotNet/Builder/DotNetDirectoryBuffer.MemberTree.cs
@@ -302,7 +302,7 @@ namespace AsmResolver.DotNet.Builder
             for (uint rid = 1; rid <= typeDefTable.Count; rid++)
             {
                 var typeToken = new MetadataToken(TableIndex.TypeDef, rid);
-                var type = _tokenMapping.GetTypeByToken(typeToken);
+                var type = _tokenMapping.GetTypeByToken(typeToken)!;
 
                 // Update extends, field list and method list columns.
                 ref var typeRow = ref typeDefTable.GetRowRef(rid);
@@ -409,7 +409,7 @@ namespace AsmResolver.DotNet.Builder
             for (uint rid = 1; rid <= definitionTable.Count; rid++)
             {
                 var newToken = new MetadataToken(TableIndex.Method, rid);
-                var method = _tokenMapping.GetMethodByToken(newToken);
+                var method = _tokenMapping.GetMethodByToken(newToken)!;
 
                 // Serialize method body and update column.
                 ref var row = ref definitionTable.GetRowRef(rid);

--- a/src/AsmResolver.DotNet/Builder/Metadata/Strings/StringsStreamBlobSuffixComparer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Strings/StringsStreamBlobSuffixComparer.cs
@@ -29,8 +29,15 @@ namespace AsmResolver.DotNet.Builder.Metadata.Strings
         }
 
         /// <inheritdoc />
-        public int Compare(byte[] x, byte[] y)
+        public int Compare(byte[]? x, byte[]? y)
         {
+            if (ReferenceEquals(x, y))
+                return 0;
+            if (x is null)
+                return -1;
+            if (y is null)
+                return 1;
+
             for (int i = x.Length - 1, j = y.Length - 1; i >= 0 && j >= 0; i--, j--)
             {
                 int charComparison = x[i].CompareTo(y[j]);

--- a/src/AsmResolver.DotNet/Builder/Metadata/Tables/SortedMetadataTableBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Tables/SortedMetadataTableBuffer.cs
@@ -12,6 +12,7 @@ namespace AsmResolver.DotNet.Builder.Metadata.Tables
     /// <typeparam name="TKey">The type of members that are assigned new metadata rows.</typeparam>
     /// <typeparam name="TRow">The type of rows to store.</typeparam>
     public class SortedMetadataTableBuffer<TKey, TRow> : ISortedMetadataTableBuffer<TKey, TRow>
+        where TKey : notnull
         where TRow : struct, IMetadataRow
     {
         private readonly List<(TKey Key, TRow Row)> _entries = new();

--- a/src/AsmResolver.DotNet/Builder/Metadata/Tables/TablesStreamBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Tables/TablesStreamBuffer.cs
@@ -183,6 +183,7 @@ namespace AsmResolver.DotNet.Builder.Metadata.Tables
         }
 
         private ISortedMetadataTableBuffer<TKey, TRow> Sorted<TKey, TRow>(TableIndex table, int primaryColumn)
+            where TKey : notnull
             where TRow : struct, IMetadataRow
         {
             return new SortedMetadataTableBuffer<TKey, TRow>(
@@ -191,6 +192,7 @@ namespace AsmResolver.DotNet.Builder.Metadata.Tables
         }
 
         private ISortedMetadataTableBuffer<TKey, TRow> Sorted<TKey, TRow>(TableIndex table, int primaryColumn, int secondaryColumn)
+            where TKey : notnull
             where TRow : struct, IMetadataRow
         {
             return new SortedMetadataTableBuffer<TKey, TRow>(

--- a/src/AsmResolver.DotNet/Builder/TokenMapping.cs
+++ b/src/AsmResolver.DotNet/Builder/TokenMapping.cs
@@ -102,13 +102,13 @@ namespace AsmResolver.DotNet.Builder
         /// </summary>
         /// <param name="newToken">The new token.</param>
         /// <returns>The type, or <c>null</c> if no type is assigned to the provided token.</returns>
-        public TypeDefinition GetTypeByToken(MetadataToken newToken) => _typeDefTokens.GetKey(newToken);
+        public TypeDefinition? GetTypeByToken(MetadataToken newToken) => _typeDefTokens.GetKey(newToken);
 
         /// <summary>
         /// Gets the method assigned to the provided metadata token.
         /// </summary>
         /// <param name="newToken">The new token.</param>
         /// <returns>The type, or <c>null</c> if no method is assigned to the provided token.</returns>
-        public MethodDefinition GetMethodByToken(MetadataToken newToken) => _methodTokens.GetKey(newToken);
+        public MethodDefinition? GetMethodByToken(MetadataToken newToken) => _methodTokens.GetKey(newToken);
     }
 }

--- a/src/AsmResolver.DotNet/Code/Cil/CilMethodBody.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilMethodBody.cs
@@ -147,7 +147,7 @@ namespace AsmResolver.DotNet.Code.Cil
             //Get Runtime Fields
             byte[] code = FieldReader.ReadField<byte[]>(dynamicMethodObj, "m_code")!;
             object scope = FieldReader.ReadField<object>(dynamicMethodObj, "m_scope")!;
-            var tokenList = FieldReader.ReadField<List<object>>(scope, "m_tokens")!;
+            var tokenList = FieldReader.ReadField<List<object?>>(scope, "m_tokens")!;
             byte[] localSig = FieldReader.ReadField<byte[]>(dynamicMethodObj, "m_localSignature")!;
             byte[] ehHeader = FieldReader.ReadField<byte[]>(dynamicMethodObj, "m_exceptionHeader")!;
             var ehInfos = FieldReader.ReadField<IList<object>>(dynamicMethodObj, "m_exceptions")!;

--- a/src/AsmResolver.DotNet/DotNetCoreAssemblyResolver.cs
+++ b/src/AsmResolver.DotNet/DotNetCoreAssemblyResolver.cs
@@ -172,10 +172,14 @@ namespace AsmResolver.DotNet
             public static readonly RuntimeNameComparer Instance = new();
 
             /// <inheritdoc />
-            public int Compare(string x, string y)
+            public int Compare(string? x, string? y)
             {
                 if (x == y)
                     return 0;
+                if (x is null)
+                    return -1;
+                if (y is null)
+                    return 1;
                 if (x == KnownRuntimeNames.NetCoreApp)
                     return 1;
                 if (y == KnownRuntimeNames.NetCoreApp)

--- a/src/AsmResolver.DotNet/DynamicMethodHelper.cs
+++ b/src/AsmResolver.DotNet/DynamicMethodHelper.cs
@@ -60,7 +60,7 @@ namespace AsmResolver.DotNet
                 int tryEnd = FieldReader.ReadField<int>(ehInfo, "m_endAddr");
                 int handlerStart = FieldReader.ReadField<int[]>(ehInfo, "m_catchAddr")![i];
                 int handlerEnd = FieldReader.ReadField<int[]>(ehInfo, "m_catchEndAddr")![i];
-                var exceptionType = FieldReader.ReadField<Type[]>(ehInfo, "m_catchClass")![i];
+                var exceptionType = FieldReader.ReadField<Type?[]>(ehInfo, "m_catchClass")![i];
                 var handlerType = (CilExceptionHandlerType) FieldReader.ReadField<int[]>(ehInfo, "m_type")![i];
 
                 var endTryLabel = instructions.GetByOffset(tryEnd)?.CreateLabel() ?? new CilOffsetLabel(tryEnd);
@@ -74,7 +74,7 @@ namespace AsmResolver.DotNet
                     FilterStart = null,
                     HandlerStart = instructions.GetLabel(handlerStart),
                     HandlerEnd = instructions.GetLabel(handlerEnd),
-                    ExceptionType = exceptionType != null ? importer.ImportType(exceptionType) : null
+                    ExceptionType = exceptionType is not null ? importer.ImportType(exceptionType) : null
                 };
 
                 methodBody.ExceptionHandlers.Add(handler);
@@ -113,7 +113,7 @@ namespace AsmResolver.DotNet
                 dynamicMethodObj = Activator.CreateInstance(dynamicResolver, (BindingFlags) (-1), null, new[]
                 {
                     ilGenerator
-                }, null);
+                }, null)!;
             }
             return dynamicMethodObj;
         }

--- a/src/AsmResolver.DotNet/ReferenceImporter.cs
+++ b/src/AsmResolver.DotNet/ReferenceImporter.cs
@@ -435,8 +435,8 @@ namespace AsmResolver.DotNet
                 ? ImportTypeSignature(info.ReturnType)
                 : TargetModule.CorLibTypeFactory.Void;
 
-            var parameters = (method.DeclaringType != null && method.DeclaringType.IsConstructedGenericType)
-                ? method.Module.ResolveMethod(method.MetadataToken).GetParameters()
+            var parameters = method.DeclaringType is { IsConstructedGenericType: true }
+                ? method.Module.ResolveMethod(method.MetadataToken)!.GetParameters()
                 : method.GetParameters();
 
             var parameterTypes = new TypeSignature[parameters.Length];
@@ -512,8 +512,8 @@ namespace AsmResolver.DotNet
             if (field is null)
                 throw new ArgumentNullException(nameof(field));
 
-            if (field.DeclaringType != null && field.DeclaringType.IsConstructedGenericType)
-                field = field.Module.ResolveField(field.MetadataToken);
+            if (field.DeclaringType is { IsConstructedGenericType: true })
+                field = field.Module.ResolveField(field.MetadataToken)!;
 
             var scope = field.DeclaringType != null
                 ? ImportType(field.DeclaringType)

--- a/src/AsmResolver.DotNet/ReflectionAssemblyDescriptor.cs
+++ b/src/AsmResolver.DotNet/ReflectionAssemblyDescriptor.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
@@ -22,7 +23,7 @@ namespace AsmResolver.DotNet
         {
             _parentModule = parentModule;
             _assemblyName = assemblyName;
-            Version = assemblyName.Version;
+            Version = assemblyName.Version ?? new Version();
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/SafeExtensions.cs
+++ b/src/AsmResolver.DotNet/SafeExtensions.cs
@@ -11,7 +11,7 @@ namespace AsmResolver.DotNet
 
             try
             {
-                string value = self.ToString();
+                string value = self.ToString()!;
                 if (value.Length > 200)
                     value = $"{value.Remove(197)}... (truncated)";
                 if (self.MetadataToken.Rid != 0)
@@ -31,7 +31,7 @@ namespace AsmResolver.DotNet
 
             try
             {
-                return self.ToString();
+                return self.ToString()!;
             }
             catch
             {

--- a/src/AsmResolver.DotNet/Serialized/SerializedAssemblyDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedAssemblyDefinition.cs
@@ -166,7 +166,7 @@ namespace AsmResolver.DotNet.Serialized
                     continue;
 
                 object? element = attribute.Signature.FixedArguments[0].Element;
-                if (element is string or Utf8String && DotNetRuntimeInfo.TryParse(element.ToString(), out info))
+                if (element is string or Utf8String && DotNetRuntimeInfo.TryParse(element.ToString()!, out info))
                     return true;
             }
 

--- a/src/AsmResolver.DotNet/Signatures/BoxedArgument.cs
+++ b/src/AsmResolver.DotNet/Signatures/BoxedArgument.cs
@@ -41,7 +41,7 @@ namespace AsmResolver.DotNet.Signatures
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return ReferenceEquals(this, obj) || obj is BoxedArgument other && Equals(other);
         }

--- a/src/AsmResolver.DotNet/Signatures/CustomAttributeArgument.cs
+++ b/src/AsmResolver.DotNet/Signatures/CustomAttributeArgument.cs
@@ -118,12 +118,12 @@ namespace AsmResolver.DotNet.Signatures
             return ElementToString(obj);
         }
 
-        private string ElementToString(object? element) => element switch
+        private static string ElementToString(object? element) => element switch
         {
             null => "null",
             IList<object?> list => $"{{{string.Join(", ", list.Select(ElementToString))}}}",
             string x => x.CreateEscapedString(),
-            _ => element.ToString()
+            _ => element.ToString() ?? string.Empty
         };
 
         /// <summary>

--- a/src/AsmResolver.DotNet/Signatures/Types/ArrayDimension.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/ArrayDimension.cs
@@ -3,7 +3,7 @@
 namespace AsmResolver.DotNet.Signatures.Types
 {
     /// <summary>
-    /// Represents a single dimension in an array specification. 
+    /// Represents a single dimension in an array specification.
     /// </summary>
     public readonly struct ArrayDimension : IEquatable<ArrayDimension>
     {
@@ -39,7 +39,7 @@ namespace AsmResolver.DotNet.Signatures.Types
         }
 
         /// <summary>
-        /// Gets or sets the lower bound for each index in the dimension (if specified). 
+        /// Gets or sets the lower bound for each index in the dimension (if specified).
         /// </summary>
         /// <remarks>
         /// When this value is not specified (<c>null</c>), a lower bound of 0 is assumed by the CLR.
@@ -52,12 +52,10 @@ namespace AsmResolver.DotNet.Signatures.Types
         /// <summary>
         /// Determines whether two dimensions are considered equal.
         /// </summary>
-        public bool Equals(ArrayDimension other) => 
-            Size == other.Size && LowerBound == other.LowerBound;
+        public bool Equals(ArrayDimension other) => Size == other.Size && LowerBound == other.LowerBound;
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => 
-            obj is ArrayDimension other && Equals(other);
+        public override bool Equals(object? obj) => obj is ArrayDimension other && Equals(other);
 
         /// <inheritdoc />
         public override int GetHashCode()
@@ -67,6 +65,6 @@ namespace AsmResolver.DotNet.Signatures.Types
                 return (Size.GetHashCode() * 397) ^ LowerBound.GetHashCode();
             }
         }
-        
+
     }
 }

--- a/src/AsmResolver.DotNet/Signatures/Types/TypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/TypeSignature.cs
@@ -23,7 +23,7 @@ namespace AsmResolver.DotNet.Signatures.Types
                     (BindingFlags) (-1),
                     null,
                     new[] {typeof(IntPtr)},
-                    null);
+                    null)!;
         }
 
         /// <inheritdoc />
@@ -163,8 +163,11 @@ namespace AsmResolver.DotNet.Signatures.Types
                     };
 
                     // Let the runtime translate the address to a type and import it.
-                    var clrType = (Type) GetTypeFromHandleUnsafeMethod.Invoke(null, new object[] {address});
-                    var asmResType = new ReferenceImporter(context.ReaderContext.ParentModule).ImportType(clrType);
+                    var clrType = (Type?) GetTypeFromHandleUnsafeMethod.Invoke(null, new object[] { address });
+                    var asmResType = clrType is not null
+                        ? new ReferenceImporter(context.ReaderContext.ParentModule).ImportType(clrType)
+                        : InvalidTypeDefOrRef.Get(InvalidTypeSignatureError.IllegalTypeSpec);
+
                     return new TypeDefOrRefSignature(asmResType);
 
                 default:

--- a/src/AsmResolver.PE.File/AsmResolver.PE.File.csproj
+++ b/src/AsmResolver.PE.File/AsmResolver.PE.File.csproj
@@ -4,12 +4,12 @@
         <Title>AsmResolver.PE.File</Title>
         <Description>Raw PE file models for the AsmResolver executable file inspection toolsuite.</Description>
         <PackageTags>exe pe headers sections inspection manipulation assembly disassembly</PackageTags>
-        <TargetFramework>netstandard2.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <NoWarn>1701;1702;NU5105</NoWarn>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
+        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/AsmResolver.PE.Win32Resources/AsmResolver.PE.Win32Resources.csproj
+++ b/src/AsmResolver.PE.Win32Resources/AsmResolver.PE.Win32Resources.csproj
@@ -3,11 +3,11 @@
     <PropertyGroup>
         <Title>AsmResolver.PE.Win32Resources</Title>
         <PackageTags>exe pe directories imports exports resources dotnet cil inspection manipulation assembly disassembly</PackageTags>
-        <TargetFramework>netstandard2.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <NoWarn>1701;1702;NU5105</NoWarn>
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
+        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/AsmResolver.PE/AsmResolver.PE.csproj
+++ b/src/AsmResolver.PE/AsmResolver.PE.csproj
@@ -4,11 +4,11 @@
         <Title>AsmResolver.PE</Title>
         <Description>PE image models for the AsmResolver executable file inspection toolsuite.</Description>
         <PackageTags>exe pe directories imports exports resources dotnet cil inspection manipulation assembly disassembly</PackageTags>
-        <TargetFramework>netstandard2.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <NoWarn>1701;1702;NU5105</NoWarn>
         <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
+        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/AsmResolver.PE/DotNet/Cil/CilInstructionFormatter.cs
+++ b/src/AsmResolver.PE/DotNet/Cil/CilInstructionFormatter.cs
@@ -87,7 +87,7 @@ namespace AsmResolver.PE.DotNet.Cil
             short longIndex => $"A_{longIndex.ToString()}",
             byte shortIndex => $"A_{shortIndex.ToString()}",
             null => InvalidOperandString,
-            _ => operand.ToString()
+            _ => operand.ToString() ?? string.Empty
         };
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace AsmResolver.PE.DotNet.Cil
             short longIndex => $"V_{longIndex.ToString()}",
             byte shortIndex => $"V_{shortIndex.ToString()}",
             null => InvalidOperandString,
-            _ => operand.ToString()
+            _ => operand.ToString() ?? string.Empty
         };
 
         /// <summary>
@@ -130,7 +130,7 @@ namespace AsmResolver.PE.DotNet.Cil
         {
             MetadataToken token => FormatToken(token),
             null => InvalidOperandString,
-            _ => operand.ToString()
+            _ => operand.ToString() ?? string.Empty
         };
 
         /// <summary>
@@ -150,7 +150,7 @@ namespace AsmResolver.PE.DotNet.Cil
             IEnumerable<ICilLabel> target => $"({string.Join(", ", target.Select(FormatBranchTarget))})",
             IEnumerable<int> offsets => $"({string.Join(", ", offsets.Select(x => FormatBranchTarget(x)))})",
             null => InvalidOperandString,
-            _ => operand.ToString()
+            _ => operand.ToString() ?? string.Empty
         };
 
         /// <summary>
@@ -175,7 +175,7 @@ namespace AsmResolver.PE.DotNet.Cil
             ICilLabel target => FormatLabel(target.Offset),
             int offset => FormatLabel(offset),
             null => InvalidOperandString,
-            _ => operand.ToString()
+            _ => operand.ToString() ?? string.Empty
         };
 
         /// <summary>
@@ -187,7 +187,7 @@ namespace AsmResolver.PE.DotNet.Cil
         {
             MetadataToken token => FormatToken(token),
             null => InvalidOperandString,
-            _ => operand.ToString()
+            _ => operand.ToString() ?? string.Empty
         };
 
     }

--- a/src/AsmResolver.PE/DotNet/Cil/CilInstructionLabel.cs
+++ b/src/AsmResolver.PE/DotNet/Cil/CilInstructionLabel.cs
@@ -39,7 +39,7 @@ namespace AsmResolver.PE.DotNet.Cil
         public bool Equals(ICilLabel? other) => other is not null && Offset == other.Offset;
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as ICilLabel);
+        public override bool Equals(object? obj) => Equals(obj as ICilLabel);
 
         /// <inheritdoc />
         public override int GetHashCode() => Offset;

--- a/src/AsmResolver.PE/DotNet/Cil/CilOffsetLabel.cs
+++ b/src/AsmResolver.PE/DotNet/Cil/CilOffsetLabel.cs
@@ -27,7 +27,7 @@ namespace AsmResolver.PE.DotNet.Cil
         public bool Equals(ICilLabel? other) => other is not null && Offset == other.Offset;
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as ICilLabel);
+        public override bool Equals(object? obj) => Equals(obj as ICilLabel);
 
         /// <inheritdoc />
         public override int GetHashCode() => Offset;

--- a/src/AsmResolver.PE/DotNet/Cil/CilOpCode.cs
+++ b/src/AsmResolver.PE/DotNet/Cil/CilOpCode.cs
@@ -1,7 +1,7 @@
 namespace AsmResolver.PE.DotNet.Cil
 {
     /// <summary>
-    /// Describes the operation that a single CIL instruction performs.  
+    /// Describes the operation that a single CIL instruction performs.
     /// </summary>
     public readonly struct CilOpCode
     {
@@ -10,7 +10,7 @@ namespace AsmResolver.PE.DotNet.Cil
 
         internal const int TwoBytesBitLength = 1;
         internal const int TwoBytesOffset = ValueOffset + ValueBitLength;
-        
+
         internal const int StackBehaviourBitLength = 5;
         internal const int StackBehaviourPushOffset = TwoBytesOffset + TwoBytesBitLength;
         internal const int StackBehaviourPopOffset = StackBehaviourPushOffset + StackBehaviourBitLength;
@@ -55,13 +55,13 @@ namespace AsmResolver.PE.DotNet.Cil
         internal CilOpCode(uint value)
         {
             _value = value;
-            
+
             if (IsLarge)
                 CilOpCodes.MultiByteOpCodes[Byte2] = this;
             else
                 CilOpCodes.SingleByteOpCodes[Byte1] = this;
         }
-        
+
         /// <summary>
         /// Gets the mnemonic of the operation code.
         /// </summary>
@@ -135,7 +135,7 @@ namespace AsmResolver.PE.DotNet.Cil
         public bool Equals(CilOpCode other) => Code == other.Code;
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is CilOpCode other && Equals(other);
+        public override bool Equals(object? obj) => obj is CilOpCode other && Equals(other);
 
         /// <inheritdoc />
         public override int GetHashCode() => (int) Code;

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/MetadataToken.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/MetadataToken.cs
@@ -3,7 +3,7 @@ using System;
 namespace AsmResolver.PE.DotNet.Metadata.Tables
 {
     /// <summary>
-    /// Represents a metadata token, referencing a member using a table and a row index. 
+    /// Represents a metadata token, referencing a member using a table and a row index.
     /// </summary>
     public readonly struct MetadataToken : IComparable<MetadataToken>
     {
@@ -11,7 +11,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables
         /// Represents the zero metadata token, or the absence of a metadata token.
         /// </summary>
         public static readonly MetadataToken Zero = new MetadataToken(0);
-        
+
         /// <summary>
         /// Converts a 32-bit integer to a metadata token.
         /// </summary>
@@ -43,7 +43,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables
         {
             return a.Equals(b);
         }
-        
+
         /// <summary>
         /// Determines whether two metadata tokens are not considered equal. That is, either the table index or the row
         /// identifier (or both) does not match the other.
@@ -119,7 +119,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is MetadataToken other && Equals(other);
         }
@@ -135,6 +135,6 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables
         {
             return _value.CompareTo(other._value);
         }
-        
+
     }
 }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyDefinitionRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyDefinitionRow.cs
@@ -200,7 +200,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is AssemblyDefinitionRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyOSRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyOSRow.cs
@@ -100,7 +100,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is AssemblyOSRow other && Equals(other);
+        public override bool Equals(object? obj) => obj is AssemblyOSRow other && Equals(other);
 
         /// <inheritdoc />
         public override int GetHashCode()

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyProcessorRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyProcessorRow.cs
@@ -69,7 +69,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is AssemblyProcessorRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyRefOSRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyRefOSRow.cs
@@ -117,7 +117,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is AssemblyRefOSRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyRefProcessorRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyRefProcessorRow.cs
@@ -85,7 +85,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is AssemblyRefProcessorRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyReferenceRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/AssemblyReferenceRow.cs
@@ -199,7 +199,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is AssemblyReferenceRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ClassLayoutRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ClassLayoutRow.cs
@@ -101,7 +101,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is ClassLayoutRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ConstantRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ConstantRow.cs
@@ -133,7 +133,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is ConstantRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/CustomAttributeRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/CustomAttributeRow.cs
@@ -105,7 +105,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is CustomAttributeRow other && Equals(other);
+        public override bool Equals(object? obj) => obj is CustomAttributeRow other && Equals(other);
 
         /// <inheritdoc />
         public override int GetHashCode()

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/EncLogRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/EncLogRow.cs
@@ -84,7 +84,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is EncLogRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/EncMapRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/EncMapRow.cs
@@ -69,7 +69,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is EncMapRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/EventDefinitionRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/EventDefinitionRow.cs
@@ -103,7 +103,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is EventDefinitionRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/EventMapRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/EventMapRow.cs
@@ -84,7 +84,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is EventMapRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/EventPointerRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/EventPointerRow.cs
@@ -69,7 +69,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is EventPointerRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ExportedTypeRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ExportedTypeRow.cs
@@ -143,7 +143,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is ExportedTypeRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FieldDefinitionRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FieldDefinitionRow.cs
@@ -103,7 +103,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is FieldDefinitionRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FieldLayoutRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FieldLayoutRow.cs
@@ -84,7 +84,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is FieldLayoutRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FieldMarshalRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FieldMarshalRow.cs
@@ -86,7 +86,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is FieldMarshalRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FieldPointerRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FieldPointerRow.cs
@@ -70,7 +70,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
 
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is FieldPointerRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FieldRvaRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FieldRvaRow.cs
@@ -93,7 +93,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is FieldRvaRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FileReferenceRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/FileReferenceRow.cs
@@ -98,7 +98,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is FileReferenceRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/GenericParameterConstraintRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/GenericParameterConstraintRow.cs
@@ -86,7 +86,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is GenericParameterConstraintRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/GenericParameterRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/GenericParameterRow.cs
@@ -116,7 +116,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is GenericParameterRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ImplementationMapRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ImplementationMapRow.cs
@@ -116,7 +116,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is ImplementationMapRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/InterfaceImplementationRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/InterfaceImplementationRow.cs
@@ -86,7 +86,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is InterfaceImplementationRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ManifestResourceRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ManifestResourceRow.cs
@@ -120,7 +120,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is ManifestResourceRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MemberReferenceRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MemberReferenceRow.cs
@@ -107,7 +107,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is MemberReferenceRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MethodDefinitionRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MethodDefinitionRow.cs
@@ -168,7 +168,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is MethodDefinitionRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MethodImplementationRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MethodImplementationRow.cs
@@ -117,7 +117,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is MethodImplementationRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MethodPointerRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MethodPointerRow.cs
@@ -69,7 +69,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is MethodPointerRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MethodSemanticsRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MethodSemanticsRow.cs
@@ -115,7 +115,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is MethodSemanticsRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MethodSpecificationRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/MethodSpecificationRow.cs
@@ -84,7 +84,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is MethodSpecificationRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ModuleDefinitionRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ModuleDefinitionRow.cs
@@ -142,7 +142,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is ModuleDefinitionRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ModuleReferenceRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ModuleReferenceRow.cs
@@ -70,7 +70,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is ModuleReferenceRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/NestedClassRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/NestedClassRow.cs
@@ -84,7 +84,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is NestedClassRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ParameterDefinitionRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ParameterDefinitionRow.cs
@@ -101,7 +101,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is ParameterDefinitionRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ParameterPointerRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/ParameterPointerRow.cs
@@ -69,7 +69,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is ParameterPointerRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/PropertyDefinitionRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/PropertyDefinitionRow.cs
@@ -116,7 +116,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is PropertyDefinitionRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/PropertyMapRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/PropertyMapRow.cs
@@ -99,7 +99,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is PropertyMapRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/PropertyPointerRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/PropertyPointerRow.cs
@@ -69,7 +69,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is PropertyPointerRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/SecurityDeclarationRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/SecurityDeclarationRow.cs
@@ -99,7 +99,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is SecurityDeclarationRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/StandAloneSignatureRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/StandAloneSignatureRow.cs
@@ -69,7 +69,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is StandAloneSignatureRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/TypeDefinitionRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/TypeDefinitionRow.cs
@@ -160,7 +160,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is TypeDefinitionRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/TypeReferenceRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/TypeReferenceRow.cs
@@ -114,7 +114,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is TypeReferenceRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/TypeSpecificationRow.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/Rows/TypeSpecificationRow.cs
@@ -70,7 +70,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables.Rows
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is TypeSpecificationRow other && Equals(other);
         }

--- a/src/AsmResolver.PE/DotNet/Metadata/UserStrings/SerializedUserStringsStream.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/UserStrings/SerializedUserStringsStream.cs
@@ -9,7 +9,7 @@ namespace AsmResolver.PE.DotNet.Metadata.UserStrings
     /// </summary>
     public class SerializedUserStringsStream : UserStringsStream
     {
-        private readonly Dictionary<uint, string> _cachedStrings = new();
+        private readonly Dictionary<uint, string?> _cachedStrings = new();
         private readonly BinaryStreamReader _reader;
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace AsmResolver.PE.DotNet.Metadata.UserStrings
         {
             index &= 0x00FFFFFF;
 
-            if (!_cachedStrings.TryGetValue(index, out string value) && index < _reader.Length)
+            if (!_cachedStrings.TryGetValue(index, out string? value) && index < _reader.Length)
             {
                 var stringsReader = _reader.ForkRelative(index);
 

--- a/src/AsmResolver.PE/DotNet/StrongName/StrongNameDataHashBuilder.cs
+++ b/src/AsmResolver.PE/DotNet/StrongName/StrongNameDataHashBuilder.cs
@@ -65,7 +65,7 @@ namespace AsmResolver.PE.DotNet.StrongName
                 _ => throw new NotSupportedException($"Invalid or unsupported hashing algorithm {_hashAlgorithm}.")
             };
 
-            var buffer = new byte[0x1000];
+            byte[] buffer = new byte[0x1000];
 
             foreach (var range in _includedRanges)
             {
@@ -85,7 +85,7 @@ namespace AsmResolver.PE.DotNet.StrongName
             }
 
             algorithm.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
-            return algorithm.Hash;
+            return algorithm.Hash!;
         }
 
         private void ZeroRangesIfApplicable(byte[] buffer, OffsetRange currentRange)

--- a/src/AsmResolver.PE/DotNet/StrongName/StrongNamePrivateKey.cs
+++ b/src/AsmResolver.PE/DotNet/StrongName/StrongNamePrivateKey.cs
@@ -92,16 +92,19 @@ namespace AsmResolver.PE.DotNet.StrongName
         /// </summary>
         /// <param name="parameters">The RSA parameters to import.</param>
         public StrongNamePrivateKey(in RSAParameters parameters)
-            : base(parameters.Modulus, ByteSwap(parameters))
+            : base(parameters.Modulus ?? throw new ArgumentException("The provided RSA parameters do not define a modulus."),
+                ByteSwap(parameters))
         {
             Modulus = parameters.Modulus;
-            P = parameters.P;
-            Q = parameters.Q;
-            DP = parameters.DP;
-            DQ = parameters.DQ;
+            P = parameters.P ?? throw new ArgumentException("The provided RSA parameters do not define prime P.");
+            Q = parameters.Q ?? throw new ArgumentException("The provided RSA parameters do not define prime Q.");;
+            DP = parameters.DP ?? throw new ArgumentException("The provided RSA parameters do not define DP.");;
+            DQ = parameters.DQ ?? throw new ArgumentException("The provided RSA parameters do not define DQ.");;
 
-            InverseQ = parameters.InverseQ;
-            PrivateExponent = parameters.D;
+            InverseQ = parameters.InverseQ
+                       ?? throw new ArgumentException("The provided RSA parameters do not define InverseQ.");
+            PrivateExponent =
+                parameters.D ?? throw new ArgumentException("The provided RSA parameters do not define D.");
         }
 
         /// <inheritdoc />
@@ -223,6 +226,9 @@ namespace AsmResolver.PE.DotNet.StrongName
 
         private static uint ByteSwap(RSAParameters parameters)
         {
+            if (parameters.Exponent is null)
+                throw new ArgumentException("The provided RSA parameters do not define an exponent.");
+
             uint exponent = 0;
             for (int i = 0; i < Math.Min(sizeof(uint), parameters.Exponent.Length); i++)
                 exponent |= (uint) (parameters.Exponent[i] << (8 * i));

--- a/src/AsmResolver.PE/DotNet/StrongName/StrongNamePublicKey.cs
+++ b/src/AsmResolver.PE/DotNet/StrongName/StrongNamePublicKey.cs
@@ -76,6 +76,11 @@ namespace AsmResolver.PE.DotNet.StrongName
         /// <param name="parameters">The RSA parameters to import.</param>
         public StrongNamePublicKey(in RSAParameters parameters)
         {
+            if (parameters.Modulus is null)
+                throw new ArgumentException("RSA parameters does not define a modulus.");
+            if (parameters.Exponent is null)
+                throw new ArgumentException("RSA parameters does not define an exponent.");
+
             Modulus = CopyReversed(parameters.Modulus);
             uint exponent = 0;
             for (int i = 0; i < Math.Min(sizeof(uint), parameters.Exponent.Length); i++)

--- a/src/AsmResolver.PE/Imports/DefaultSymbolResolver.cs
+++ b/src/AsmResolver.PE/Imports/DefaultSymbolResolver.cs
@@ -676,7 +676,7 @@ namespace AsmResolver.PE.Imports
             if (!_staticMappings.TryGetValue(moduleName, out var staticMapping))
                 return null;
 
-            return staticMapping.TryGetValue(symbol.Ordinal, out string exportName)
+            return staticMapping.TryGetValue(symbol.Ordinal, out string? exportName)
                 ? new ExportedSymbol(SegmentReference.Null, exportName)
                 : null;
         }

--- a/src/AsmResolver.PE/Relocations/BaseRelocation.cs
+++ b/src/AsmResolver.PE/Relocations/BaseRelocation.cs
@@ -56,7 +56,7 @@ namespace AsmResolver.PE.Relocations
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is BaseRelocation other && Equals(other);
         }

--- a/src/AsmResolver.PE/Win32Resources/Builder/ResourceTableBuffer.cs
+++ b/src/AsmResolver.PE/Win32Resources/Builder/ResourceTableBuffer.cs
@@ -8,8 +8,9 @@ namespace AsmResolver.PE.Win32Resources.Builder
     /// </summary>
     /// <typeparam name="TEntry">The type of entries to store in the table.</typeparam>
     public abstract class ResourceTableBuffer<TEntry> : SegmentBase
+        where TEntry : notnull
     {
-        private readonly IDictionary<TEntry, uint> _entryOffsets = new Dictionary<TEntry, uint>();
+        private readonly Dictionary<TEntry, uint> _entryOffsets = new();
         private readonly ISegment _parentBuffer;
         private uint _length;
 

--- a/src/AsmResolver/AsmResolver.csproj
+++ b/src/AsmResolver/AsmResolver.csproj
@@ -4,11 +4,11 @@
         <Title>AsmResolver</Title>
         <Description>The base library for the AsmResolver executable file inspection toolsuite.</Description>
        <PackageTags>exe pe dotnet cil inspection manipulation assembly disassembly</PackageTags>
-        <TargetFramework>netstandard2.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <NoWarn>1701;1702;NU5105</NoWarn>
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
+        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/AsmResolver/ByteArrayEqualityComparer.cs
+++ b/src/AsmResolver/ByteArrayEqualityComparer.cs
@@ -84,8 +84,15 @@ namespace AsmResolver
         }
 
         /// <inheritdoc />
-        public int Compare(byte[] x, byte[] y)
+        public int Compare(byte[]? x, byte[]? y)
         {
+            if (ReferenceEquals(x, y))
+                return 0;
+            if (x is null)
+                return -1;
+            if (y is null)
+                return 1;
+
             int length = Math.Min(x.Length, y.Length);
             for (int i = 0; i < length; i++)
             {

--- a/src/AsmResolver/Collections/OneToManyRelation.cs
+++ b/src/AsmResolver/Collections/OneToManyRelation.cs
@@ -8,6 +8,8 @@ namespace AsmResolver.Collections
     /// <typeparam name="TKey">The type of objects to map.</typeparam>
     /// <typeparam name="TValue">The type of objects to map to.</typeparam>
     public sealed class OneToManyRelation<TKey, TValue>
+        where TKey : notnull
+        where TValue : notnull
     {
         private readonly Dictionary<TKey, ICollection<TValue>> _memberLists = new();
         private readonly Dictionary<TValue, TKey> _memberOwners = new();

--- a/src/AsmResolver/Collections/OneToOneRelation.cs
+++ b/src/AsmResolver/Collections/OneToOneRelation.cs
@@ -8,6 +8,8 @@ namespace AsmResolver.Collections
     /// <typeparam name="TKey">The first object type.</typeparam>
     /// <typeparam name="TValue">The second object type.</typeparam>
     public sealed class OneToOneRelation<TKey, TValue>
+        where TKey : notnull
+        where TValue : notnull
     {
         private readonly Dictionary<TKey, TValue> _keyToValue = new();
         private readonly Dictionary<TValue, TKey> _valueToKey = new();
@@ -36,7 +38,7 @@ namespace AsmResolver.Collections
         /// </summary>
         /// <param name="key">The key.</param>
         /// <returns>The value.</returns>
-        public TValue GetValue(TKey key)
+        public TValue? GetValue(TKey key)
         {
             _keyToValue.TryGetValue(key, out var value);
             return value;
@@ -47,7 +49,7 @@ namespace AsmResolver.Collections
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The key.</returns>
-        public TKey GetKey(TValue value)
+        public TKey? GetKey(TValue value)
         {
             _valueToKey.TryGetValue(value, out var key);
             return key;

--- a/src/AsmResolver/Utf8String.cs
+++ b/src/AsmResolver/Utf8String.cs
@@ -268,22 +268,25 @@ namespace AsmResolver
         /// <remarks>
         /// This operation performs a byte-level comparison of the two strings.
         /// </remarks>
-        public bool Equals(Utf8String other) => ByteArrayEqualityComparer.Instance.Equals(_data, other._data);
+        public bool Equals(Utf8String? other) =>
+            other is not null && ByteArrayEqualityComparer.Instance.Equals(_data, other._data);
 
         /// <inheritdoc />
         /// <remarks>
         /// This operation performs a byte-level comparison of the two strings.
         /// </remarks>
-        public bool Equals(byte[] other) => ByteArrayEqualityComparer.Instance.Equals(_data, other);
+        public bool Equals(byte[]? other) => other is not null && ByteArrayEqualityComparer.Instance.Equals(_data, other);
 
         /// <inheritdoc />
         /// <remarks>
         /// This operation performs a byte-level comparison of the two strings.
         /// </remarks>
-        public bool Equals(string other) => Value.Equals(other);
+        public bool Equals(string? other) =>other is not null && Value.Equals(other);
 
         /// <inheritdoc />
-        public int CompareTo(Utf8String other) => ByteArrayEqualityComparer.Instance.Compare(_data, other._data);
+        public int CompareTo(Utf8String? other) => other is not null
+            ? ByteArrayEqualityComparer.Instance.Compare(_data, other._data)
+            : 1;
 
         /// <inheritdoc />
         public IEnumerator<char> GetEnumerator() => Value.GetEnumerator();

--- a/test/AsmResolver.Benchmarks/AsmResolver.Benchmarks.csproj
+++ b/test/AsmResolver.Benchmarks/AsmResolver.Benchmarks.csproj
@@ -2,8 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
         <LangVersion>10</LangVersion>
+        <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/AsmResolver.Benchmarks/ModuleReadWriteBenchmark.cs
+++ b/test/AsmResolver.Benchmarks/ModuleReadWriteBenchmark.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using AsmResolver.DotNet;
 using BenchmarkDotNet.Attributes;
@@ -11,8 +12,16 @@ namespace AsmResolver.Benchmarks
         private static readonly byte[] HelloWorldApp = HelloWorld;
         private static readonly byte[] CrackMeApp = Test;
         private static readonly byte[] ManyMethods = Utilities.DecompressDeflate(HelloWorld_ManyMethods);
+        private static readonly byte[] CoreLib;
 
         private readonly MemoryStream _outputStream = new();
+
+        static ModuleReadWriteBenchmark()
+        {
+            var resolver = new DotNetCoreAssemblyResolver(new Version(3, 1, 0));
+            string path = resolver.Resolve(KnownCorLibs.SystemPrivateCoreLib_v4_0_0_0)!.ManifestModule!.FilePath;
+            CoreLib = File.ReadAllBytes(path);
+        }
 
         [Benchmark]
         public void HelloWorld_Read()
@@ -51,6 +60,13 @@ namespace AsmResolver.Benchmarks
         {
             var file = ModuleDefinition.FromBytes(ManyMethods);
             file.Write(_outputStream);
+        }
+
+        [Benchmark]
+        public void CoreLib_ReadWrite()
+        {
+            var module = ModuleDefinition.FromBytes(CoreLib);
+            module.Write(_outputStream);
         }
     }
 }

--- a/test/AsmResolver.DotNet.Tests/ModuleDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/ModuleDefinitionTest.cs
@@ -343,7 +343,7 @@ namespace AsmResolver.DotNet.Tests
         [Fact]
         public void DetectTargetStandard()
         {
-            var module = ModuleDefinition.FromFile(typeof(ISegment).Assembly.Location);
+            var module = ModuleDefinition.FromFile(typeof(TestCases.Types.Class).Assembly.Location);
             Assert.Contains(DotNetRuntimeInfo.NetStandard, module.OriginalTargetRuntime.Name);
             Assert.Equal(2, module.OriginalTargetRuntime.Version.Major);
         }


### PR DESCRIPTION
Includes build targets for LTS versions of .NET (.NET Core 3.1 and .NET 6.0). Introduces more NRT annotations as well and some additional null checks.

See #265 for justification.
Also related #260 .