### PR TITLE
Use actual types for private readonly fields

### DIFF
--- a/src/AsmResolver.DotNet/Builder/Metadata/Blob/BlobStreamBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Blob/BlobStreamBuffer.cs
@@ -14,7 +14,7 @@ namespace AsmResolver.DotNet.Builder.Metadata.Blob
     public class BlobStreamBuffer : IMetadataStreamBuffer
     {
         private readonly MemoryStream _rawStream = new();
-        private readonly IBinaryStreamWriter _writer;
+        private readonly BinaryStreamWriter _writer;
         private readonly Dictionary<byte[], uint> _blobs = new(ByteArrayEqualityComparer.Instance);
 
         /// <summary>

--- a/src/AsmResolver.DotNet/Builder/Metadata/Guid/GuidStreamBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Guid/GuidStreamBuffer.cs
@@ -13,7 +13,7 @@ namespace AsmResolver.DotNet.Builder.Metadata.Guid
     public class GuidStreamBuffer : IMetadataStreamBuffer
     {
         private readonly MemoryStream _rawStream = new();
-        private readonly IBinaryStreamWriter _writer;
+        private readonly BinaryStreamWriter _writer;
         private readonly Dictionary<System.Guid, uint> _guids = new();
 
         /// <summary>

--- a/src/AsmResolver.DotNet/Builder/Metadata/UserStrings/UserStringsStreamBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/UserStrings/UserStringsStreamBuffer.cs
@@ -14,7 +14,7 @@ namespace AsmResolver.DotNet.Builder.Metadata.UserStrings
     public class UserStringsStreamBuffer : IMetadataStreamBuffer
     {
         private readonly MemoryStream _rawStream = new();
-        private readonly IBinaryStreamWriter _writer;
+        private readonly BinaryStreamWriter _writer;
         private readonly Dictionary<string, uint> _strings = new();
 
         /// <summary>

--- a/src/AsmResolver.DotNet/Builder/Resources/DotNetResourcesDirectoryBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/Resources/DotNetResourcesDirectoryBuffer.cs
@@ -12,7 +12,7 @@ namespace AsmResolver.DotNet.Builder.Resources
     public class DotNetResourcesDirectoryBuffer
     {
         private readonly MemoryStream _rawStream = new();
-        private readonly IBinaryStreamWriter _writer;
+        private readonly BinaryStreamWriter _writer;
         private readonly Dictionary<byte[], uint> _dataOffsets = new(ByteArrayEqualityComparer.Instance);
 
         /// <summary>

--- a/src/AsmResolver.DotNet/Collections/ParameterCollection.cs
+++ b/src/AsmResolver.DotNet/Collections/ParameterCollection.cs
@@ -15,7 +15,7 @@ namespace AsmResolver.DotNet.Collections
     [DebuggerDisplay("Count = {" + nameof(Count) + "}")]
     public class ParameterCollection : IReadOnlyList<Parameter>
     {
-        private readonly IList<Parameter> _parameters = new List<Parameter>();
+        private readonly List<Parameter> _parameters = new List<Parameter>();
         private readonly MethodDefinition _owner;
         private bool _hasThis;
 

--- a/src/AsmResolver.DotNet/DefaultMetadataResolver.cs
+++ b/src/AsmResolver.DotNet/DefaultMetadataResolver.cs
@@ -12,7 +12,7 @@ namespace AsmResolver.DotNet
     /// </summary>
     public class DefaultMetadataResolver : IMetadataResolver
     {
-        private readonly IDictionary<ITypeDescriptor, TypeDefinition> _typeCache;
+        private readonly ConcurrentDictionary<ITypeDescriptor, TypeDefinition> _typeCache;
         private readonly SignatureComparer _comparer = new()
         {
             AcceptNewerAssemblyVersionNumbers = true
@@ -55,7 +55,7 @@ namespace AsmResolver.DotNet
                 // Check if type definition has changed since last lookup.
                 if (typeDef.IsTypeOf(type.Namespace, type.Name))
                     return typeDef;
-                _typeCache.Remove(type);
+                _typeCache.TryRemove(type, out _);
             }
 
             return null;

--- a/src/AsmResolver.PE.File/SerializedPEFile.cs
+++ b/src/AsmResolver.PE.File/SerializedPEFile.cs
@@ -10,7 +10,7 @@ namespace AsmResolver.PE.File
     /// </summary>
     public class SerializedPEFile : PEFile
     {
-        private readonly IList<SectionHeader> _sectionHeaders;
+        private readonly List<SectionHeader> _sectionHeaders;
         private readonly BinaryStreamReader _reader;
 
         /// <summary>

--- a/src/AsmResolver.PE.Win32Resources/Icon/IconResource.cs
+++ b/src/AsmResolver.PE.Win32Resources/Icon/IconResource.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -12,7 +12,7 @@ namespace AsmResolver.PE.Win32Resources.Icon
         /// <summary>
         /// Used to keep track of icon groups.
         /// </summary>
-        private readonly IDictionary<uint, IconGroupDirectory> _entries = new Dictionary<uint, IconGroupDirectory>();
+        private readonly Dictionary<uint, IconGroupDirectory> _entries = new Dictionary<uint, IconGroupDirectory>();
 
         /// <summary>
         /// Obtains the icon group resources from the provided root win32 resources directory.

--- a/src/AsmResolver.PE.Win32Resources/Version/StringTable.cs
+++ b/src/AsmResolver.PE.Win32Resources/Version/StringTable.cs
@@ -122,7 +122,7 @@ namespace AsmResolver.PE.Win32Resources.Version
             return new KeyValuePair<string, string>(header.Key, value);
         }
 
-        private readonly IDictionary<string, string> _entries = new Dictionary<string, string>();
+        private readonly Dictionary<string, string> _entries = new Dictionary<string, string>();
 
         /// <summary>
         /// Creates a new string table.

--- a/src/AsmResolver.PE.Win32Resources/Version/VersionInfoResource.cs
+++ b/src/AsmResolver.PE.Win32Resources/Version/VersionInfoResource.cs
@@ -98,7 +98,7 @@ namespace AsmResolver.PE.Win32Resources.Version
         }
 
         private FixedVersionInfo _fixedVersionInfo = new FixedVersionInfo();
-        private readonly IDictionary<string, VersionTableEntry> _entries = new Dictionary<string, VersionTableEntry>();
+        private readonly Dictionary<string, VersionTableEntry> _entries = new Dictionary<string, VersionTableEntry>();
 
         /// <inheritdoc />
         public override string Key => VsVersionInfoKey;

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/TablesStream.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/TablesStream.cs
@@ -31,7 +31,7 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables
         /// </summary>
         public const string UncompressedStreamName = "#Schema";
 
-        private readonly IDictionary<CodedIndex, IndexEncoder> _indexEncoders;
+        private readonly Dictionary<CodedIndex, IndexEncoder> _indexEncoders;
         private readonly LazyVariable<IList<IMetadataTable>> _tables;
         private readonly LazyVariable<IList<TableLayout>> _layouts;
 


### PR DESCRIPTION
Closes #271 

A note on the change from:
```cs
_typeCache.Remove(type);
```
To:
```cs
_typeCache.TryRemove(type, out _);
```
The runtime uses this behavior too:

https://github.com/dotnet/runtime/blob/3ae87395f638a533f37b8e3385f6d3f199a72f4f/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs#L1472