### PR TITLE
Use ConcurrentDictionary as backing cache for DefaultMetadataResolver

### DIFF
--- a/src/AsmResolver.DotNet/DefaultMetadataResolver.cs
+++ b/src/AsmResolver.DotNet/DefaultMetadataResolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Types;
@@ -24,7 +25,7 @@ namespace AsmResolver.DotNet
         public DefaultMetadataResolver(IAssemblyResolver assemblyResolver)
         {
             AssemblyResolver = assemblyResolver ?? throw new ArgumentNullException(nameof(assemblyResolver));
-            _typeCache = new Dictionary<ITypeDescriptor, TypeDefinition>();
+            _typeCache = new ConcurrentDictionary<ITypeDescriptor, TypeDefinition>();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
As discussed, closes #269. Some of the unit tests aren't passing on my local machine (41 of the 44 under Builder/TokenPreservation) but they don't pass on master either (but they seem to work on AppVeyor?) so I'm assuming I haven't broken anything. The error is 
`
System.BadImageFormatException: Input PE image does not contain a .NET metadata directory.
`.