### PR TITLE
Rentable BinaryStreamWriters that write to temporary MemoryStream

### DIFF
--- a/src/AsmResolver.DotNet/Builder/Metadata/Blob/BlobStreamBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/Blob/BlobStreamBuffer.cs
@@ -17,6 +17,8 @@ namespace AsmResolver.DotNet.Builder.Metadata.Blob
         private readonly BinaryStreamWriter _writer;
         private readonly Dictionary<byte[], uint> _blobs = new(ByteArrayEqualityComparer.Instance);
 
+        private readonly MemoryStreamWriterPool _blobWriterPool = new();
+
         /// <summary>
         /// Creates a new blob stream buffer with the default blob stream name.
         /// </summary>
@@ -116,11 +118,11 @@ namespace AsmResolver.DotNet.Builder.Metadata.Blob
                 return 0u;
 
             // Serialize blob.
-            using var stream = new MemoryStream();
-            var writer = new BinaryStreamWriter(stream);
-            signature.Write(new BlobSerializationContext(writer, provider, errorListener));
 
-            return GetBlobIndex(stream.ToArray());
+            using var rentedWriter = _blobWriterPool.Rent();
+            signature.Write(new BlobSerializationContext(rentedWriter.Writer, provider, errorListener));
+
+            return GetBlobIndex(rentedWriter.GetData());
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/Code/Cil/CilMethodBodySerializer.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilMethodBodySerializer.cs
@@ -15,6 +15,8 @@ namespace AsmResolver.DotNet.Code.Cil
     /// </summary>
     public class CilMethodBodySerializer : IMethodBodySerializer
     {
+        private readonly MemoryStreamWriterPool _writerPool = new();
+
         /// <summary>
         /// Gets or sets the value of an override switch indicating whether the max stack should always be recalculated
         /// or should always be preserved.
@@ -88,7 +90,7 @@ namespace AsmResolver.DotNet.Code.Cil
             }
 
             // Serialize CIL stream.
-            var code = BuildRawCodeStream(context, body);
+            byte[] code = BuildRawCodeStream(context, body);
 
             // Build method body.
             var rawBody = body.IsFat
@@ -98,8 +100,7 @@ namespace AsmResolver.DotNet.Code.Cil
             return rawBody.ToReference();
         }
 
-        private static CilRawMethodBody BuildTinyMethodBody(byte[] code) =>
-            new CilRawTinyMethodBody(code);
+        private static CilRawMethodBody BuildTinyMethodBody(byte[] code) => new CilRawTinyMethodBody(code);
 
         private CilRawMethodBody BuildFatMethodBody(MethodBodySerializationContext context, CilMethodBody body, byte[] code)
         {
@@ -137,35 +138,33 @@ namespace AsmResolver.DotNet.Code.Cil
             return fatBody;
         }
 
-        private static byte[] BuildRawCodeStream(MethodBodySerializationContext context, CilMethodBody body)
+        private byte[] BuildRawCodeStream(MethodBodySerializationContext context, CilMethodBody body)
         {
-            using var codeStream = new MemoryStream();
             var bag = context.ErrorListener;
 
-            var writer = new BinaryStreamWriter(codeStream);
+            using var rentedWriter = _writerPool.Rent();
             var assembler = new CilAssembler(
-                writer,
+                rentedWriter.Writer,
                 new CilOperandBuilder(context.TokenProvider, bag),
                 body.Owner.SafeToString,
                 bag);
 
             assembler.WriteInstructions(body.Instructions);
 
-            return codeStream.ToArray();
+            return rentedWriter.GetData();
         }
 
         private byte[] SerializeExceptionHandlers(MethodBodySerializationContext context, IList<CilExceptionHandler> exceptionHandlers, bool needsFatFormat)
         {
-            using var sectionStream = new MemoryStream();
-            var writer = new BinaryStreamWriter(sectionStream);
+            using var rentedWriter = _writerPool.Rent();
 
             for (int i = 0; i < exceptionHandlers.Count; i++)
             {
                 var handler = exceptionHandlers[i];
-                WriteExceptionHandler(context, writer, handler, needsFatFormat);
+                WriteExceptionHandler(context, rentedWriter.Writer, handler, needsFatFormat);
             }
 
-            return sectionStream.ToArray();
+            return rentedWriter.GetData();
         }
 
         private void WriteExceptionHandler(MethodBodySerializationContext context, IBinaryStreamWriter writer, CilExceptionHandler handler, bool useFatFormat)

--- a/src/AsmResolver/IO/BinaryStreamWriter.cs
+++ b/src/AsmResolver/IO/BinaryStreamWriter.cs
@@ -8,107 +8,113 @@ namespace AsmResolver.IO
     /// </summary>
     public class BinaryStreamWriter : IBinaryStreamWriter
     {
-        private readonly Stream _stream;
-
         /// <summary>
         /// Creates a new binary stream writer using the provided output stream.
         /// </summary>
         /// <param name="stream">The stream to write to.</param>
         public BinaryStreamWriter(Stream stream)
         {
-            _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+            BaseStream = stream ?? throw new ArgumentNullException(nameof(stream));
+        }
+
+        /// <summary>
+        /// Gets the stream this writer writes to.
+        /// </summary>
+        public Stream BaseStream
+        {
+            get;
         }
 
         /// <inheritdoc />
         public ulong Offset
         {
-            get => (uint) _stream.Position;
+            get => (uint) BaseStream.Position;
             set
             {
                 // Check if position actually changed before actually setting. If we don't do this, this can cause
                 // performance issues on some systems. See https://github.com/Washi1337/AsmResolver/issues/232
-                if (_stream.Position != (long) value)
-                    _stream.Position = (long) value;
+                if (BaseStream.Position != (long) value)
+                    BaseStream.Position = (long) value;
             }
         }
 
         /// <inheritdoc />
-        public uint Length => (uint) _stream.Length;
+        public uint Length => (uint) BaseStream.Length;
 
         /// <inheritdoc />
         public void WriteBytes(byte[] buffer, int startIndex, int count)
         {
-            _stream.Write(buffer, startIndex, count);
+            BaseStream.Write(buffer, startIndex, count);
         }
 
         /// <inheritdoc />
         public void WriteByte(byte value)
         {
-            _stream.WriteByte(value);
+            BaseStream.WriteByte(value);
         }
 
         /// <inheritdoc />
         public void WriteUInt16(ushort value)
         {
-            _stream.WriteByte((byte) (value & 0xFF));
-            _stream.WriteByte((byte) ((value >> 8) & 0xFF));
+            BaseStream.WriteByte((byte) (value & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 8) & 0xFF));
         }
 
         /// <inheritdoc />
         public void WriteUInt32(uint value)
         {
-            _stream.WriteByte((byte) (value & 0xFF));
-            _stream.WriteByte((byte) ((value >> 8) & 0xFF));
-            _stream.WriteByte((byte) ((value >> 16) & 0xFF));
-            _stream.WriteByte((byte) ((value >> 24) & 0xFF));
+            BaseStream.WriteByte((byte) (value & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 8) & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 16) & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 24) & 0xFF));
         }
 
         /// <inheritdoc />
         public void WriteUInt64(ulong value)
         {
-            _stream.WriteByte((byte) (value & 0xFF));
-            _stream.WriteByte((byte) ((value >> 8) & 0xFF));
-            _stream.WriteByte((byte) ((value >> 16) & 0xFF));
-            _stream.WriteByte((byte) ((value >> 24) & 0xFF));
-            _stream.WriteByte((byte) ((value >> 32) & 0xFF));
-            _stream.WriteByte((byte) ((value >> 40) & 0xFF));
-            _stream.WriteByte((byte) ((value >> 48) & 0xFF));
-            _stream.WriteByte((byte) ((value >> 56) & 0xFF));
+            BaseStream.WriteByte((byte) (value & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 8) & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 16) & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 24) & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 32) & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 40) & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 48) & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 56) & 0xFF));
         }
 
         /// <inheritdoc />
         public void WriteSByte(sbyte value)
         {
-            _stream.WriteByte(unchecked((byte) value));
+            BaseStream.WriteByte(unchecked((byte) value));
         }
 
         /// <inheritdoc />
         public void WriteInt16(short value)
         {
-            _stream.WriteByte((byte) (value & 0xFF));
-            _stream.WriteByte((byte) ((value >> 8) & 0xFF));
+            BaseStream.WriteByte((byte) (value & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 8) & 0xFF));
         }
 
         /// <inheritdoc />
         public void WriteInt32(int value)
         {
-            _stream.WriteByte((byte) (value & 0xFF));
-            _stream.WriteByte((byte) ((value >> 8) & 0xFF));
-            _stream.WriteByte((byte) ((value >> 16) & 0xFF));
-            _stream.WriteByte((byte) ((value >> 24) & 0xFF));
+            BaseStream.WriteByte((byte) (value & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 8) & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 16) & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 24) & 0xFF));
         }
 
         /// <inheritdoc />
         public void WriteInt64(long value)
         {
-            _stream.WriteByte((byte) (value & 0xFF));
-            _stream.WriteByte((byte) ((value >> 8) & 0xFF));
-            _stream.WriteByte((byte) ((value >> 16) & 0xFF));
-            _stream.WriteByte((byte) ((value >> 24) & 0xFF));
-            _stream.WriteByte((byte) ((value >> 32) & 0xFF));
-            _stream.WriteByte((byte) ((value >> 40) & 0xFF));
-            _stream.WriteByte((byte) ((value >> 48) & 0xFF));
-            _stream.WriteByte((byte) ((value >> 56) & 0xFF));
+            BaseStream.WriteByte((byte) (value & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 8) & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 16) & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 24) & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 32) & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 40) & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 48) & 0xFF));
+            BaseStream.WriteByte((byte) ((value >> 56) & 0xFF));
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver/IO/MemoryStreamWriterPool.cs
+++ b/src/AsmResolver/IO/MemoryStreamWriterPool.cs
@@ -8,6 +8,9 @@ namespace AsmResolver.IO
     /// Provides a pool of reusable instances of <see cref="BinaryStreamWriter"/> that are meant to be used for
     /// constructing byte arrays.
     /// </summary>
+    /// <remarks>
+    /// This class is thread-safe. All threads are allowed to rent and return writers from this pool simultaneously.
+    /// </remarks>
     public class MemoryStreamWriterPool
     {
         private readonly ConcurrentQueue<BinaryStreamWriter> _writers = new();

--- a/src/AsmResolver/IO/MemoryStreamWriterPool.cs
+++ b/src/AsmResolver/IO/MemoryStreamWriterPool.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+
+namespace AsmResolver.IO
+{
+    /// <summary>
+    /// Provides a pool of reusable instances of <see cref="BinaryStreamWriter"/> that are meant to be used for
+    /// constructing byte arrays.
+    /// </summary>
+    public class MemoryStreamWriterPool
+    {
+        private readonly ConcurrentQueue<BinaryStreamWriter> _writers = new();
+
+        /// <summary>
+        /// Rents a single binary stream writer.
+        /// </summary>
+        /// <returns>The writer.</returns>
+        public RentedWriter Rent()
+        {
+            if (!_writers.TryDequeue(out var writer))
+                writer = new BinaryStreamWriter(new MemoryStream());
+
+            writer.BaseStream.SetLength(0);
+            return new RentedWriter(this, writer);
+        }
+
+        private void Return(BinaryStreamWriter writer) => _writers.Enqueue(writer);
+
+        /// <summary>
+        /// Represents a single instance of a <see cref="BinaryStreamWriter"/> that is rented by a writer pool.
+        /// </summary>
+        public readonly struct RentedWriter : IDisposable
+        {
+            internal RentedWriter(MemoryStreamWriterPool pool, BinaryStreamWriter writer)
+            {
+                Pool = pool;
+                Writer = writer;
+            }
+
+            /// <summary>
+            /// Gets the pool the writer was rented from.
+            /// </summary>
+            public MemoryStreamWriterPool Pool
+            {
+                get;
+            }
+
+            /// <summary>
+            /// Gets the writer instance.
+            /// </summary>
+            public BinaryStreamWriter Writer
+            {
+                get;
+            }
+
+            /// <summary>
+            /// Gets the data that was written to the temporary stream.
+            /// </summary>
+            /// <returns></returns>
+            public byte[] GetData() => ((MemoryStream) Writer.BaseStream).ToArray();
+
+            /// <inheritdoc />
+            public void Dispose() => Pool.Return(Writer);
+        }
+    }
+}

--- a/test/AsmResolver.Tests/IO/MemoryStreamReaderPoolTest.cs
+++ b/test/AsmResolver.Tests/IO/MemoryStreamReaderPoolTest.cs
@@ -1,0 +1,136 @@
+using System;
+using System.IO;
+using System.Linq;
+using AsmResolver.IO;
+using Xunit;
+
+namespace AsmResolver.Tests.IO
+{
+    public class MemoryStreamReaderPoolTest
+    {
+        private readonly MemoryStreamWriterPool _pool = new();
+
+        [Fact]
+        public void RentShouldStartWithEmptyStream()
+        {
+            using (var rent = _pool.Rent())
+            {
+                Assert.Equal(0u, rent.Writer.Length);
+                rent.Writer.WriteInt64(0x0123456789abcdef);
+                Assert.Equal(8u, rent.Writer.Length);
+            }
+
+            using (var rent = _pool.Rent())
+            {
+                Assert.Equal(0u, rent.Writer.Length);
+            }
+        }
+
+        [Fact]
+        public void RentBeforeDisposeShouldUseNewBackendStream()
+        {
+            using var rent1 = _pool.Rent();
+            using var rent2 = _pool.Rent();
+            Assert.NotSame(rent1.Writer.BaseStream, rent2.Writer.BaseStream);
+        }
+
+        [Fact]
+        public void RentAfterDisposeShouldReuseBackendStream()
+        {
+            Stream stream;
+            using (var rent = _pool.Rent())
+            {
+                stream = rent.Writer.BaseStream;
+            }
+
+            using (var rent = _pool.Rent())
+            {
+                Assert.Same(stream, rent.Writer.BaseStream);
+            }
+        }
+
+        [Fact]
+        public void RentAfterDisposeShouldReuseBackendStream2()
+        {
+            var rent1 = _pool.Rent();
+            var rent2 = _pool.Rent();
+            var stream2 = rent2.Writer.BaseStream;
+            var rent3 = _pool.Rent();
+
+            rent2.Dispose();
+            var rent4 = _pool.Rent();
+
+            Assert.Same(stream2, rent4.Writer.BaseStream);
+        }
+
+        [Fact]
+        public void GetFinalData()
+        {
+            byte[] value = Enumerable.Range(0, 255)
+                .Select(x => (byte) x)
+                .ToArray();
+
+            using var rent = _pool.Rent();
+            rent.Writer.WriteBytes(value);
+            rent.Writer.WriteBytes(value);
+            Assert.Equal(value.Concat(value), rent.GetData());
+        }
+
+        [Fact]
+        public void UseAfterDisposeShouldThrow()
+        {
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                var rent = _pool.Rent();
+                rent.Dispose();
+                rent.Writer.WriteInt64(0);
+            });
+
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                var rent = _pool.Rent();
+                rent.Dispose();
+                return rent.GetData();
+            });
+        }
+
+        [Fact]
+        public void DisposeTwiceShouldNotReturnTwice()
+        {
+            var rent1 = _pool.Rent();
+            var stream = rent1.Writer.BaseStream;
+
+            rent1.Dispose();
+            rent1.Dispose();
+
+            var rent2 = _pool.Rent();
+            var rent3 = _pool.Rent();
+
+            Assert.Same(stream, rent2.Writer.BaseStream);
+            Assert.NotSame(stream, rent3.Writer.BaseStream);
+        }
+
+        [Fact]
+        public void GetDataShouldNotResultInSameInstance()
+        {
+            byte[] data1;
+
+            using (var rent1 = _pool.Rent())
+            {
+                rent1.Writer.WriteInt64(0x0123456789abcdef);
+                data1 = rent1.GetData();
+                byte[] data2 = rent1.GetData();
+                Assert.Equal(data1, data2);
+                Assert.NotSame(data1, data2);
+            }
+
+            using (var rent2 = _pool.Rent())
+            {
+                rent2.Writer.WriteInt64(0x0123456789abcdef);
+                byte[] data3 = rent2.GetData();
+                Assert.Equal(data1, data3);
+                Assert.NotSame(data1, data3);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds `MemoryStreamWriterPool` class that allows for renting `BinaryStreamWriter` instances from a pool. This significantly reduces the amount of allocated writer objects, as well as backing buffers when serializing code streams and blob signatures.
