### PR TITLE
[Feature]: Allow .NET 6 assembly trimming for PE.File, PE and Win32Resources

### DIFF
--- a/src/AsmResolver.DotNet/Code/Cil/CilMethodBody.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilMethodBody.cs
@@ -136,6 +136,7 @@ namespace AsmResolver.DotNet.Code.Cil
         /// <param name="method">The method that owns the method body.</param>
         /// <param name="dynamicMethodObj">The Dynamic Method/Delegate/DynamicResolver.</param>
         /// <returns>The method body.</returns>
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Calls ResolveDynamicResolver")]
         public static CilMethodBody FromDynamicMethod(MethodDefinition method, object dynamicMethodObj)
         {
             if (!(method.Module is SerializedModuleDefinition module))

--- a/src/AsmResolver.DotNet/Config/Json/RuntimeConfiguration.cs
+++ b/src/AsmResolver.DotNet/Config/Json/RuntimeConfiguration.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace AsmResolver.DotNet.Config.Json
 {
@@ -9,13 +8,6 @@ namespace AsmResolver.DotNet.Config.Json
     /// </summary>
     public class RuntimeConfiguration
     {
-        private static readonly JsonSerializerOptions JsonSerializerOptions = new()
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            WriteIndented = true,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-        };
-
         /// <summary>
         /// Parses runtime configuration from a JSON file.
         /// </summary>
@@ -33,7 +25,7 @@ namespace AsmResolver.DotNet.Config.Json
         /// <returns>The parsed runtime configuration.</returns>
         public static RuntimeConfiguration? FromJson(string json)
         {
-            return JsonSerializer.Deserialize<RuntimeConfiguration>(json, JsonSerializerOptions);
+            return JsonSerializer.Deserialize(json, RuntimeConfigurationSerializerContext.Default.RuntimeConfiguration);
         }
 
         /// <summary>
@@ -67,7 +59,7 @@ namespace AsmResolver.DotNet.Config.Json
         /// <returns>The JSON string.</returns>
         public string ToJson()
         {
-            return JsonSerializer.Serialize(this, JsonSerializerOptions);
+            return JsonSerializer.Serialize(this, RuntimeConfigurationSerializerContext.Default.RuntimeConfiguration);
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/Config/Json/RuntimeConfigurationSerializerContext.cs
+++ b/src/AsmResolver.DotNet/Config/Json/RuntimeConfigurationSerializerContext.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace AsmResolver.DotNet.Config.Json
+{
+    [JsonSourceGenerationOptions(
+        PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonSerializable(typeof(RuntimeConfiguration))]
+    internal partial class RuntimeConfigurationSerializerContext : JsonSerializerContext
+    {
+    }
+}

--- a/src/AsmResolver.DotNet/DynamicMethodDefinition.cs
+++ b/src/AsmResolver.DotNet/DynamicMethodDefinition.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Signatures;
@@ -18,6 +18,7 @@ namespace AsmResolver.DotNet
         /// </summary>
         /// <param name="module">Target Module</param>
         /// <param name="dynamicMethodObj">Dynamic Method / Delegate / DynamicResolver</param>
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Calls ResolveDynamicResolver and FromDynamicMethod")]
         public DynamicMethodDefinition(ModuleDefinition module,object dynamicMethodObj) :
             base(new MetadataToken(TableIndex.Method, 0))
         {

--- a/src/AsmResolver.DotNet/DynamicMethodHelper.cs
+++ b/src/AsmResolver.DotNet/DynamicMethodHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -81,6 +81,7 @@ namespace AsmResolver.DotNet
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Calls GetTypes")]
         public static object ResolveDynamicResolver(object dynamicMethodObj)
         {
             //Convert dynamicMethodObj to DynamicResolver

--- a/src/AsmResolver.DotNet/RequiresUnreferencedCodeAttribute.cs
+++ b/src/AsmResolver.DotNet/RequiresUnreferencedCodeAttribute.cs
@@ -1,0 +1,34 @@
+#if !NET6_0_OR_GREATER
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Indicates that the specified method requires dynamic access to code that is not
+    /// referenced statically, for example, through System.Reflection.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Method, Inherited = false)]
+    internal sealed class RequiresUnreferencedCodeAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets a message that contains information about the usage of unreferenced code.
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// Gets or sets an optional URL that contains more information about the method,
+        /// why it requires unreferenced code, and what options a consumer has to deal with
+        /// it.
+        /// </summary>
+        public string? Url { get; set; }
+ 
+        /// <summary>
+        /// Initializes a new instance of the System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute
+        /// class with the specified message.
+        /// </summary>
+        /// <param name="message">A message that contains information about the usage of unreferenced code.</param>
+        public RequiresUnreferencedCodeAttribute(string message)
+        {
+            Message = message;
+        }
+    }
+}
+#endif

--- a/src/AsmResolver.PE.File/AsmResolver.PE.File.csproj
+++ b/src/AsmResolver.PE.File/AsmResolver.PE.File.csproj
@@ -9,6 +9,7 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Nullable>enable</Nullable>
         <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
+        <IsTrimmable>true</IsTrimmable>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/AsmResolver.PE.Win32Resources/AsmResolver.PE.Win32Resources.csproj
+++ b/src/AsmResolver.PE.Win32Resources/AsmResolver.PE.Win32Resources.csproj
@@ -7,6 +7,7 @@
         <NoWarn>1701;1702;NU5105</NoWarn>
         <Nullable>enable</Nullable>
         <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
+        <IsTrimmable>true</IsTrimmable>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/AsmResolver.PE/AsmResolver.PE.csproj
+++ b/src/AsmResolver.PE/AsmResolver.PE.csproj
@@ -8,6 +8,7 @@
         <NoWarn>1701;1702;NU5105</NoWarn>
         <Nullable>enable</Nullable>
         <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
+        <IsTrimmable>true</IsTrimmable>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/AsmResolver/AsmResolver.csproj
+++ b/src/AsmResolver/AsmResolver.csproj
@@ -3,11 +3,12 @@
     <PropertyGroup>
         <Title>AsmResolver</Title>
         <Description>The base library for the AsmResolver executable file inspection toolsuite.</Description>
-       <PackageTags>exe pe dotnet cil inspection manipulation assembly disassembly</PackageTags>
+        <PackageTags>exe pe dotnet cil inspection manipulation assembly disassembly</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <NoWarn>1701;1702;NU5105</NoWarn>
         <Nullable>enable</Nullable>
         <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
+        <IsTrimmable>true</IsTrimmable>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/test/AsmResolver.PE.Tests/DotNet/Metadata/UserStringsStreamTest.cs
+++ b/test/AsmResolver.PE.Tests/DotNet/Metadata/UserStringsStreamTest.cs
@@ -22,7 +22,7 @@ namespace AsmResolver.PE.Tests.DotNet.Metadata
         [InlineData("")]
         [InlineData("ABC")]
         [InlineData("DEF")]
-        public void FindExistingString(string? value) => AssertHasString(new byte[]
+        public void FindExistingString(string value) => AssertHasString(new byte[]
             {
                 0x00,
                 0x07, 0x41, 0x00, 0x42, 0x00, 0x43, 0x00, 0x00,


### PR DESCRIPTION
I was able to add trimming for:
* `AsmResolver`
* `AsmResolver.PE`
* `AsmResolver.PE.File`
* `AsmResolver.PE.Win32Resources`

I was not able to add trimming to `AsmResolver.DotNet`. Problems originated from only 3 files:
* `DynamicMethodHelper.cs`
* `ReferenceImporter.cs`
* `RuntimeConfiguration.cs`

Annotating these couple uses of json and reflection quickly devolved into me needing to annotate most of the library.