### PR TITLE
Add and use collection Capacity properties

### DIFF
--- a/src/AsmResolver.DotNet/Builder/DotNetDirectoryBuffer.MemberTree.cs
+++ b/src/AsmResolver.DotNet/Builder/DotNetDirectoryBuffer.MemberTree.cs
@@ -132,6 +132,9 @@ namespace AsmResolver.DotNet.Builder
             var typeDefTable = Metadata.TablesStream.GetTable<TypeDefinitionRow>(TableIndex.TypeDef);
             var nestedClassTable = Metadata.TablesStream.GetSortedTable<TypeDefinition, NestedClassRow>(TableIndex.NestedClass);
 
+            if (types is ICollection<TypeDefinition> collection)
+                typeDefTable.EnsureCapacity(typeDefTable.Count + collection.Count);
+
             foreach (var type in types)
             {
                 // At this point, we might not have added all type defs/refs/specs yet, so we cannot determine
@@ -177,6 +180,8 @@ namespace AsmResolver.DotNet.Builder
         public void DefineFields(IEnumerable<FieldDefinition> fields)
         {
             var table = Metadata.TablesStream.GetTable<FieldDefinitionRow>(TableIndex.Field);
+            if (fields is ICollection<FieldDefinition> collection)
+                table.EnsureCapacity(table.Count + collection.Count);
 
             foreach (var field in fields)
             {
@@ -197,6 +202,8 @@ namespace AsmResolver.DotNet.Builder
         public void DefineMethods(IEnumerable<MethodDefinition> methods)
         {
             var table = Metadata.TablesStream.GetTable<MethodDefinitionRow>(TableIndex.Method);
+            if (methods is ICollection<MethodDefinition> collection)
+                table.EnsureCapacity(table.Count + collection.Count);
 
             foreach (var method in methods)
             {
@@ -227,6 +234,8 @@ namespace AsmResolver.DotNet.Builder
         public void DefineParameters(IEnumerable<ParameterDefinition> parameters)
         {
             var table = Metadata.TablesStream.GetTable<ParameterDefinitionRow>(TableIndex.Param);
+            if (parameters is ICollection<ParameterDefinition> collection)
+                table.EnsureCapacity(table.Count + collection.Count);
 
             foreach (var parameter in parameters)
             {
@@ -247,6 +256,8 @@ namespace AsmResolver.DotNet.Builder
         public void DefineProperties(IEnumerable<PropertyDefinition> properties)
         {
             var table = Metadata.TablesStream.GetTable<PropertyDefinitionRow>(TableIndex.Property);
+            if (properties is ICollection<PropertyDefinition> collection)
+                table.EnsureCapacity(table.Count + collection.Count);
 
             foreach (var property in properties)
             {
@@ -267,6 +278,8 @@ namespace AsmResolver.DotNet.Builder
         public void DefineEvents(IEnumerable<EventDefinition> events)
         {
             var table = Metadata.TablesStream.GetTable<EventDefinitionRow>(TableIndex.Event);
+            if (events is ICollection<EventDefinition> collection)
+                table.EnsureCapacity(table.Count + collection.Count);
 
             foreach (var @event in events)
             {
@@ -298,6 +311,17 @@ namespace AsmResolver.DotNet.Builder
             uint methodList = 1;
             uint propertyList = 1;
             uint eventList = 1;
+
+            tablesStream.GetTable<FieldPointerRow>(TableIndex.FieldPtr)
+                .EnsureCapacity(tablesStream.GetTable<FieldDefinitionRow>(TableIndex.Field).Count);
+            tablesStream.GetTable<MethodPointerRow>(TableIndex.MethodPtr)
+                .EnsureCapacity(tablesStream.GetTable<MethodDefinitionRow>(TableIndex.Method).Count);
+            tablesStream.GetTable<ParameterPointerRow>(TableIndex.ParamPtr)
+                .EnsureCapacity(tablesStream.GetTable<ParameterDefinitionRow>(TableIndex.Param).Count);
+            tablesStream.GetTable<PropertyPointerRow>(TableIndex.PropertyPtr)
+                .EnsureCapacity(tablesStream.GetTable<PropertyDefinitionRow>(TableIndex.Property).Count);
+            tablesStream.GetTable<EventPointerRow>(TableIndex.EventPtr)
+                .EnsureCapacity(tablesStream.GetTable<EventDefinitionRow>(TableIndex.Event).Count);
 
             for (uint rid = 1; rid <= typeDefTable.Count; rid++)
             {

--- a/src/AsmResolver.DotNet/Builder/Metadata/Tables/DistinctMetadataTableBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Tables/DistinctMetadataTableBuffer.cs
@@ -45,6 +45,16 @@ namespace AsmResolver.DotNet.Builder.Metadata.Tables
         }
 
         /// <inheritdoc />
+        public void EnsureCapacity(int capacity)
+        {
+            _underlyingBuffer.EnsureCapacity(capacity);
+
+#if NETSTANDARD2_1_OR_GREATER
+            _entries.EnsureCapacity(capacity);
+#endif
+        }
+
+        /// <inheritdoc />
         public ref TRow GetRowRef(uint rid) => ref _underlyingBuffer.GetRowRef(rid);
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/Builder/Metadata/Tables/IMetadataTableBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Tables/IMetadataTableBuffer.cs
@@ -45,6 +45,12 @@ namespace AsmResolver.DotNet.Builder.Metadata.Tables
         }
 
         /// <summary>
+        /// Ensures the capacity of the table buffer is at least the provided amount of elements.
+        /// </summary>
+        /// <param name="capacity">The number of elements to store.</param>
+        void EnsureCapacity(int capacity);
+
+        /// <summary>
         /// Gets or sets a reference to a row in the metadata table.
         /// </summary>
         /// <param name="rid">The identifier of the metadata row.</param>

--- a/src/AsmResolver.DotNet/Builder/Metadata/Tables/UnsortedMetadataTableBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Tables/UnsortedMetadataTableBuffer.cs
@@ -37,6 +37,13 @@ namespace AsmResolver.DotNet.Builder.Metadata.Tables
         }
 
         /// <inheritdoc />
+        public void EnsureCapacity(int capacity)
+        {
+            if (_entries.Capacity < capacity)
+                _entries.Capacity = capacity;
+        }
+
+        /// <inheritdoc />
         public ref TRow GetRowRef(uint rid) => ref _entries.GetElementRef((int)(rid - 1));
 
         /// <inheritdoc />
@@ -49,6 +56,9 @@ namespace AsmResolver.DotNet.Builder.Metadata.Tables
         /// <inheritdoc />
         public void FlushToTable()
         {
+            if (_table.Capacity < _entries.Count)
+                _table.Capacity = _entries.Count;
+
             foreach (var row in _entries)
                 _table.Add(row);
         }

--- a/src/AsmResolver.DotNet/Collections/MethodSemanticsCollection.cs
+++ b/src/AsmResolver.DotNet/Collections/MethodSemanticsCollection.cs
@@ -20,6 +20,16 @@ namespace AsmResolver.DotNet.Collections
         {
         }
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="MethodSemanticsCollection"/> class.
+        /// </summary>
+        /// <param name="owner">The owner of the collection.</param>
+        /// <param name="capacity">The initial number of elements the collection can store.</param>
+        public MethodSemanticsCollection(IHasSemantics owner, int capacity)
+            : base(owner, capacity)
+        {
+        }
+
         internal bool ValidateMembership
         {
             get;

--- a/src/AsmResolver.DotNet/Serialized/SerializedGenericParameter.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedGenericParameter.cs
@@ -58,10 +58,11 @@ namespace AsmResolver.DotNet.Serialized
         /// <inheritdoc />
         protected override IList<GenericParameterConstraint> GetConstraints()
         {
-            var result = new OwnedCollection<GenericParameter, GenericParameterConstraint>(this);
-
             var module = _context.ParentModule;
-            foreach (uint rid in module.GetGenericParameterConstraints(MetadataToken))
+            var rids = module.GetGenericParameterConstraints(MetadataToken);
+            var result = new OwnedCollection<GenericParameter, GenericParameterConstraint>(this, rids.Count);
+
+            foreach (uint rid in rids)
             {
                 var constraintToken = new MetadataToken(TableIndex.GenericParamConstraint, rid);
                 result.Add((GenericParameterConstraint) module.LookupMember(constraintToken));

--- a/src/AsmResolver.DotNet/Serialized/SerializedMethodDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedMethodDefinition.cs
@@ -81,9 +81,10 @@ namespace AsmResolver.DotNet.Serialized
         /// <inheritdoc />
         protected override IList<ParameterDefinition> GetParameterDefinitions()
         {
-            var result = new OwnedCollection<MethodDefinition, ParameterDefinition>(this);
+            var parameterRange = _context.ParentModule.GetParameterRange(MetadataToken.Rid);
+            var result = new OwnedCollection<MethodDefinition, ParameterDefinition>(this, parameterRange.Count);
 
-            foreach (var token in _context.ParentModule.GetParameterRange(MetadataToken.Rid))
+            foreach (var token in parameterRange)
             {
                 if (_context.ParentModule.TryLookupMember(token, out var member) && member is ParameterDefinition parameter)
                     result.Add(parameter);
@@ -108,9 +109,10 @@ namespace AsmResolver.DotNet.Serialized
         /// <inheritdoc />
         protected override IList<GenericParameter> GetGenericParameters()
         {
-            var result = new OwnedCollection<IHasGenericParameters, GenericParameter>(this);
+            var rids = _context.ParentModule.GetGenericParameters(MetadataToken);
+            var result = new OwnedCollection<IHasGenericParameters, GenericParameter>(this, rids.Count);
 
-            foreach (uint rid in _context.ParentModule.GetGenericParameters(MetadataToken))
+            foreach (uint rid in rids)
             {
                 if (_context.ParentModule.TryLookupMember(new MetadataToken(TableIndex.GenericParam, rid), out var member)
                     && member is GenericParameter genericParameter)

--- a/src/AsmResolver.DotNet/Serialized/SerializedModuleDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedModuleDefinition.cs
@@ -204,11 +204,17 @@ namespace AsmResolver.DotNet.Serialized
         {
             EnsureTypeDefinitionTreeInitialized();
 
-            var types = new OwnedCollection<ModuleDefinition, TypeDefinition>(this);
-
             var typeDefTable = ReaderContext.Metadata
                 .GetStream<TablesStream>()
                 .GetTable<TypeDefinitionRow>(TableIndex.TypeDef);
+
+            int nestedTypeCount = ReaderContext.Metadata
+                .GetStream<TablesStream>()
+                .GetTable(TableIndex.NestedClass)
+                .Count;
+
+            var types = new OwnedCollection<ModuleDefinition, TypeDefinition>(this,
+                typeDefTable.Count - nestedTypeCount);
 
             for (int i = 0; i < typeDefTable.Count; i++)
             {
@@ -226,11 +232,11 @@ namespace AsmResolver.DotNet.Serialized
         /// <inheritdoc />
         protected override IList<AssemblyReference> GetAssemblyReferences()
         {
-            var result = new OwnedCollection<ModuleDefinition, AssemblyReference>(this);
-
             var table = ReaderContext.Metadata
                 .GetStream<TablesStream>()
                 .GetTable<AssemblyReferenceRow>(TableIndex.AssemblyRef);
+
+            var result = new OwnedCollection<ModuleDefinition, AssemblyReference>(this, table.Count);
 
             // Don't use the member factory here, this method may be called before the member factory is initialized.
             for (int i = 0; i < table.Count; i++)
@@ -245,11 +251,11 @@ namespace AsmResolver.DotNet.Serialized
         /// <inheritdoc />
         protected override IList<ModuleReference> GetModuleReferences()
         {
-            var result = new OwnedCollection<ModuleDefinition, ModuleReference>(this);
-
             var table = ReaderContext.Metadata
                 .GetStream<TablesStream>()
                 .GetTable(TableIndex.ModuleRef);
+
+            var result = new OwnedCollection<ModuleDefinition, ModuleReference>(this, table.Count);
 
             for (int i = 0; i < table.Count; i++)
             {
@@ -264,11 +270,11 @@ namespace AsmResolver.DotNet.Serialized
         /// <inheritdoc />
         protected override IList<FileReference> GetFileReferences()
         {
-            var result = new OwnedCollection<ModuleDefinition, FileReference>(this);
-
             var table = ReaderContext.Metadata
                 .GetStream<TablesStream>()
                 .GetTable(TableIndex.File);
+
+            var result = new OwnedCollection<ModuleDefinition, FileReference>(this, table.Count);
 
             for (int i = 0; i < table.Count; i++)
             {
@@ -283,11 +289,11 @@ namespace AsmResolver.DotNet.Serialized
         /// <inheritdoc />
         protected override IList<ManifestResource> GetResources()
         {
-            var result = new OwnedCollection<ModuleDefinition, ManifestResource>(this);
-
             var table = ReaderContext.Metadata
                 .GetStream<TablesStream>()
                 .GetTable(TableIndex.ManifestResource);
+
+            var result = new OwnedCollection<ModuleDefinition, ManifestResource>(this, table.Count);
 
             for (int i = 0; i < table.Count; i++)
             {
@@ -302,11 +308,11 @@ namespace AsmResolver.DotNet.Serialized
         /// <inheritdoc />
         protected override IList<ExportedType> GetExportedTypes()
         {
-            var result = new OwnedCollection<ModuleDefinition, ExportedType>(this);
-
             var table = ReaderContext.Metadata
                 .GetStream<TablesStream>()
                 .GetTable(TableIndex.ExportedType);
+
+            var result = new OwnedCollection<ModuleDefinition, ExportedType>(this, table.Count);
 
             for (int i = 0; i < table.Count; i++)
             {
@@ -350,12 +356,11 @@ namespace AsmResolver.DotNet.Serialized
 
             if (assemblyTable.Count > 0)
             {
-                var assembly = new SerializedAssemblyDefinition(
+                return new SerializedAssemblyDefinition(
                     ReaderContext,
                     new MetadataToken(TableIndex.Assembly, 1),
                     assemblyTable[0],
                     this);
-                return assembly;
             }
 
             return null;

--- a/src/AsmResolver.DotNet/Serialized/SerializedPropertyDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedPropertyDefinition.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Collections;
 using AsmResolver.PE.DotNet.Metadata;
@@ -70,11 +71,13 @@ namespace AsmResolver.DotNet.Serialized
         /// <inheritdoc />
         protected override IList<MethodSemantics> GetSemantics()
         {
-            var result = new MethodSemanticsCollection(this);
+            var module = _context.ParentModule;
+            var rids = module.GetMethodSemantics(MetadataToken);
+
+            var result = new MethodSemanticsCollection(this, rids.Count);
             result.ValidateMembership = false;
 
-            var module = _context.ParentModule;
-            foreach (uint rid in module.GetMethodSemantics(MetadataToken))
+            foreach (uint rid in rids)
             {
                 var semanticsToken = new MetadataToken(TableIndex.MethodSemantics, rid);
                 result.Add((MethodSemantics) module.LookupMember(semanticsToken));

--- a/src/AsmResolver.DotNet/Signatures/CustomAttributeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/CustomAttributeSignature.cs
@@ -12,6 +12,8 @@ namespace AsmResolver.DotNet.Signatures
     /// </summary>
     public class CustomAttributeSignature : ExtendableBlobSignature
     {
+        private readonly List<CustomAttributeArgument> _fixedArguments;
+        private readonly List<CustomAttributeNamedArgument> _namedArguments;
         private const ushort CustomAttributeSignaturePrologue = 0x0001;
 
         /// <summary>
@@ -35,18 +37,20 @@ namespace AsmResolver.DotNet.Signatures
 
             // Read fixed arguments.
             var parameterTypes = ctor.Signature?.ParameterTypes ?? Array.Empty<TypeSignature>();
+            result._fixedArguments.Capacity = parameterTypes.Count;
             for (int i = 0; i < parameterTypes.Count; i++)
             {
                 var argument = CustomAttributeArgument.FromReader(context, parameterTypes[i], ref reader);
-                result.FixedArguments.Add(argument);
+                result._fixedArguments.Add(argument);
             }
 
             // Read named arguments.
             ushort namedArgumentCount = reader.ReadUInt16();
+            result._namedArguments.Capacity = namedArgumentCount;
             for (int i = 0; i < namedArgumentCount; i++)
             {
                 var argument = CustomAttributeNamedArgument.FromReader(context, ref reader);
-                result.NamedArguments.Add(argument);
+                result._namedArguments.Add(argument);
             }
 
             return result;
@@ -73,25 +77,19 @@ namespace AsmResolver.DotNet.Signatures
         /// </summary>
         public CustomAttributeSignature(IEnumerable<CustomAttributeArgument> fixedArguments, IEnumerable<CustomAttributeNamedArgument> namedArguments)
         {
-            FixedArguments = new List<CustomAttributeArgument>(fixedArguments);
-            NamedArguments = new List<CustomAttributeNamedArgument>(namedArguments);
+            _fixedArguments = new List<CustomAttributeArgument>(fixedArguments);
+            _namedArguments = new List<CustomAttributeNamedArgument>(namedArguments);
         }
 
         /// <summary>
         /// Gets a collection of fixed arguments that are passed onto the constructor of the attribute.
         /// </summary>
-        public IList<CustomAttributeArgument> FixedArguments
-        {
-            get;
-        }
+        public IList<CustomAttributeArgument> FixedArguments => _fixedArguments;
 
         /// <summary>
         /// Gets a collection of values that are assigned to fields and/or members of the attribute class.
         /// </summary>
-        public IList<CustomAttributeNamedArgument> NamedArguments
-        {
-            get;
-        }
+        public IList<CustomAttributeNamedArgument> NamedArguments => _namedArguments;
 
         /// <inheritdoc />
         public override string ToString()

--- a/src/AsmResolver.DotNet/Signatures/GenericInstanceMethodSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/GenericInstanceMethodSignature.cs
@@ -21,14 +21,14 @@ namespace AsmResolver.DotNet.Signatures
             }
 
             var attributes = (CallingConventionAttributes) reader.ReadByte();
-            var result = new GenericInstanceMethodSignature(attributes);
 
             if (!reader.TryReadCompressedUInt32(out uint count))
             {
                 context.ReaderContext.BadImage("Invalid number of type arguments in generic method signature.");
-                return result;
+                return new GenericInstanceMethodSignature(attributes);
             }
 
+            var result = new GenericInstanceMethodSignature(attributes, (int) count);
             for (int i = 0; i < count; i++)
                 result.TypeArguments.Add(TypeSignature.FromReader(context, ref reader));
 
@@ -42,6 +42,17 @@ namespace AsmResolver.DotNet.Signatures
         public GenericInstanceMethodSignature(CallingConventionAttributes attributes)
             : this(attributes, Enumerable.Empty<TypeSignature>())
         {
+        }
+
+        /// <summary>
+        /// Creates a new instantiation signature for a generic method.
+        /// </summary>
+        /// <param name="attributes">The attributes.</param>
+        /// <param name="capacity">The initial number of elements that the <see cref="TypeArguments"/> property can store.</param>
+        public GenericInstanceMethodSignature(CallingConventionAttributes attributes, int capacity)
+            : base(attributes)
+        {
+            TypeArguments = new List<TypeSignature>(capacity);
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/Signatures/MethodSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/MethodSignature.cs
@@ -20,8 +20,10 @@ namespace AsmResolver.DotNet.Signatures
         /// <returns>The method signature.</returns>
         public static MethodSignature FromReader(in BlobReadContext context, ref BinaryStreamReader reader)
         {
-            var result = new MethodSignature((CallingConventionAttributes) reader.ReadByte(),
-                context.ReaderContext.ParentModule.CorLibTypeFactory.Void, Enumerable.Empty<TypeSignature>());
+            var result = new MethodSignature(
+                (CallingConventionAttributes) reader.ReadByte(),
+                context.ReaderContext.ParentModule.CorLibTypeFactory.Void,
+                Enumerable.Empty<TypeSignature>());
 
             // Generic parameter count.
             if (result.IsGeneric)

--- a/src/AsmResolver.DotNet/Signatures/MethodSignatureBase.cs
+++ b/src/AsmResolver.DotNet/Signatures/MethodSignatureBase.cs
@@ -10,28 +10,27 @@ namespace AsmResolver.DotNet.Signatures
     /// </summary>
     public abstract class MethodSignatureBase : MemberSignature
     {
+        private readonly List<TypeSignature> _parameterTypes;
+
         /// <summary>
         /// Initializes the base of a method signature.
         /// </summary>
-        /// <param name="attributes"></param>
-        /// <param name="memberReturnType"></param>
-        /// <param name="parameterTypes"></param>
+        /// <param name="attributes">The attributes associated to the signature.</param>
+        /// <param name="memberReturnType">The return type of the member.</param>
+        /// <param name="parameterTypes">The types of all (non-sentinel) parameters.</param>
         protected MethodSignatureBase(
             CallingConventionAttributes attributes,
             TypeSignature memberReturnType,
             IEnumerable<TypeSignature> parameterTypes)
             : base(attributes, memberReturnType)
         {
-            ParameterTypes = new List<TypeSignature>(parameterTypes);
+            _parameterTypes = new List<TypeSignature>(parameterTypes);
         }
 
         /// <summary>
         /// Gets an ordered list of types indicating the types of the parameters that this member defines.
         /// </summary>
-        public IList<TypeSignature> ParameterTypes
-        {
-            get;
-        }
+        public IList<TypeSignature> ParameterTypes => _parameterTypes;
 
         /// <summary>
         /// Gets or sets the type of the value that this member returns.
@@ -120,6 +119,7 @@ namespace AsmResolver.DotNet.Signatures
             ReturnType = TypeSignature.FromReader(context, ref reader);
 
             // Parameter types.
+            _parameterTypes.Capacity = (int) parameterCount;
             bool sentinel = false;
             for (int i = 0; i < parameterCount; i++)
             {

--- a/src/AsmResolver.DotNet/Signatures/Types/ArrayTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/ArrayTypeSignature.cs
@@ -87,7 +87,7 @@ namespace AsmResolver.DotNet.Signatures.Types
                 return signature;
             }
 
-            var sizes = new List<uint>();
+            var sizes = new List<uint>((int) numSizes);
             for (int i = 0; i < numSizes; i++)
             {
                 if (!reader.TryReadCompressedUInt32(out uint size))
@@ -106,7 +106,7 @@ namespace AsmResolver.DotNet.Signatures.Types
                 return signature;
             }
 
-            var loBounds = new List<uint>();
+            var loBounds = new List<uint>((int) numLoBounds);
             for (int i = 0; i < numLoBounds; i++)
             {
                 if (!reader.TryReadCompressedUInt32(out uint bound))

--- a/src/AsmResolver.DotNet/Signatures/Types/FunctionPointerTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/FunctionPointerTypeSignature.cs
@@ -47,7 +47,7 @@ namespace AsmResolver.DotNet.Signatures.Types
 
         /// <inheritdoc />
         public override ITypeDefOrRef? GetUnderlyingTypeDefOrRef() =>
-            Signature?.ReturnType?.Module?.CorLibTypeFactory.IntPtr.Type;
+            Signature.ReturnType.Module?.CorLibTypeFactory.IntPtr.Type;
 
         /// <inheritdoc />
         public override bool IsImportedInModule(ModuleDefinition module) => Signature.IsImportedInModule(module);

--- a/src/AsmResolver.DotNet/Signatures/Types/GenericInstanceTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/GenericInstanceTypeSignature.cs
@@ -10,6 +10,8 @@ namespace AsmResolver.DotNet.Signatures.Types
     /// </summary>
     public class GenericInstanceTypeSignature : TypeSignature, IGenericArgumentsProvider
     {
+        private readonly List<TypeSignature> _typeArguments;
+
         internal new static GenericInstanceTypeSignature FromReader(in BlobReadContext context, ref BinaryStreamReader reader)
         {
             var genericType = TypeSignature.FromReader(context, ref reader);
@@ -21,8 +23,9 @@ namespace AsmResolver.DotNet.Signatures.Types
                 return signature;
             }
 
+            signature._typeArguments.Capacity = (int) count;
             for (int i = 0; i < count; i++)
-                signature.TypeArguments.Add(TypeSignature.FromReader(context, ref reader));
+                signature._typeArguments.Add(TypeSignature.FromReader(context, ref reader));
 
             return signature;
         }
@@ -53,7 +56,7 @@ namespace AsmResolver.DotNet.Signatures.Types
             IEnumerable<TypeSignature> typeArguments)
         {
             GenericType = genericType;
-            TypeArguments = new List<TypeSignature>(typeArguments);
+            _typeArguments = new List<TypeSignature>(typeArguments);
             IsValueType = isValueType;
         }
 
@@ -72,10 +75,7 @@ namespace AsmResolver.DotNet.Signatures.Types
         /// <summary>
         /// Gets a collection of type arguments used to instantiate the generic type.
         /// </summary>
-        public IList<TypeSignature> TypeArguments
-        {
-            get;
-        }
+        public IList<TypeSignature> TypeArguments => _typeArguments;
 
         /// <inheritdoc />
         public override string? Name

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/MetadataTable.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/MetadataTable.cs
@@ -88,6 +88,15 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables
         /// <inheritdoc cref="ICollection{T}.Count" />
         public virtual int Count => Rows.Count;
 
+        /// <summary>
+        /// Gets or sets the total number of rows that the underlying array can store.
+        /// </summary>
+        public int Capacity
+        {
+            get => Rows.Capacity;
+            set => Rows.Capacity = value;
+        }
+
         /// <inheritdoc />
         public bool IsReadOnly => false; // TODO: it might be necessary later to make this configurable.
 

--- a/src/AsmResolver/Collections/LazyList.cs
+++ b/src/AsmResolver/Collections/LazyList.cs
@@ -12,7 +12,24 @@ namespace AsmResolver.Collections
     [DebuggerDisplay("Count = {" + nameof(Count) + "}")]
     public abstract class LazyList<TItem> : IList<TItem>
     {
-        private readonly List<TItem> _items = new();
+        private readonly List<TItem> _items;
+
+        /// <summary>
+        /// Creates a new, empty, uninitialized list.
+        /// </summary>
+        public LazyList()
+        {
+            _items = new List<TItem>();
+        }
+
+        /// <summary>
+        /// Creates a new, empty, uninitialized list.
+        /// </summary>
+        /// <param name="capacity">The initial number of elements the list can store.</param>
+        public LazyList(int capacity)
+        {
+            _items = new List<TItem>(capacity);
+        }
 
         /// <inheritdoc />
         public TItem this[int index]
@@ -37,6 +54,15 @@ namespace AsmResolver.Collections
                 EnsureIsInitialized();
                 return Items.Count;
             }
+        }
+
+        /// <summary>
+        /// Gets or sets the total number of elements the list can contain before it has to resize its internal buffer.
+        /// </summary>
+        public int Capacity
+        {
+            get => _items.Capacity;
+            set => _items.Capacity = value;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver/Collections/OneToManyRelation.cs
+++ b/src/AsmResolver/Collections/OneToManyRelation.cs
@@ -11,8 +11,27 @@ namespace AsmResolver.Collections
         where TKey : notnull
         where TValue : notnull
     {
-        private readonly Dictionary<TKey, ICollection<TValue>> _memberLists = new();
-        private readonly Dictionary<TValue, TKey> _memberOwners = new();
+        private readonly Dictionary<TKey, ICollection<TValue>> _memberLists;
+        private readonly Dictionary<TValue, TKey> _memberOwners;
+
+        /// <summary>
+        /// Creates a new, empty one-to-many relation mapping.
+        /// </summary>
+        public OneToManyRelation()
+        {
+            _memberLists = new Dictionary<TKey, ICollection<TValue>>();
+            _memberOwners = new Dictionary<TValue, TKey>();
+        }
+
+        /// <summary>
+        /// Creates a new, empty one-to-many relation mapping.
+        /// </summary>
+        /// <param name="capacity">The initial number of elements the relation can store.</param>
+        public OneToManyRelation(int capacity)
+        {
+            _memberLists = new Dictionary<TKey, ICollection<TValue>>(capacity);
+            _memberOwners = new Dictionary<TValue, TKey>(capacity);
+        }
 
         /// <summary>
         /// Registers a relation between two objects.

--- a/src/AsmResolver/Collections/OneToOneRelation.cs
+++ b/src/AsmResolver/Collections/OneToOneRelation.cs
@@ -11,8 +11,27 @@ namespace AsmResolver.Collections
         where TKey : notnull
         where TValue : notnull
     {
-        private readonly Dictionary<TKey, TValue> _keyToValue = new();
-        private readonly Dictionary<TValue, TKey> _valueToKey = new();
+        private readonly Dictionary<TKey, TValue> _keyToValue;
+        private readonly Dictionary<TValue, TKey> _valueToKey;
+
+        /// <summary>
+        /// Creates a new, empty one-to-one mapping.
+        /// </summary>
+        public OneToOneRelation()
+        {
+            _keyToValue = new Dictionary<TKey, TValue>();
+            _valueToKey = new Dictionary<TValue, TKey>();
+        }
+
+        /// <summary>
+        /// Creates a new, empty one-to-one mapping.
+        /// </summary>
+        /// <param name="capacity">The initial number of elements the relation can store.</param>
+        public OneToOneRelation(int capacity)
+        {
+            _keyToValue = new Dictionary<TKey, TValue>(capacity);
+            _valueToKey = new Dictionary<TValue, TKey>(capacity);
+        }
 
         /// <summary>
         /// Registers a one-to-one relation between two objects.

--- a/src/AsmResolver/Collections/OwnedCollection.cs
+++ b/src/AsmResolver/Collections/OwnedCollection.cs
@@ -27,6 +27,17 @@ namespace AsmResolver.Collections
         }
 
         /// <summary>
+        /// Creates a new empty collection that is owned by an object.
+        /// </summary>
+        /// <param name="owner">The owner of the collection.</param>
+        /// <param name="capacity">The initial number of elements the collection can store.</param>
+        public OwnedCollection(TOwner owner, int capacity)
+            : base(capacity)
+        {
+            Owner = owner ?? throw new ArgumentNullException(nameof(owner));
+        }
+
+        /// <summary>
         /// Gets the owner of the collection.
         /// </summary>
         public TOwner Owner

--- a/src/AsmResolver/Collections/RefList.cs
+++ b/src/AsmResolver/Collections/RefList.cs
@@ -46,9 +46,23 @@ namespace AsmResolver.Collections
         public int Count => _count;
 
         /// <summary>
-        /// Gets the capacity of the underlying array.
+        /// Gets or sets the total number of elements that the underlying array can store.
         /// </summary>
-        public int Capacity => _items.Length;
+        public int Capacity
+        {
+            get => _items.Length;
+            set
+            {
+                if (value == _items.Length)
+                    return;
+
+                if (value < _count)
+                    throw new ArgumentException("Capacity must be equal or larger than the current number of elements in the list.");
+
+                EnsureEnoughCapacity(value);
+                IncrementVersion();
+            }
+        }
 
         /// <summary>
         /// Gets a number indicating the current version of the list.
@@ -248,7 +262,7 @@ namespace AsmResolver.Collections
 
         private void EnsureEnoughCapacity(int requiredCount)
         {
-            if (_items.Length >= requiredCount)
+            if (_items.Length >= requiredCount) 
                 return;
 
             int newCapacity = _items.Length == 0 ? 1 : _items.Length * 2;

--- a/src/AsmResolver/Collections/RefList.cs
+++ b/src/AsmResolver/Collections/RefList.cs
@@ -59,7 +59,7 @@ namespace AsmResolver.Collections
                 if (value < _count)
                     throw new ArgumentException("Capacity must be equal or larger than the current number of elements in the list.");
 
-                EnsureEnoughCapacity(value);
+                EnsureCapacity(value);
                 IncrementVersion();
             }
         }
@@ -141,7 +141,7 @@ namespace AsmResolver.Collections
         /// <param name="item">The element.</param>
         public void Add(in T item)
         {
-            EnsureEnoughCapacity(_count + 1);
+            EnsureCapacity(_count + 1);
             _items[_count] = item;
             _count++;
             IncrementVersion();
@@ -208,7 +208,7 @@ namespace AsmResolver.Collections
         /// <param name="item">The element to insert.</param>
         public void Insert(int index, in T item)
         {
-            EnsureEnoughCapacity(_count + 1);
+            EnsureCapacity(_count + 1);
 
             if (index < _count)
                 Array.Copy(_items, index, _items, index + 1, _count - index);
@@ -260,9 +260,9 @@ namespace AsmResolver.Collections
                 throw new IndexOutOfRangeException();
         }
 
-        private void EnsureEnoughCapacity(int requiredCount)
+        private void EnsureCapacity(int requiredCount)
         {
-            if (_items.Length >= requiredCount) 
+            if (_items.Length >= requiredCount)
                 return;
 
             int newCapacity = _items.Length == 0 ? 1 : _items.Length * 2;

--- a/test/AsmResolver.Tests/Collections/RefListTest.cs
+++ b/test/AsmResolver.Tests/Collections/RefListTest.cs
@@ -1,3 +1,4 @@
+using System;
 using AsmResolver.Collections;
 using Xunit;
 
@@ -9,6 +10,47 @@ namespace AsmResolver.Tests.Collections
         public void EmptyList()
         {
             Assert.Empty(new RefList<int>());
+        }
+
+        [Fact]
+        public void SetCapacityToCount()
+        {
+            var list = new RefList<int>
+            {
+                1,
+                2,
+                3
+            };
+
+            list.Capacity = 3;
+            Assert.True(list.Capacity >= 3);
+        }
+
+        [Fact]
+        public void SetCapacityToLargerThanCount()
+        {
+            var list = new RefList<int>
+            {
+                1,
+                2,
+                3
+            };
+
+            list.Capacity = 6;
+            Assert.True(list.Capacity >= 6);
+        }
+
+        [Fact]
+        public void SetCapacityToSmallerThanCountShouldThrow()
+        {
+            var list = new RefList<int>
+            {
+                1,
+                2,
+                3
+            };
+
+            Assert.Throws<ArgumentException>(() => list.Capacity = 2);
         }
 
         [Fact]


### PR DESCRIPTION
Includes:
- Add `RefList::Capacity.set`
- Add `IMetadataTableBuffer::EnsureCapacity(int)`
- Changes some internal `ModuleDefinition::GetXCollection` methods to return `ICollection<T>` instead of `IEnumerable<T>`.
- Use of `List.Capacity` in various reader and builder methods when the number of elements to add is known.
