### PR TITLE
Thorough type sig imported check

### DIFF
--- a/src/AsmResolver.DotNet/AssemblyDefinition.cs
+++ b/src/AsmResolver.DotNet/AssemblyDefinition.cs
@@ -223,6 +223,9 @@ namespace AsmResolver.DotNet
         }
 
         /// <inheritdoc />
+        public override bool IsImportedInModule(ModuleDefinition module) => ManifestModule == module;
+
+        /// <inheritdoc />
         public override AssemblyDefinition Resolve() => this;
 
         /// <summary>

--- a/src/AsmResolver.DotNet/AssemblyDescriptor.cs
+++ b/src/AsmResolver.DotNet/AssemblyDescriptor.cs
@@ -2,18 +2,20 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Security.Cryptography;
 using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
+using AssemblyHashAlgorithm = AsmResolver.PE.DotNet.Metadata.Tables.Rows.AssemblyHashAlgorithm;
 
 namespace AsmResolver.DotNet
 {
     /// <summary>
     /// Provides a base implementation for describing a self-describing .NET assembly hosted by a common language runtime (CLR).
     /// </summary>
-    public abstract class AssemblyDescriptor : MetadataMember, IHasCustomAttribute, IFullNameProvider
+    public abstract class AssemblyDescriptor : MetadataMember, IHasCustomAttribute, IFullNameProvider, IImportable
     {
         private const int PublicKeyTokenLength = 8;
 
@@ -211,6 +213,9 @@ namespace AsmResolver.DotNet
 
         /// <inheritdoc />
         public override string ToString() => FullName;
+
+        /// <inheritdoc />
+        public abstract bool IsImportedInModule(ModuleDefinition module);
 
         /// <summary>
         /// Computes the token of a public key using the provided hashing algorithm.

--- a/src/AsmResolver.DotNet/AssemblyReference.cs
+++ b/src/AsmResolver.DotNet/AssemblyReference.cs
@@ -148,6 +148,9 @@ namespace AsmResolver.DotNet
         protected virtual byte[]? GetHashValue() => null;
 
         /// <inheritdoc />
+        public override bool IsImportedInModule(ModuleDefinition module) => Module == module;
+
+        /// <inheritdoc />
         public override AssemblyDefinition? Resolve() => Module?.MetadataResolver.AssemblyResolver.Resolve(this);
 
         AssemblyDescriptor IResolutionScope.GetAssembly() => this;

--- a/src/AsmResolver.DotNet/EventDefinition.cs
+++ b/src/AsmResolver.DotNet/EventDefinition.cs
@@ -170,6 +170,13 @@ namespace AsmResolver.DotNet
 
         IMemberDefinition IMemberDescriptor.Resolve() => this;
 
+        /// <inheritdoc />
+        public bool IsImportedInModule(ModuleDefinition module)
+        {
+            return Module == module
+                   && (EventType?.IsImportedInModule(module) ?? false);
+        }
+
         /// <summary>
         /// Obtains the list of custom attributes assigned to the member.
         /// </summary>

--- a/src/AsmResolver.DotNet/ExportedType.cs
+++ b/src/AsmResolver.DotNet/ExportedType.cs
@@ -146,7 +146,11 @@ namespace AsmResolver.DotNet
         public TypeDefinition? Resolve() => Module?.MetadataResolver.ResolveType(this);
 
         /// <inheritdoc />
-        public bool IsImportedInModule(ModuleDefinition module) => Module == module;
+        public bool IsImportedInModule(ModuleDefinition module)
+        {
+            return Module == module
+                   && (Implementation?.IsImportedInModule(module) ?? false);
+        }
 
         IMemberDefinition? IMemberDescriptor.Resolve() => Resolve();
 

--- a/src/AsmResolver.DotNet/ExportedType.cs
+++ b/src/AsmResolver.DotNet/ExportedType.cs
@@ -28,8 +28,8 @@ namespace AsmResolver.DotNet
         protected ExportedType(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(() => GetName());
-            _namespace = new LazyVariable<Utf8String?>(() => GetNamespace());
+            _name = new LazyVariable<Utf8String?>(GetName);
+            _namespace = new LazyVariable<Utf8String?>(GetNamespace);
             _implementation = new LazyVariable<IImplementation?>(GetImplementation);
         }
 
@@ -144,6 +144,9 @@ namespace AsmResolver.DotNet
 
         /// <inheritdoc />
         public TypeDefinition? Resolve() => Module?.MetadataResolver.ResolveType(this);
+
+        /// <inheritdoc />
+        public bool IsImportedInModule(ModuleDefinition module) => Module == module;
 
         IMemberDefinition? IMemberDescriptor.Resolve() => Resolve();
 

--- a/src/AsmResolver.DotNet/FieldDefinition.cs
+++ b/src/AsmResolver.DotNet/FieldDefinition.cs
@@ -386,6 +386,13 @@ namespace AsmResolver.DotNet
 
         FieldDefinition IFieldDescriptor.Resolve() => this;
 
+        /// <inheritdoc />
+        public bool IsImportedInModule(ModuleDefinition module)
+        {
+            return Module == module
+                   && (Signature?.IsImportedInModule(module) ?? false);
+        }
+
         IMemberDefinition IMemberDescriptor.Resolve() => this;
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/FileReference.cs
+++ b/src/AsmResolver.DotNet/FileReference.cs
@@ -120,6 +120,9 @@ namespace AsmResolver.DotNet
             }
         }
 
+        /// <inheritdoc />
+        public bool IsImportedInModule(ModuleDefinition module) => Module == module;
+
         /// <summary>
         /// Obtains the name of the referenced file.
         /// </summary>

--- a/src/AsmResolver.DotNet/IImplementation.cs
+++ b/src/AsmResolver.DotNet/IImplementation.cs
@@ -4,7 +4,7 @@ namespace AsmResolver.DotNet
     /// Represents a member that is either a reference to an external file, assembly or type, and can be referenced by
     /// an Implementation coded index.
     /// </summary>
-    public interface IImplementation : IFullNameProvider, IModuleProvider, IHasCustomAttribute
+    public interface IImplementation : IFullNameProvider, IModuleProvider, IHasCustomAttribute, IImportable
     {
     }
 }

--- a/src/AsmResolver.DotNet/IImportable.cs
+++ b/src/AsmResolver.DotNet/IImportable.cs
@@ -11,7 +11,8 @@ namespace AsmResolver.DotNet
         /// <param name="module">The module that is supposed to import the member.</param>
         /// <returns><c>true</c> if the descriptor of the member is fully imported by the module, <c>false</c> otherwise.</returns>
         /// <remarks>
-        /// This method verifies all references in the descriptor of the member, but does not verify the contents (e.g. a method body).
+        /// This method verifies all references in the descriptor of the member only. It does not verify any additional
+        /// data or contents (such as a method body) associated to the member.
         /// </remarks>
         bool IsImportedInModule(ModuleDefinition module);
     }

--- a/src/AsmResolver.DotNet/IImportable.cs
+++ b/src/AsmResolver.DotNet/IImportable.cs
@@ -1,0 +1,18 @@
+namespace AsmResolver.DotNet
+{
+    /// <summary>
+    /// Represents an entity in a .NET module that can be imported using the <see cref="ReferenceImporter"/>.
+    /// </summary>
+    public interface IImportable
+    {
+        /// <summary>
+        /// Determines whether the descriptor of the member is fully imported in the provided module.
+        /// </summary>
+        /// <param name="module">The module that is supposed to import the member.</param>
+        /// <returns><c>true</c> if the descriptor of the member is fully imported by the module, <c>false</c> otherwise.</returns>
+        /// <remarks>
+        /// This method verifies all references in the descriptor of the member, but does not verify the contents (e.g. a method body).
+        /// </remarks>
+        bool IsImportedInModule(ModuleDefinition module);
+    }
+}

--- a/src/AsmResolver.DotNet/IMemberDescriptor.cs
+++ b/src/AsmResolver.DotNet/IMemberDescriptor.cs
@@ -3,7 +3,7 @@ namespace AsmResolver.DotNet
     /// <summary>
     /// Provides members for describing a (reference to a) member defined in a .NET assembly.
     /// </summary>
-    public interface IMemberDescriptor : IFullNameProvider, IModuleProvider
+    public interface IMemberDescriptor : IFullNameProvider, IModuleProvider, IImportable
     {
         /// <summary>
         /// When this member is defined in a type, gets the enclosing type.

--- a/src/AsmResolver.DotNet/IResolutionScope.cs
+++ b/src/AsmResolver.DotNet/IResolutionScope.cs
@@ -3,7 +3,7 @@ namespace AsmResolver.DotNet
     /// <summary>
     /// Represents a member that can be referenced by a ResolutionScope coded index.
     /// </summary>
-    public interface IResolutionScope : IMetadataMember, INameProvider, IModuleProvider
+    public interface IResolutionScope : IMetadataMember, INameProvider, IModuleProvider, IImportable
     {
         /// <summary>
         /// Gets the underlying assembly that this scope defines.

--- a/src/AsmResolver.DotNet/InvalidTypeDefOrRef.cs
+++ b/src/AsmResolver.DotNet/InvalidTypeDefOrRef.cs
@@ -73,6 +73,9 @@ namespace AsmResolver.DotNet
             return instance;
         }
 
+        /// <inheritdoc />
+        public bool IsImportedInModule(ModuleDefinition module) => false;
+
         IMemberDefinition? IMemberDescriptor.Resolve() => null;
 
         TypeDefinition? ITypeDescriptor.Resolve() => null;

--- a/src/AsmResolver.DotNet/MemberReference.cs
+++ b/src/AsmResolver.DotNet/MemberReference.cs
@@ -153,6 +153,13 @@ namespace AsmResolver.DotNet
             throw new ArgumentOutOfRangeException();
         }
 
+        /// <inheritdoc />
+        public bool IsImportedInModule(ModuleDefinition module)
+        {
+            return Module == module
+                   && (Signature?.IsImportedInModule(module) ?? false);
+        }
+
         FieldDefinition? IFieldDescriptor.Resolve()
         {
             if (!IsField)

--- a/src/AsmResolver.DotNet/MethodDefinition.cs
+++ b/src/AsmResolver.DotNet/MethodDefinition.cs
@@ -691,6 +691,13 @@ namespace AsmResolver.DotNet
 
         MethodDefinition IMethodDescriptor.Resolve() => this;
 
+        /// <inheritdoc />
+        public bool IsImportedInModule(ModuleDefinition module)
+        {
+            return Module == module
+                   && (Signature?.IsImportedInModule(module) ?? false);
+        }
+
         IMemberDefinition IMemberDescriptor.Resolve() => this;
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/MethodSpecification.cs
+++ b/src/AsmResolver.DotNet/MethodSpecification.cs
@@ -99,6 +99,13 @@ namespace AsmResolver.DotNet
         /// <inheritdoc />
         public MethodDefinition? Resolve() => Method?.Resolve();
 
+        /// <inheritdoc />
+        public bool IsImportedInModule(ModuleDefinition module)
+        {
+            return (Method?.IsImportedInModule(module) ?? false)
+                   && (Signature?.IsImportedInModule(module) ?? false);
+        }
+
         IMemberDefinition? IMemberDescriptor.Resolve() => Resolve();
 
         /// <summary>

--- a/src/AsmResolver.DotNet/ModuleDefinition.cs
+++ b/src/AsmResolver.DotNet/ModuleDefinition.cs
@@ -1104,6 +1104,9 @@ namespace AsmResolver.DotNet
         /// <inheritdoc />
         public override string ToString() => Name ?? string.Empty;
 
+        /// <inheritdoc />
+        bool IImportable.IsImportedInModule(ModuleDefinition module) => this == module;
+
         /// <summary>
         /// Rebuilds the .NET module to a portable executable file and writes it to the file system.
         /// </summary>

--- a/src/AsmResolver.DotNet/ModuleReference.cs
+++ b/src/AsmResolver.DotNet/ModuleReference.cs
@@ -76,6 +76,9 @@ namespace AsmResolver.DotNet
             }
         }
 
+        /// <inheritdoc />
+        public bool IsImportedInModule(ModuleDefinition module) => Module == module;
+
         /// <summary>
         /// Obtains the name of the module.
         /// </summary>

--- a/src/AsmResolver.DotNet/PropertyDefinition.cs
+++ b/src/AsmResolver.DotNet/PropertyDefinition.cs
@@ -187,6 +187,13 @@ namespace AsmResolver.DotNet
 
         IMemberDefinition IMemberDescriptor.Resolve() => this;
 
+        /// <inheritdoc />
+        public bool IsImportedInModule(ModuleDefinition module)
+        {
+            return Module == module
+                   && (Signature?.IsImportedInModule(module) ?? false);
+        }
+
         /// <summary>
         /// Obtains the name of the property definition.
         /// </summary>

--- a/src/AsmResolver.DotNet/ReferenceImporter.cs
+++ b/src/AsmResolver.DotNet/ReferenceImporter.cs
@@ -47,7 +47,7 @@ namespace AsmResolver.DotNet
         {
             if (scope is null)
                 throw new ArgumentNullException(nameof(scope));
-            if (scope.Module == TargetModule)
+            if (scope.IsImportedInModule(TargetModule))
                 return scope;
 
             return scope switch
@@ -69,7 +69,7 @@ namespace AsmResolver.DotNet
         {
             if (assembly is null)
                 throw new ArgumentNullException(nameof(assembly));
-            if (assembly is AssemblyReference r && r.Module == TargetModule)
+            if (assembly is AssemblyReference r && assembly.IsImportedInModule(TargetModule))
                 return r;
 
             var reference = TargetModule.AssemblyReferences.FirstOrDefault(a => _comparer.Equals(a, assembly));
@@ -92,7 +92,7 @@ namespace AsmResolver.DotNet
         {
             if (module is null)
                 throw new ArgumentNullException(nameof(module));
-            if (module.Module == TargetModule)
+            if (module.IsImportedInModule(TargetModule))
                 return module;
 
             var reference = TargetModule.ModuleReferences.FirstOrDefault(a => _comparer.Equals(a, module));
@@ -139,7 +139,7 @@ namespace AsmResolver.DotNet
         {
             AssertTypeIsValid(type);
 
-            if (type.Module == TargetModule)
+            if (type.IsImportedInModule(TargetModule))
                 return type;
 
             return new TypeReference(TargetModule, ImportScope(type.Module!), type.Namespace, type.Name);
@@ -154,7 +154,7 @@ namespace AsmResolver.DotNet
         {
             AssertTypeIsValid(type);
 
-            if (type.Module == TargetModule)
+            if (type.IsImportedInModule(TargetModule))
                 return type;
 
             return new TypeReference(TargetModule, ImportScope(type.Scope!), type.Namespace, type.Name);
@@ -171,7 +171,7 @@ namespace AsmResolver.DotNet
             if (type.Signature is null)
                 throw new ArgumentNullException(nameof(type));
 
-            if (type.Module == TargetModule)
+            if (type.IsImportedInModule(TargetModule))
                 return type;
 
             return new TypeSpecification(ImportTypeSignature(type.Signature));
@@ -186,7 +186,7 @@ namespace AsmResolver.DotNet
         {
             if (type is null)
                 throw new ArgumentNullException(nameof(type));
-            if (type.Module == TargetModule)
+            if (type.IsImportedInModule(TargetModule))
                 return type;
 
             return type.AcceptVisitor(this);
@@ -212,11 +212,8 @@ namespace AsmResolver.DotNet
                 throw new ArgumentNullException(nameof(type));
 
             var importedTypeSig = ImportTypeSignature(type);
-            if (importedTypeSig is TypeDefOrRefSignature
-                || importedTypeSig is CorLibTypeSignature)
-            {
+            if (importedTypeSig is TypeDefOrRefSignature or CorLibTypeSignature)
                 return importedTypeSig.GetUnderlyingTypeDefOrRef()!;
-            }
 
             return new TypeSpecification(importedTypeSig);
         }
@@ -266,6 +263,7 @@ namespace AsmResolver.DotNet
             var result = new ArrayTypeSignature(baseType);
             for (int i = 0; i < rank; i++)
                 result.Dimensions.Add(new ArrayDimension());
+
             return result;
         }
 
@@ -318,7 +316,7 @@ namespace AsmResolver.DotNet
             if (method.Signature is null)
                 throw new ArgumentException("Cannot import a method that does not have a signature.");
 
-            if (method.Module == TargetModule)
+            if (method.IsImportedInModule(TargetModule))
                 return method;
 
             return new MemberReference(
@@ -406,7 +404,7 @@ namespace AsmResolver.DotNet
             if (method.DeclaringType is null)
                 throw new ArgumentException("Cannot import a method that is not added to a type.");
 
-            if (method.Module == TargetModule)
+            if (method.IsImportedInModule(TargetModule))
                 return method;
 
             var memberRef = ImportMethod(method.Method);
@@ -479,7 +477,7 @@ namespace AsmResolver.DotNet
             if (field.Signature is null)
                 throw new ArgumentException("Cannot import a field that does not have a signature.");
 
-            if (field.Module == TargetModule)
+            if (field.IsImportedInModule(TargetModule))
                 return field;
 
             return new MemberReference(

--- a/src/AsmResolver.DotNet/ReflectionAssemblyDescriptor.cs
+++ b/src/AsmResolver.DotNet/ReflectionAssemblyDescriptor.cs
@@ -33,6 +33,9 @@ namespace AsmResolver.DotNet
         protected override Utf8String? GetCulture() => _assemblyName.CultureName;
 
         /// <inheritdoc />
+        public override bool IsImportedInModule(ModuleDefinition module) => false;
+
+        /// <inheritdoc />
         public override bool IsCorLib => Name is not null && KnownCorLibs.KnownCorLibNames.Contains(Name);
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/Signatures/CallingConventionSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/CallingConventionSignature.cs
@@ -7,7 +7,7 @@ namespace AsmResolver.DotNet.Signatures
     /// Provides a base for all signature that deal with a calling convention. This includes most member signatures,
     /// such as method and field signatures.
     /// </summary>
-    public abstract class CallingConventionSignature : ExtendableBlobSignature
+    public abstract class CallingConventionSignature : ExtendableBlobSignature, IImportable
     {
         private const CallingConventionAttributes SignatureTypeMask = (CallingConventionAttributes)0xF;
 
@@ -148,5 +148,8 @@ namespace AsmResolver.DotNet.Signatures
             set => Attributes = (Attributes & ~CallingConventionAttributes.Sentinel)
                                 | (value ? CallingConventionAttributes.Sentinel : 0);
         }
+
+        /// <inheritdoc />
+        public abstract bool IsImportedInModule(ModuleDefinition module);
     }
 }

--- a/src/AsmResolver.DotNet/Signatures/GenericInstanceMethodSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/GenericInstanceMethodSignature.cs
@@ -92,6 +92,18 @@ namespace AsmResolver.DotNet.Signatures
         }
 
         /// <inheritdoc />
+        public override bool IsImportedInModule(ModuleDefinition module)
+        {
+            for (int i = 0; i < TypeArguments.Count; i++)
+            {
+                if (!TypeArguments[i].IsImportedInModule(module))
+                    return false;
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc />
         public override string ToString()
         {
             return $"<{string.Join(", ", TypeArguments)}>";

--- a/src/AsmResolver.DotNet/Signatures/LocalVariablesSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/LocalVariablesSignature.cs
@@ -69,6 +69,18 @@ namespace AsmResolver.DotNet.Signatures
         }
 
         /// <inheritdoc />
+        public override bool IsImportedInModule(ModuleDefinition module)
+        {
+            for (int i = 0; i < VariableTypes.Count; i++)
+            {
+                if (!VariableTypes[i].IsImportedInModule(module))
+                    return false;
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc />
         protected override void WriteContents(BlobSerializationContext context)
         {
             var writer = context.Writer;

--- a/src/AsmResolver.DotNet/Signatures/MemberSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/MemberSignature.cs
@@ -28,6 +28,9 @@ namespace AsmResolver.DotNet.Signatures
         }
 
         /// <inheritdoc />
+        public override bool IsImportedInModule(ModuleDefinition module) => MemberReturnType.IsImportedInModule(module);
+
+        /// <inheritdoc />
         public override string ToString()
         {
             string prefix = HasThis ? "instance " : string.Empty;

--- a/src/AsmResolver.DotNet/Signatures/MethodSignatureBase.cs
+++ b/src/AsmResolver.DotNet/Signatures/MethodSignatureBase.cs
@@ -78,6 +78,29 @@ namespace AsmResolver.DotNet.Signatures
             get;
         } = new List<TypeSignature>();
 
+        /// <inheritdoc />
+        public override bool IsImportedInModule(ModuleDefinition module)
+        {
+            if (!ReturnType.IsImportedInModule(module))
+                return false;
+
+            for (int i = 0; i < ParameterTypes.Count; i++)
+            {
+                var x = ParameterTypes[i];
+                if (!x.IsImportedInModule(module))
+                    return false;
+            }
+
+            for (int i = 0; i < SentinelParameterTypes.Count; i++)
+            {
+                var x = SentinelParameterTypes[i];
+                if (!x.IsImportedInModule(module))
+                    return false;
+            }
+
+            return true;
+        }
+
         /// <summary>
         /// Initializes the <see cref="ParameterTypes"/> and <see cref="ReturnType"/> properties by reading
         /// the parameter count, return type and parameter fields of the signature from the provided input stream.

--- a/src/AsmResolver.DotNet/Signatures/SignatureComparer.TypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/SignatureComparer.TypeSignature.cs
@@ -20,6 +20,7 @@ namespace AsmResolver.DotNet.Signatures
         IEqualityComparer<GenericParameterSignature>,
         IEqualityComparer<ArrayTypeSignature>,
         IEqualityComparer<SentinelTypeSignature>,
+        IEqualityComparer<FunctionPointerTypeSignature>,
         IEqualityComparer<IList<TypeSignature>>,
         IEqualityComparer<IEnumerable<TypeSignature>>
     {
@@ -59,6 +60,7 @@ namespace AsmResolver.DotNet.Signatures
                 case ElementType.Boxed:
                     return Equals(x as BoxedTypeSignature, y as BoxedTypeSignature);
                 case ElementType.FnPtr:
+                    return Equals(x as FunctionPointerTypeSignature, y as FunctionPointerTypeSignature);
                 case ElementType.Internal:
                 case ElementType.Modifier:
                     throw new NotSupportedException();
@@ -307,6 +309,22 @@ namespace AsmResolver.DotNet.Signatures
 
                 return hashCode;
             }
+        }
+
+        /// <inheritdoc />
+        public bool Equals(FunctionPointerTypeSignature? x, FunctionPointerTypeSignature? y)
+        {
+            if (ReferenceEquals(x, y))
+                return true;
+            if (x is null || y is null)
+                return false;
+            return Equals(x.Signature, y.Signature);
+        }
+
+        /// <inheritdoc />
+        public int GetHashCode(FunctionPointerTypeSignature obj)
+        {
+            return obj.Signature.GetHashCode();
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/Signatures/Types/CorLibTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/CorLibTypeSignature.cs
@@ -79,6 +79,9 @@ namespace AsmResolver.DotNet.Signatures.Types
         }
 
         /// <inheritdoc />
+        public override bool IsImportedInModule(ModuleDefinition module) => Module == module;
+
+        /// <inheritdoc />
         public override ITypeDefOrRef? GetUnderlyingTypeDefOrRef()
         {
             return Type;

--- a/src/AsmResolver.DotNet/Signatures/Types/CustomModifierTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/CustomModifierTypeSignature.cs
@@ -76,6 +76,10 @@ namespace AsmResolver.DotNet.Signatures.Types
             visitor.VisitCustomModifierType(this, state);
 
         /// <inheritdoc />
+        public override bool IsImportedInModule(ModuleDefinition module) =>
+            ModifierType.IsImportedInModule(module) && base.IsImportedInModule(module);
+
+        /// <inheritdoc />
         protected override void WriteContents(BlobSerializationContext context)
         {
             context.Writer.WriteByte((byte) ElementType);

--- a/src/AsmResolver.DotNet/Signatures/Types/FunctionPointerTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/FunctionPointerTypeSignature.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
 namespace AsmResolver.DotNet.Signatures.Types
@@ -47,6 +48,9 @@ namespace AsmResolver.DotNet.Signatures.Types
         /// <inheritdoc />
         public override ITypeDefOrRef? GetUnderlyingTypeDefOrRef() =>
             Signature?.ReturnType?.Module?.CorLibTypeFactory.IntPtr.Type;
+
+        /// <inheritdoc />
+        public override bool IsImportedInModule(ModuleDefinition module) => Signature.IsImportedInModule(module);
 
         /// <inheritdoc />
         protected override void WriteContents(BlobSerializationContext context)

--- a/src/AsmResolver.DotNet/Signatures/Types/GenericInstanceTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/GenericInstanceTypeSignature.cs
@@ -109,6 +109,21 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override ITypeDefOrRef? GetUnderlyingTypeDefOrRef() => GenericType;
 
         /// <inheritdoc />
+        public override bool IsImportedInModule(ModuleDefinition module)
+        {
+            if (!GenericType.IsImportedInModule(module))
+                return false;
+
+            for (int i = 0; i < TypeArguments.Count; i++)
+            {
+                if (!TypeArguments[i].IsImportedInModule(module))
+                    return false;
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc />
         protected override void WriteContents(BlobSerializationContext context)
         {
             var writer = context.Writer;

--- a/src/AsmResolver.DotNet/Signatures/Types/GenericParameterSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/GenericParameterSignature.cs
@@ -9,8 +9,6 @@ namespace AsmResolver.DotNet.Signatures.Types
     /// </summary>
     public class GenericParameterSignature : TypeSignature
     {
-        private readonly IResolutionScope? _scope;
-
         /// <summary>
         /// Creates a new reference to a generic parameter.
         /// </summary>
@@ -30,7 +28,7 @@ namespace AsmResolver.DotNet.Signatures.Types
         /// <param name="index">The index of the referenced parameter.</param>
         public GenericParameterSignature(ModuleDefinition module, GenericParameterType parameterType, int index)
         {
-            _scope = module;
+            Scope = module;
             ParameterType = parameterType;
             Index = index;
         }
@@ -74,7 +72,10 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override string? Namespace => null;
 
         /// <inheritdoc />
-        public override IResolutionScope? Scope => _scope;
+        public override IResolutionScope? Scope
+        {
+            get;
+        }
 
         /// <inheritdoc />
         public override bool IsValueType => false;

--- a/src/AsmResolver.DotNet/Signatures/Types/GenericParameterSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/GenericParameterSignature.cs
@@ -83,6 +83,9 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override TypeDefinition? Resolve() => null;
 
         /// <inheritdoc />
+        public override bool IsImportedInModule(ModuleDefinition module) => Module == module;
+
+        /// <inheritdoc />
         public override ITypeDefOrRef? GetUnderlyingTypeDefOrRef() => null;
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/Signatures/Types/SentinelTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/SentinelTypeSignature.cs
@@ -34,6 +34,9 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override ITypeDefOrRef? GetUnderlyingTypeDefOrRef() => null;
 
         /// <inheritdoc />
+        public override bool IsImportedInModule(ModuleDefinition module) => true;
+
+        /// <inheritdoc />
         protected override void WriteContents(BlobSerializationContext context) =>
             context.Writer.WriteByte((byte) ElementType);
 

--- a/src/AsmResolver.DotNet/Signatures/Types/TypeDefOrRefSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/TypeDefOrRefSignature.cs
@@ -61,6 +61,9 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override TypeDefinition? Resolve() => Type.Resolve();
 
         /// <inheritdoc />
+        public override bool IsImportedInModule(ModuleDefinition module) => Type.IsImportedInModule(module);
+
+        /// <inheritdoc />
         public override ITypeDefOrRef ToTypeDefOrRef() => Type;
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/Signatures/Types/TypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/TypeSignature.cs
@@ -376,6 +376,9 @@ namespace AsmResolver.DotNet.Signatures.Types
         public TypeSignature InstantiateGenericTypes(GenericContext context)
             => AcceptVisitor(GenericTypeActivator.Instance, context);
 
+        /// <inheritdoc />
+        public abstract bool IsImportedInModule(ModuleDefinition module);
+
         /// <summary>
         /// Visit the current type signature using the provided visitor.
         /// </summary>

--- a/src/AsmResolver.DotNet/Signatures/Types/TypeSpecificationSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/TypeSpecificationSignature.cs
@@ -38,6 +38,9 @@ namespace AsmResolver.DotNet.Signatures.Types
             BaseType.GetUnderlyingTypeDefOrRef();
 
         /// <inheritdoc />
+        public override bool IsImportedInModule(ModuleDefinition module) => BaseType.IsImportedInModule(module);
+
+        /// <inheritdoc />
         protected override void WriteContents(BlobSerializationContext context)
         {
             context.Writer.WriteByte((byte) ElementType);

--- a/src/AsmResolver.DotNet/Signatures/Types/TypeSpecificationSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/TypeSpecificationSignature.cs
@@ -24,6 +24,9 @@ namespace AsmResolver.DotNet.Signatures.Types
         }
 
         /// <inheritdoc />
+        public override ModuleDefinition? Module => BaseType.Module;
+
+        /// <inheritdoc />
         public override string? Namespace => BaseType.Namespace;
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/TypeDefinition.cs
+++ b/src/AsmResolver.DotNet/TypeDefinition.cs
@@ -681,6 +681,9 @@ namespace AsmResolver.DotNet
         }
 
         /// <inheritdoc />
+        public bool IsImportedInModule(ModuleDefinition module) => Module == module;
+
+        /// <inheritdoc />
         public bool IsAccessibleFromType(TypeDefinition type)
         {
             // TODO: Check types of the same family.

--- a/src/AsmResolver.DotNet/TypeReference.cs
+++ b/src/AsmResolver.DotNet/TypeReference.cs
@@ -137,6 +137,9 @@ namespace AsmResolver.DotNet
         }
 
         /// <inheritdoc />
+        public bool IsImportedInModule(ModuleDefinition module) => Module == module;
+
+        /// <inheritdoc />
         public TypeDefinition? Resolve() => Module?.MetadataResolver.ResolveType(this);
 
         IMemberDefinition? IMemberDescriptor.Resolve() => Resolve();

--- a/src/AsmResolver.DotNet/TypeSpecification.cs
+++ b/src/AsmResolver.DotNet/TypeSpecification.cs
@@ -96,6 +96,9 @@ namespace AsmResolver.DotNet
             Signature ?? throw new ArgumentException("Signature embedded into the type specification is null.");
 
         /// <inheritdoc />
+        public bool IsImportedInModule(ModuleDefinition module) => Signature?.IsImportedInModule(module) ?? false;
+
+        /// <inheritdoc />
         public TypeDefinition? Resolve() => Module?.MetadataResolver.ResolveType(this);
 
         IMemberDefinition? IMemberDescriptor.Resolve() => Resolve();

--- a/test/AsmResolver.DotNet.Tests/ReferenceImporterTest.cs
+++ b/test/AsmResolver.DotNet.Tests/ReferenceImporterTest.cs
@@ -305,7 +305,7 @@ namespace AsmResolver.DotNet.Tests
             var imported = _importer.ImportTypeSignature(signature);
 
             Assert.NotSame(signature, imported);
-            Assert.Equal(signature, imported, _comparer);
+            Assert.Equal(signature, imported, Comparer);
             Assert.Equal(_module, imported.Module);
         }
 
@@ -402,7 +402,7 @@ namespace AsmResolver.DotNet.Tests
 
             var newInstance = Assert.IsAssignableFrom<FunctionPointerTypeSignature>(imported);
             Assert.NotSame(signature, newInstance);
-            Assert.Equal(signature, newInstance, _comparer);
+            Assert.Equal(signature, newInstance, Comparer);
             Assert.Equal(_module, newInstance.Module);
             Assert.Equal(_module, newInstance.Signature.ParameterTypes[0].Module);
         }
@@ -420,7 +420,7 @@ namespace AsmResolver.DotNet.Tests
 
             var newInstance = Assert.IsAssignableFrom<FunctionPointerTypeSignature>(imported);
             Assert.NotSame(signature, newInstance);
-            Assert.Equal(signature, newInstance, _comparer);
+            Assert.Equal(signature, newInstance, Comparer);
             Assert.Equal(_module, newInstance.Module);
             Assert.Equal(_module, newInstance.Signature.ReturnType.Module);
         }

--- a/test/AsmResolver.DotNet.Tests/ReferenceImporterTest.cs
+++ b/test/AsmResolver.DotNet.Tests/ReferenceImporterTest.cs
@@ -310,10 +310,35 @@ namespace AsmResolver.DotNet.Tests
         }
 
         [Fact]
+        public void ImportTypeSpecWithNonImportedBaseTypeShouldResultInNewInstance()
+        {
+            var signature = new TypeReference(_module.CorLibTypeFactory.CorLibScope, "System.IO", "Stream")
+                .ToTypeSignature()
+                .MakeSzArrayType();
+
+            var imported = _importer.ImportTypeSignature(signature);
+            var newInstance = Assert.IsAssignableFrom<SzArrayTypeSignature>(imported);
+            Assert.NotSame(signature, newInstance);
+            Assert.Equal(signature, newInstance, Comparer);
+            Assert.Equal(_module, newInstance.BaseType.Module);
+        }
+
+        [Fact]
         public void ImportFullyImportedTypeDefOrRefShouldResultInSameInstance()
         {
             var signature = new TypeReference(_module, _module.CorLibTypeFactory.CorLibScope, "System.IO", "Stream")
                 .ToTypeSignature();
+
+            var imported = _importer.ImportTypeSignature(signature);
+            Assert.Same(signature, imported);
+        }
+
+        [Fact]
+        public void ImportFullyImportedTypeSpecShouldResultInSameInstance()
+        {
+            var signature = new TypeReference(_module, _module.CorLibTypeFactory.CorLibScope, "System.IO", "Stream")
+                .ToTypeSignature()
+                .MakeSzArrayType();
 
             var imported = _importer.ImportTypeSignature(signature);
             Assert.Same(signature, imported);

--- a/test/AsmResolver.DotNet.Tests/ReferenceImporterTest.cs
+++ b/test/AsmResolver.DotNet.Tests/ReferenceImporterTest.cs
@@ -266,7 +266,30 @@ namespace AsmResolver.DotNet.Tests
         }
 
         [Fact]
-        public void ImportTypeSigWithNonImportedEmbeddedReferenceShouldResultInNewInstance()
+        public void ImportNonImportedTypeDefOrRefShouldResultInNewInstance()
+        {
+            var signature = new TypeReference(_module.CorLibTypeFactory.CorLibScope, "System.IO", "Stream")
+                .ToTypeSignature();
+
+            var imported = _importer.ImportTypeSignature(signature);
+
+            Assert.NotSame(signature, imported);
+            Assert.Equal(signature, imported, _comparer);
+            Assert.Equal(_module, imported.Module);
+        }
+
+        [Fact]
+        public void ImportFullyImportedTypeDefOrRefShouldResultInSameInstance()
+        {
+            var signature = new TypeReference(_module, _module.CorLibTypeFactory.CorLibScope, "System.IO", "Stream")
+                .ToTypeSignature();
+
+            var imported = _importer.ImportTypeSignature(signature);
+            Assert.Same(signature, imported);
+        }
+
+        [Fact]
+        public void ImportGenericTypeSigWithNonImportedTypeArgumentShouldResultInNewInstance()
         {
             // https://github.com/Washi1337/AsmResolver/issues/268
 
@@ -288,7 +311,7 @@ namespace AsmResolver.DotNet.Tests
         }
 
         [Fact]
-        public void ImportTypeSigWithImportedEmbeddedReferenceShouldResultInSameInstance()
+        public void ImportFullyImportedGenericTypeSigShouldResultInSameInstance()
         {
             // https://github.com/Washi1337/AsmResolver/issues/268
 
@@ -305,6 +328,85 @@ namespace AsmResolver.DotNet.Tests
 
             var newInstance = Assert.IsAssignableFrom<GenericInstanceTypeSignature>(imported);
             Assert.Same(instance, newInstance);
+        }
+
+        [Fact]
+        public void ImportCustomModifierTypeWithNonImportedModifierTypeShouldResultInNewInstance()
+        {
+            var signature = new TypeReference(_module, _dummyAssembly, "SomeNamespace", "SomeType")
+                .ToTypeSignature()
+                .MakeModifierType(new TypeReference(_dummyAssembly, "SomeNamespace", "SomeModifierType"), true);
+
+            var imported = _importer.ImportTypeSignature(signature);
+
+            var newInstance = Assert.IsAssignableFrom<CustomModifierTypeSignature>(imported);
+            Assert.NotSame(signature, newInstance);
+            Assert.Equal(_module, newInstance.Module);
+            Assert.Equal(_module, newInstance.ModifierType.Module);
+        }
+
+        [Fact]
+        public void ImportFullyImportedCustomModifierTypeShouldResultInSameInstance()
+        {
+            var signature = new TypeReference(_module, _dummyAssembly, "SomeNamespace", "SomeType")
+                .ToTypeSignature()
+                .MakeModifierType(new TypeReference(_module, _dummyAssembly, "SomeNamespace", "SomeModifierType"), true);
+
+            var imported = _importer.ImportTypeSignature(signature);
+
+            var newInstance = Assert.IsAssignableFrom<CustomModifierTypeSignature>(imported);
+            Assert.Same(signature, newInstance);
+        }
+
+        [Fact]
+        public void ImportFunctionPointerTypeWithNonImportedParameterShouldResultInNewInstance()
+        {
+            var signature = MethodSignature
+                .CreateStatic(
+                    _module.CorLibTypeFactory.Void,
+                    new TypeReference(_dummyAssembly, "SomeNamespace", "SomeType").ToTypeSignature())
+                .MakeFunctionPointerType();
+
+            var imported = _importer.ImportTypeSignature(signature);
+
+            var newInstance = Assert.IsAssignableFrom<FunctionPointerTypeSignature>(imported);
+            Assert.NotSame(signature, newInstance);
+            Assert.Equal(signature, newInstance, _comparer);
+            Assert.Equal(_module, newInstance.Module);
+            Assert.Equal(_module, newInstance.Signature.ParameterTypes[0].Module);
+        }
+
+        [Fact]
+        public void ImportFunctionPointerTypeWithNonImportedReturnTypeShouldResultInNewInstance()
+        {
+            var signature = MethodSignature
+                .CreateStatic(
+                    new TypeReference(_dummyAssembly, "SomeNamespace", "SomeType").ToTypeSignature(),
+                    _module.CorLibTypeFactory.Int32)
+                .MakeFunctionPointerType();
+
+            var imported = _importer.ImportTypeSignature(signature);
+
+            var newInstance = Assert.IsAssignableFrom<FunctionPointerTypeSignature>(imported);
+            Assert.NotSame(signature, newInstance);
+            Assert.Equal(signature, newInstance, _comparer);
+            Assert.Equal(_module, newInstance.Module);
+            Assert.Equal(_module, newInstance.Signature.ReturnType.Module);
+        }
+
+        [Fact]
+        public void ImportFullyImportedFunctionPointerTypeShouldResultInSameInstance()
+        {
+            var signature = MethodSignature
+                .CreateStatic(
+                    _module.CorLibTypeFactory.Void,
+                    new TypeReference(_module, _dummyAssembly, "SomeNamespace", "SomeType").ToTypeSignature())
+                .MakeFunctionPointerType();
+
+            var imported = _importer.ImportTypeSignature(signature);
+
+            var newInstance = Assert.IsAssignableFrom<FunctionPointerTypeSignature>(imported);
+            Assert.Same(signature, newInstance);
         }
     }
 }


### PR DESCRIPTION
Includes:
- `IImportable` interface. 
- `ReferenceImporter` now does more thorough checks for whether a reference or signature was already fully imported or not.
- Fix for comparing `FunctionPointerTypeSignature`s.
- Fix for `TypeSpecificationSignature.Module` being null in some cases.

Closes #268 