### PR TITLE
[Feature]: Add a SetSemanticMethods method to PropertyDefinition and EventDefinition

### DIFF
--- a/src/AsmResolver.DotNet/EventDefinition.cs
+++ b/src/AsmResolver.DotNet/EventDefinition.cs
@@ -170,7 +170,7 @@ namespace AsmResolver.DotNet
         /// <param name="addMethod">The method definition representing the add accessor of this event definition.</param>
         /// <param name="removeMethod">The method definition representing the remove accessor of this event definition.</param>
         /// <param name="fireMethod">The method definition representing the fire accessor of this event definition.</param>
-        public void ApplyMethods(MethodDefinition? addMethod, MethodDefinition? removeMethod, MethodDefinition? fireMethod)
+        public void SetSemanticMethods(MethodDefinition? addMethod, MethodDefinition? removeMethod, MethodDefinition? fireMethod)
         {
             Semantics.Clear();
             if (addMethod is not null)

--- a/src/AsmResolver.DotNet/EventDefinition.cs
+++ b/src/AsmResolver.DotNet/EventDefinition.cs
@@ -136,19 +136,19 @@ namespace AsmResolver.DotNet
         }
 
         /// <summary>
-        /// Gets the method definition representing the add accessor of this event definition.
+        /// Gets the method definition representing the first add accessor of this event definition.
         /// </summary>
         public MethodDefinition? AddMethod =>
             Semantics.FirstOrDefault(s => s.Attributes == MethodSemanticsAttributes.AddOn)?.Method;
 
         /// <summary>
-        /// Gets the method definition representing the remove accessor of this event definition.
+        /// Gets the method definition representing the first remove accessor of this event definition.
         /// </summary>
         public MethodDefinition? RemoveMethod =>
             Semantics.FirstOrDefault(s => s.Attributes == MethodSemanticsAttributes.RemoveOn)?.Method;
 
         /// <summary>
-        /// Gets the method definition representing the fire accessor of this event definition.
+        /// Gets the method definition representing the first fire accessor of this event definition.
         /// </summary>
         public MethodDefinition? FireMethod =>
             Semantics.FirstOrDefault(s => s.Attributes == MethodSemanticsAttributes.Fire)?.Method;
@@ -162,6 +162,23 @@ namespace AsmResolver.DotNet
                     Interlocked.CompareExchange(ref _customAttributes, GetCustomAttributes(), null);
                 return _customAttributes;
             }
+        }
+
+        /// <summary>
+        /// Clear <see cref="Semantics"/> and apply these methods to the event definition.
+        /// </summary>
+        /// <param name="addMethod">The method definition representing the add accessor of this event definition.</param>
+        /// <param name="removeMethod">The method definition representing the remove accessor of this event definition.</param>
+        /// <param name="fireMethod">The method definition representing the fire accessor of this event definition.</param>
+        public void ApplyMethods(MethodDefinition? addMethod, MethodDefinition? removeMethod, MethodDefinition? fireMethod)
+        {
+            Semantics.Clear();
+            if (addMethod is not null)
+                Semantics.Add(new MethodSemantics(addMethod, MethodSemanticsAttributes.AddOn));
+            if (removeMethod is not null)
+                Semantics.Add(new MethodSemantics(removeMethod, MethodSemanticsAttributes.RemoveOn));
+            if (fireMethod is not null)
+                Semantics.Add(new MethodSemantics(fireMethod, MethodSemanticsAttributes.Fire));
         }
 
         /// <inheritdoc />
@@ -188,7 +205,7 @@ namespace AsmResolver.DotNet
             new OwnedCollection<IHasCustomAttribute, CustomAttribute>(this);
 
         /// <summary>
-        /// Obtains the name of the property definition.
+        /// Obtains the name of the event definition.
         /// </summary>
         /// <returns>The name.</returns>
         /// <remarks>
@@ -197,7 +214,7 @@ namespace AsmResolver.DotNet
         protected virtual Utf8String? GetName() => null;
 
         /// <summary>
-        /// Obtains the event type of the property definition.
+        /// Obtains the event type of the event definition.
         /// </summary>
         /// <returns>The event type.</returns>
         /// <remarks>
@@ -206,7 +223,7 @@ namespace AsmResolver.DotNet
         protected virtual ITypeDefOrRef? GetEventType() => null;
 
         /// <summary>
-        /// Obtains the declaring type of the property definition.
+        /// Obtains the declaring type of the event definition.
         /// </summary>
         /// <returns>The declaring type.</returns>
         /// <remarks>
@@ -215,7 +232,7 @@ namespace AsmResolver.DotNet
         protected virtual TypeDefinition? GetDeclaringType() => null;
 
         /// <summary>
-        /// Obtains the methods associated to this property definition.
+        /// Obtains the methods associated to this event definition.
         /// </summary>
         /// <returns>The method semantic objects.</returns>
         /// <remarks>

--- a/src/AsmResolver.DotNet/PropertyDefinition.cs
+++ b/src/AsmResolver.DotNet/PropertyDefinition.cs
@@ -186,7 +186,7 @@ namespace AsmResolver.DotNet
         /// </summary>
         /// <param name="getMethod">The method definition representing the get accessor of this property definition.</param>
         /// <param name="setMethod">The method definition representing the set accessor of this property definition.</param>
-        public void ApplyMethods(MethodDefinition? getMethod, MethodDefinition? setMethod)
+        public void SetSemanticMethods(MethodDefinition? getMethod, MethodDefinition? setMethod)
         {
             Semantics.Clear();
             if (getMethod is not null)

--- a/src/AsmResolver.DotNet/PropertyDefinition.cs
+++ b/src/AsmResolver.DotNet/PropertyDefinition.cs
@@ -170,16 +170,30 @@ namespace AsmResolver.DotNet
         }
 
         /// <summary>
-        /// Gets the method definition representing the get accessor of this property definition.
+        /// Gets the method definition representing the first get accessor of this property definition.
         /// </summary>
         public MethodDefinition? GetMethod =>
             Semantics.FirstOrDefault(s => s.Attributes == MethodSemanticsAttributes.Getter)?.Method;
 
         /// <summary>
-        /// Gets the method definition representing the set accessor of this property definition.
+        /// Gets the method definition representing the first set accessor of this property definition.
         /// </summary>
         public MethodDefinition? SetMethod =>
             Semantics.FirstOrDefault(s => s.Attributes == MethodSemanticsAttributes.Setter)?.Method;
+
+        /// <summary>
+        /// Clear <see cref="Semantics"/> and apply these methods to the property definition.
+        /// </summary>
+        /// <param name="getMethod">The method definition representing the get accessor of this property definition.</param>
+        /// <param name="setMethod">The method definition representing the set accessor of this property definition.</param>
+        public void ApplyMethods(MethodDefinition? getMethod, MethodDefinition? setMethod)
+        {
+            Semantics.Clear();
+            if (getMethod is not null)
+                Semantics.Add(new MethodSemantics(getMethod, MethodSemanticsAttributes.Getter));
+            if (setMethod is not null)
+                Semantics.Add(new MethodSemantics(setMethod, MethodSemanticsAttributes.Setter));
+        }
 
         /// <inheritdoc />
         public bool IsAccessibleFromType(TypeDefinition type) =>


### PR DESCRIPTION
Closes #168 

I named these 2 methods `ApplyMethods`. Do you prefer them to be named something different?