### PR TITLE
Update SignatureComparer.TypeDefOrRef.cs

### DIFF
--- a/src/AsmResolver.DotNet/Signatures/SignatureComparer.ResolutionScope.cs
+++ b/src/AsmResolver.DotNet/Signatures/SignatureComparer.ResolutionScope.cs
@@ -85,7 +85,7 @@ namespace AsmResolver.DotNet.Signatures
 
             return versionMatch
                    && x.Name == y.Name
-                   && x.Culture == y.Culture
+                   && (x.Culture == y.Culture || (Utf8String.IsNullOrEmpty(x.Culture) && Utf8String.IsNullOrEmpty(y.Culture)))
                    && Equals(x.GetPublicKeyToken(), y.GetPublicKeyToken());
         }
 

--- a/src/AsmResolver.DotNet/Signatures/SignatureComparer.TypeDefOrRef.cs
+++ b/src/AsmResolver.DotNet/Signatures/SignatureComparer.TypeDefOrRef.cs
@@ -43,21 +43,15 @@ namespace AsmResolver.DotNet.Signatures
 
         private bool SimpleTypeEquals(ITypeDescriptor x, ITypeDescriptor y)
         {
-            // Namespace can be null if It is a nested type so we need to check declaring type too
-            if (x.DeclaringType?.Name != y.DeclaringType?.Name)
-                return false;
             // Check the basic properties first.
-            else if (!x.IsTypeOf(y.Namespace, y.Name))
+            if (!x.IsTypeOf(y.Namespace, y.Name))
                 return false;
-
             // If scope matches, it is a perfect match.
             if (Equals(x.Scope, y.Scope))
                 return true;
-
-            // If scope does not match, it can still be a reference to an exported type.
-            return x.Resolve() is { } definition1
-                   && y.Resolve() is { } definition2
-                   && Equals(definition1.Module!.Assembly, definition2.Module!.Assembly);
+            if (!Equals(x.Module, y.Module))
+                return x.Resolve() is { } definition1 && y.Resolve() is { } definition2 && Equals(definition1.Module!.Assembly, definition2.Module!.Assembly);
+            return false;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/Signatures/SignatureComparer.TypeDefOrRef.cs
+++ b/src/AsmResolver.DotNet/Signatures/SignatureComparer.TypeDefOrRef.cs
@@ -46,11 +46,14 @@ namespace AsmResolver.DotNet.Signatures
             // Check the basic properties first.
             if (!x.IsTypeOf(y.Namespace, y.Name))
                 return false;
+
+            if (x.DeclaringType != null && y.DeclaringType != null && !Equals(x.DeclaringType, y.DeclaringType))
+                return false;
+
+            var scopeCheck = Equals(x.Scope, y.Scope);
             // If scope matches, it is a perfect match.
-            if (Equals(x.Scope, y.Scope))
+            if (scopeCheck || (!scopeCheck && x.Resolve() is { } definition1 && y.Resolve() is { } definition2 && Equals(definition1.Module!.Assembly, definition2.Module!.Assembly)))
                 return true;
-            if (!Equals(x.Module, y.Module))
-                return x.Resolve() is { } definition1 && y.Resolve() is { } definition2 && Equals(definition1.Module!.Assembly, definition2.Module!.Assembly);
             return false;
         }
 

--- a/src/AsmResolver.DotNet/Signatures/SignatureComparer.TypeDefOrRef.cs
+++ b/src/AsmResolver.DotNet/Signatures/SignatureComparer.TypeDefOrRef.cs
@@ -43,8 +43,11 @@ namespace AsmResolver.DotNet.Signatures
 
         private bool SimpleTypeEquals(ITypeDescriptor x, ITypeDescriptor y)
         {
+            // Namespace can be null if It is a nested type so we need to check declaring type too
+            if (x.DeclaringType?.Name != y.DeclaringType?.Name)
+                return false;
             // Check the basic properties first.
-            if (!x.IsTypeOf(y.Namespace, y.Name))
+            else if (!x.IsTypeOf(y.Namespace, y.Name))
                 return false;
 
             // If scope matches, it is a perfect match.

--- a/test/AsmResolver.DotNet.Tests/Signatures/SignatureComparerTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Signatures/SignatureComparerTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Types;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
@@ -113,6 +114,36 @@ namespace AsmResolver.DotNet.Tests.Signatures
             var signature2 = PropertySignature.CreateStatic(type.ToTypeSignature());
 
             Assert.Equal(signature1, signature2, _comparer);
+        }
+
+        [Fact]
+        public void MatchNestedTypes()
+        {
+            var nestedTypes = ModuleDefinition.FromModule(typeof(SignatureComparerTest).Assembly.ManifestModule).GetAllTypes().FirstOrDefault(c => c.Name == "SignatureComparerTest").NestedTypes.FirstOrDefault();
+            var firstType = nestedTypes.NestedTypes[0].NestedTypes[0];
+            var secondType = nestedTypes.NestedTypes[1].NestedTypes[0];
+            Assert.NotEqual(firstType, secondType, _comparer);
+        }
+        public class NestedTypes
+        {
+            public class FirstType
+            {
+                public class TypeWithCommonName
+                {
+                    public string stringValue { get; set; }
+                    public bool boolValue { get; set; }
+                }
+
+            }
+            public class SecondType
+            {
+
+                public class TypeWithCommonName
+                {
+                    public int intValue { get; set; }
+                    public byte byteValue { get; set; }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Comparing by namespace is not enough, need to compare by declaring type too, because namespace can be null which way it leads to situation where two nested different types with same name can be compared as equal