### PR TITLE
[Feature]: Custom ReferenceImporter in MemberCloner

### DIFF
--- a/src/AsmResolver.DotNet/Cloning/CloneContextAwareReferenceImporter.cs
+++ b/src/AsmResolver.DotNet/Cloning/CloneContextAwareReferenceImporter.cs
@@ -5,7 +5,10 @@ namespace AsmResolver.DotNet.Cloning
     /// </summary>
     public class CloneContextAwareReferenceImporter : ReferenceImporter
     {
-        private readonly MemberCloneContext _context;
+        /// <summary>
+        /// The working space for this member cloning procedure.
+        /// </summary>
+        protected readonly MemberCloneContext _context;
 
         /// <summary>
         /// Creates a new instance of the <see cref="CloneContextAwareReferenceImporter"/> class.

--- a/src/AsmResolver.DotNet/Cloning/CloneContextAwareReferenceImporter.cs
+++ b/src/AsmResolver.DotNet/Cloning/CloneContextAwareReferenceImporter.cs
@@ -5,10 +5,7 @@ namespace AsmResolver.DotNet.Cloning
     /// </summary>
     public class CloneContextAwareReferenceImporter : ReferenceImporter
     {
-        /// <summary>
-        /// The working space for this member cloning procedure.
-        /// </summary>
-        protected readonly MemberCloneContext _context;
+        private readonly MemberCloneContext _context;
 
         /// <summary>
         /// Creates a new instance of the <see cref="CloneContextAwareReferenceImporter"/> class.
@@ -19,6 +16,11 @@ namespace AsmResolver.DotNet.Cloning
         {
             _context = context;
         }
+
+        /// <summary>
+        /// The working space for this member cloning procedure.
+        /// </summary>
+        protected MemberCloneContext Context => _context;
 
         /// <inheritdoc />
         protected override ITypeDefOrRef ImportType(TypeDefinition type)

--- a/src/AsmResolver.DotNet/Cloning/MemberCloneContext.cs
+++ b/src/AsmResolver.DotNet/Cloning/MemberCloneContext.cs
@@ -12,9 +12,15 @@ namespace AsmResolver.DotNet.Cloning
         /// Creates a new instance of the <see cref="MemberCloneContext"/> class.
         /// </summary>
         /// <param name="module">The target module to copy the cloned members into.</param>
+        public MemberCloneContext(ModuleDefinition module) : this(module, null) { }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="MemberCloneContext"/> class.
+        /// </summary>
+        /// <param name="module">The target module to copy the cloned members into.</param>
         /// <param name="importerInstantiator">The instantiator for creating the reference importer</param>
         public MemberCloneContext(ModuleDefinition module,
-            Func<MemberCloneContext, CloneContextAwareReferenceImporter>? importerInstantiator = null)
+            Func<MemberCloneContext, CloneContextAwareReferenceImporter>? importerInstantiator)
         {
             Module = module ?? throw new ArgumentNullException(nameof(module));
             Importer = importerInstantiator?.Invoke(this) ?? new CloneContextAwareReferenceImporter(this);

--- a/src/AsmResolver.DotNet/Cloning/MemberCloneContext.cs
+++ b/src/AsmResolver.DotNet/Cloning/MemberCloneContext.cs
@@ -12,10 +12,12 @@ namespace AsmResolver.DotNet.Cloning
         /// Creates a new instance of the <see cref="MemberCloneContext"/> class.
         /// </summary>
         /// <param name="module">The target module to copy the cloned members into.</param>
-        public MemberCloneContext(ModuleDefinition module)
+        /// <param name="importerInstantiator">The instantiator for creating the reference importer</param>
+        public MemberCloneContext(ModuleDefinition module,
+            Func<MemberCloneContext, CloneContextAwareReferenceImporter>? importerInstantiator = null)
         {
             Module = module ?? throw new ArgumentNullException(nameof(module));
-            Importer = new CloneContextAwareReferenceImporter(this);
+            Importer = importerInstantiator?.Invoke(this) ?? new CloneContextAwareReferenceImporter(this);
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/Cloning/MemberCloneContext.cs
+++ b/src/AsmResolver.DotNet/Cloning/MemberCloneContext.cs
@@ -18,12 +18,12 @@ namespace AsmResolver.DotNet.Cloning
         /// Creates a new instance of the <see cref="MemberCloneContext"/> class.
         /// </summary>
         /// <param name="module">The target module to copy the cloned members into.</param>
-        /// <param name="importerInstantiator">The instantiator for creating the reference importer</param>
+        /// <param name="importerFactory">The factory for creating the reference importer</param>
         public MemberCloneContext(ModuleDefinition module,
-            Func<MemberCloneContext, CloneContextAwareReferenceImporter>? importerInstantiator)
+            Func<MemberCloneContext, CloneContextAwareReferenceImporter>? importerFactory)
         {
             Module = module ?? throw new ArgumentNullException(nameof(module));
-            Importer = importerInstantiator?.Invoke(this) ?? new CloneContextAwareReferenceImporter(this);
+            Importer = importerFactory?.Invoke(this) ?? new CloneContextAwareReferenceImporter(this);
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/Cloning/MemberCloner.cs
+++ b/src/AsmResolver.DotNet/Cloning/MemberCloner.cs
@@ -17,6 +17,7 @@ namespace AsmResolver.DotNet.Cloning
     /// </remarks>
     public partial class MemberCloner
     {
+        private readonly Func<MemberCloneContext, CloneContextAwareReferenceImporter>? _importerInstantiator;
         private readonly ModuleDefinition _targetModule;
 
         private readonly HashSet<TypeDefinition> _typesToClone = new();
@@ -29,9 +30,12 @@ namespace AsmResolver.DotNet.Cloning
         /// Creates a new instance of the <see cref="MemberCloner"/> class.
         /// </summary>
         /// <param name="targetModule">The target module to copy the members into.</param>
-        public MemberCloner(ModuleDefinition targetModule)
+        /// <param name="importerInstantiator">The instantiator for creating the reference importer</param>
+        public MemberCloner(ModuleDefinition targetModule,
+            Func<MemberCloneContext, CloneContextAwareReferenceImporter>? importerInstantiator = null)
         {
             _targetModule = targetModule ?? throw new ArgumentNullException(nameof(targetModule));
+            _importerInstantiator = importerInstantiator;
         }
 
         /// <summary>
@@ -220,7 +224,7 @@ namespace AsmResolver.DotNet.Cloning
         /// <returns>An object representing the result of the cloning process.</returns>
         public MemberCloneResult Clone()
         {
-            var context = new MemberCloneContext(_targetModule);
+            var context = new MemberCloneContext(_targetModule, _importerInstantiator);
 
             CreateMemberStubs(context);
             DeepCopyMembers(context);

--- a/src/AsmResolver.DotNet/Cloning/MemberCloner.cs
+++ b/src/AsmResolver.DotNet/Cloning/MemberCloner.cs
@@ -30,9 +30,15 @@ namespace AsmResolver.DotNet.Cloning
         /// Creates a new instance of the <see cref="MemberCloner"/> class.
         /// </summary>
         /// <param name="targetModule">The target module to copy the members into.</param>
+        public MemberCloner(ModuleDefinition targetModule) : this(targetModule, null) { }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="MemberCloner"/> class.
+        /// </summary>
+        /// <param name="targetModule">The target module to copy the members into.</param>
         /// <param name="importerInstantiator">The instantiator for creating the reference importer</param>
         public MemberCloner(ModuleDefinition targetModule,
-            Func<MemberCloneContext, CloneContextAwareReferenceImporter>? importerInstantiator = null)
+            Func<MemberCloneContext, CloneContextAwareReferenceImporter>? importerInstantiator)
         {
             _targetModule = targetModule ?? throw new ArgumentNullException(nameof(targetModule));
             _importerInstantiator = importerInstantiator;

--- a/src/AsmResolver.DotNet/Cloning/MemberCloner.cs
+++ b/src/AsmResolver.DotNet/Cloning/MemberCloner.cs
@@ -17,7 +17,7 @@ namespace AsmResolver.DotNet.Cloning
     /// </remarks>
     public partial class MemberCloner
     {
-        private readonly Func<MemberCloneContext, CloneContextAwareReferenceImporter>? _importerInstantiator;
+        private readonly Func<MemberCloneContext, CloneContextAwareReferenceImporter>? _importerFactory;
         private readonly ModuleDefinition _targetModule;
 
         private readonly HashSet<TypeDefinition> _typesToClone = new();
@@ -36,12 +36,12 @@ namespace AsmResolver.DotNet.Cloning
         /// Creates a new instance of the <see cref="MemberCloner"/> class.
         /// </summary>
         /// <param name="targetModule">The target module to copy the members into.</param>
-        /// <param name="importerInstantiator">The instantiator for creating the reference importer</param>
+        /// <param name="importerFactory">The factory for creating the reference importer</param>
         public MemberCloner(ModuleDefinition targetModule,
-            Func<MemberCloneContext, CloneContextAwareReferenceImporter>? importerInstantiator)
+            Func<MemberCloneContext, CloneContextAwareReferenceImporter>? importerFactory)
         {
             _targetModule = targetModule ?? throw new ArgumentNullException(nameof(targetModule));
-            _importerInstantiator = importerInstantiator;
+            _importerFactory = importerFactory;
         }
 
         /// <summary>
@@ -230,7 +230,7 @@ namespace AsmResolver.DotNet.Cloning
         /// <returns>An object representing the result of the cloning process.</returns>
         public MemberCloneResult Clone()
         {
-            var context = new MemberCloneContext(_targetModule, _importerInstantiator);
+            var context = new MemberCloneContext(_targetModule, _importerFactory);
 
             CreateMemberStubs(context);
             DeepCopyMembers(context);


### PR DESCRIPTION
A draft pull request for addressing #93

One of the major design decisions I made was to require that any custom importers inherit from `CloneContextAwareReferenceImporter` instead of `ReferenceImporter` or a hypothetical `IReferenceImporter` interface. I felt that this was the cleanest way to maintain correct references between cloned members.