### PR TITLE
Refactor ISegment::UpdateOffsets

### DIFF
--- a/docs/peimage/tls.rst
+++ b/docs/peimage/tls.rst
@@ -6,7 +6,7 @@ Executables that use multiple threads might require static (non-stack) memory th
 All code relevant to the TLS data directory of a PE resides in the following namespace:
 
 .. code-block:: csharp
-    
+
     using AsmResolver.PE.Tls;
 
 
@@ -21,7 +21,7 @@ The PE file format defines a segment of memory within the TLS data directory tha
 
 
 .. code-block:: csharp
-    
+
     var indexSegment = new DataSegment(new byte[8]);
 
     var directory = new TlsDirectory
@@ -48,18 +48,14 @@ Next to static initialization data, it is also possible to specify a list of fun
 Creating new TLS directories
 ----------------------------
 
-Since the TLS data directory stores its data using virtual addresses (VA) rather than relative virtual addresses (RVA), AsmResolver requires the image base as well as the pointer size. This is done through the ``ImageBase`` and ``Is32Bit`` properties. By default, the following values are assumed:
+Adding a new TLS directory to an image can be done using the parameterless constructor of the ``TlsDirectory`` class:
 
 .. code-block:: csharp
 
-    var directory = new TlsDirectory();
-    directory.ImageBase = 0x00400000;
-    directory.Is32Bit = true;
+    var tlsDirectory = new TlsDirectory();
+    image.TlsDirectory = tlsDirectory;
 
-
-Typically, you should make sure they are in sync with the values found in the file and optional header of the final PE file. Upon reading from an existing PE file, these two properties are initialized to the values stored in these two headers.
-
-When building a relocatable PE file, you might also need to add base address relocations to the VAs inside the TLS directory. To quickly get all the base relocations required, use the ``GetRequiredBaseRelocations`` method:
+A TLS directory references all its sub segments using virtual addresses (VA) rather than relative addresses (RVA). This means that constructing a relocatable PE image with a TLS directory requires base relocation entries to be registered that let the Windows PE loader rebase all virtual addresses used in the directory when necessary. To quickly register all the required base relocations, you can call the ``GetRequiredBaseRelocations`` method and add all returned entries to the base relocation directory of the PE image:
 
 .. code-block:: csharp
 
@@ -67,5 +63,5 @@ When building a relocatable PE file, you might also need to add base address rel
 
     IPEImage image = ...;
 
-    foreach (var relocation in image.TlsDirectory.GetRequiredBaseRelocations())
+    foreach (var relocation in tlsDirectory.GetRequiredBaseRelocations())
         image.Relocations.Add(relocation);

--- a/src/AsmResolver.DotNet/Builder/ManagedPEImageBuilder.cs
+++ b/src/AsmResolver.DotNet/Builder/ManagedPEImageBuilder.cs
@@ -70,7 +70,7 @@ namespace AsmResolver.DotNet.Builder
                 };
 
                 // Construct new .NET directory.
-                var symbolProvider = new NativeSymbolsProvider(image.ImageBase);
+                var symbolProvider = new NativeSymbolsProvider();
                 var result = DotNetDirectoryFactory.CreateDotNetDirectory(
                     module,
                     symbolProvider,

--- a/src/AsmResolver.DotNet/Builder/VTableFixups/VTableFixupsBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/VTableFixups/VTableFixupsBuffer.cs
@@ -61,7 +61,7 @@ namespace AsmResolver.DotNet.Builder.VTableFixups
             vtableFixup.Tokens.Add(token);
             var vtableSymbol = new Symbol(vtableFixup.Tokens.GetReferenceToIndex(vtableFixup.Tokens.Count - 1));
 
-            var thunkStub = _targetPlatform.CreateThunkStub(0x00400000, vtableSymbol);
+            var thunkStub = _targetPlatform.CreateThunkStub(vtableSymbol);
 
             // Register exported symbol.
             var stubReference = thunkStub.Segment.ToReference();

--- a/src/AsmResolver.DotNet/Bundles/BundleManifest.cs
+++ b/src/AsmResolver.DotNet/Bundles/BundleManifest.cs
@@ -445,7 +445,7 @@ namespace AsmResolver.DotNet.Bundles
                 if (file.Type == BundleFileType.Assembly)
                     writer.Align(alignment);
 
-                file.Contents.UpdateOffsets(writer.Offset, (uint) writer.Offset);
+                file.Contents.UpdateOffsets(new RelocationParameters(writer.Offset, (uint) writer.Offset));
                 file.Contents.Write(writer);
             }
         }

--- a/src/AsmResolver.DotNet/Code/Native/INativeSymbolsProvider.cs
+++ b/src/AsmResolver.DotNet/Code/Native/INativeSymbolsProvider.cs
@@ -9,14 +9,6 @@ namespace AsmResolver.DotNet.Code.Native
     public interface INativeSymbolsProvider
     {
         /// <summary>
-        /// Gets or sets the image base the final PE image is using.
-        /// </summary>
-        ulong ImageBase
-        {
-            get;
-        }
-
-        /// <summary>
         /// Adds a single symbol to the prototype.
         /// </summary>
         /// <param name="symbol">The symbol to import.</param>

--- a/src/AsmResolver.DotNet/Code/Native/NativeMethodBodySerializer.cs
+++ b/src/AsmResolver.DotNet/Code/Native/NativeMethodBodySerializer.cs
@@ -18,7 +18,7 @@ namespace AsmResolver.DotNet.Code.Native
             var provider = context.SymbolsProvider;
 
             // Create new raw code segment containing the native code.
-            var segment = new CodeSegment(provider.ImageBase, nativeMethodBody.Code);
+            var segment = new CodeSegment(nativeMethodBody.Code);
 
             // Process fixups.
             for (int i = 0; i < nativeMethodBody.AddressFixups.Count; i++)

--- a/src/AsmResolver.DotNet/Code/Native/NativeSymbolsProvider.cs
+++ b/src/AsmResolver.DotNet/Code/Native/NativeSymbolsProvider.cs
@@ -22,21 +22,6 @@ namespace AsmResolver.DotNet.Code.Native
         private uint _maxExportedOrdinal = 0;
         private readonly List<ExportedSymbol> _floatingExportedSymbols = new();
 
-        /// <summary>
-        /// Creates a new instance of the <see cref="NativeSymbolsProvider"/> class.
-        /// </summary>
-        /// <param name="imageBase">The image base of the final PE image.</param>
-        public NativeSymbolsProvider(ulong imageBase)
-        {
-            ImageBase = imageBase;
-        }
-
-        /// <inheritdoc />
-        public ulong ImageBase
-        {
-            get;
-        }
-
         /// <inheritdoc />
         public ISymbol ImportSymbol(ISymbol symbol)
         {

--- a/src/AsmResolver.PE.File/PEFile.cs
+++ b/src/AsmResolver.PE.File/PEFile.cs
@@ -415,7 +415,7 @@ namespace AsmResolver.PE.File
                 var section = Sections[i];
 
                 section.UpdateOffsets(relocation);
-                relocation = relocation.Advance(
+                relocation.Advance(
                     section.GetPhysicalSize().Align(OptionalHeader.FileAlignment),
                     section.GetVirtualSize().Align(OptionalHeader.SectionAlignment));
             }

--- a/src/AsmResolver.PE.File/PEFile.cs
+++ b/src/AsmResolver.PE.File/PEFile.cs
@@ -371,12 +371,15 @@ namespace AsmResolver.PE.File
 
             FileHeader.NumberOfSections = (ushort) Sections.Count;
 
-            FileHeader.UpdateOffsets(
+            var relocation = new RelocationParameters(OptionalHeader.ImageBase, 0, 0,
+                OptionalHeader.Magic == OptionalHeaderMagic.Pe32);
+
+            FileHeader.UpdateOffsets(relocation.WithOffsetRva(
                 DosHeader.NextHeaderOffset + 4,
-                DosHeader.NextHeaderOffset + 4);
-            OptionalHeader.UpdateOffsets(
+                DosHeader.NextHeaderOffset + 4));
+            OptionalHeader.UpdateOffsets(relocation.WithOffsetRva(
                 FileHeader.Offset + FileHeader.GetPhysicalSize(),
-                FileHeader.Rva + FileHeader.GetVirtualSize());
+                FileHeader.Rva + FileHeader.GetVirtualSize()));
 
             FileHeader.SizeOfOptionalHeader = (ushort) OptionalHeader.GetPhysicalSize();
             OptionalHeader.SizeOfHeaders = (uint) (OptionalHeader.Offset
@@ -391,7 +394,9 @@ namespace AsmResolver.PE.File
             OptionalHeader.SizeOfImage = lastSection.Rva
                                          + lastSection.GetVirtualSize().Align(OptionalHeader.SectionAlignment);
 
-            EofData?.UpdateOffsets(lastSection.Offset + lastSection.GetPhysicalSize(), OptionalHeader.SizeOfImage);
+            EofData?.UpdateOffsets(relocation.WithOffsetRva(
+                lastSection.Offset + lastSection.GetPhysicalSize(),
+                OptionalHeader.SizeOfImage));
         }
 
         /// <summary>
@@ -399,19 +404,20 @@ namespace AsmResolver.PE.File
         /// </summary>
         public void AlignSections()
         {
-            uint currentFileOffset = OptionalHeader.SizeOfHeaders;
+            var relocation = new RelocationParameters(
+                OptionalHeader.ImageBase,
+                OptionalHeader.SizeOfHeaders.Align(OptionalHeader.FileAlignment),
+                OptionalHeader.SizeOfHeaders.Align(OptionalHeader.SectionAlignment),
+                OptionalHeader.Magic == OptionalHeaderMagic.Pe32);
 
             for (int i = 0; i < Sections.Count; i++)
             {
                 var section = Sections[i];
 
-                uint rva = i > 0
-                    ? Sections[i - 1].Rva + Sections[i - 1].GetVirtualSize()
-                    : OptionalHeader.SizeOfHeaders.Align(OptionalHeader.SectionAlignment);
-
-                currentFileOffset = currentFileOffset.Align(OptionalHeader.FileAlignment);
-                section.UpdateOffsets(currentFileOffset, rva.Align(OptionalHeader.SectionAlignment));
-                currentFileOffset += section.GetPhysicalSize();
+                section.UpdateOffsets(relocation);
+                relocation = relocation.Advance(
+                    section.GetPhysicalSize().Align(OptionalHeader.FileAlignment),
+                    section.GetVirtualSize().Align(OptionalHeader.SectionAlignment));
             }
         }
 

--- a/src/AsmResolver.PE.File/PESection.cs
+++ b/src/AsmResolver.PE.File/PESection.cs
@@ -216,7 +216,7 @@ namespace AsmResolver.PE.File
         public bool CanUpdateOffsets => true;
 
         /// <inheritdoc />
-        public void UpdateOffsets(ulong newOffset, uint newRva) => Contents?.UpdateOffsets(newOffset, newRva);
+        public void UpdateOffsets(in RelocationParameters parameters) => Contents?.UpdateOffsets(parameters);
 
         /// <inheritdoc />
         public uint GetPhysicalSize() => Contents?.GetPhysicalSize() ?? 0;

--- a/src/AsmResolver.PE.File/PESegmentReference.cs
+++ b/src/AsmResolver.PE.File/PESegmentReference.cs
@@ -33,16 +33,10 @@ namespace AsmResolver.PE.File
         }
 
         /// <inheritdoc />
-        bool IOffsetProvider.CanUpdateOffsets => false;
-
-        /// <inheritdoc />
         public bool CanRead => _peFile.TryGetSectionContainingRva(Rva, out _);
 
         /// <inheritdoc />
         public bool IsBounded => false;
-
-        /// <inheritdoc />
-        void IOffsetProvider.UpdateOffsets(ulong newOffset, uint newRva) => throw new InvalidOperationException();
 
         /// <inheritdoc />
         public BinaryStreamReader CreateReader() => _peFile.CreateReaderAtRva(Rva);

--- a/src/AsmResolver.PE.Win32Resources/Version/FixedVersionInfo.cs
+++ b/src/AsmResolver.PE.Win32Resources/Version/FixedVersionInfo.cs
@@ -24,7 +24,7 @@ namespace AsmResolver.PE.Win32Resources.Version
         public static FixedVersionInfo FromReader(ref BinaryStreamReader reader)
         {
             var result = new FixedVersionInfo();
-            result.UpdateOffsets(reader.Offset, reader.Rva);
+            result.UpdateOffsets(new RelocationParameters(reader.Offset, reader.Rva));
 
             uint signature = reader.ReadUInt32();
             if (signature != Signature)

--- a/src/AsmResolver.PE/Code/CodeSegment.cs
+++ b/src/AsmResolver.PE/Code/CodeSegment.cs
@@ -57,6 +57,13 @@ namespace AsmResolver.PE.Code
         } = new List<AddressFixup>();
 
         /// <inheritdoc />
+        public override void UpdateOffsets(in RelocationParameters parameters)
+        {
+            ImageBase = parameters.ImageBase;
+            base.UpdateOffsets(in parameters);
+        }
+
+        /// <inheritdoc />
         public override uint GetPhysicalSize() => (uint) Code.Length;
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/Debug/Builder/DebugDirectoryBuffer.cs
+++ b/src/AsmResolver.PE/Debug/Builder/DebugDirectoryBuffer.cs
@@ -41,7 +41,7 @@ namespace AsmResolver.PE.Debug.Builder
         public bool CanUpdateOffsets => true;
 
         /// <inheritdoc />
-        public void UpdateOffsets(ulong newOffset, uint newRva) => _headers.UpdateOffsets(newOffset, newRva);
+        public void UpdateOffsets(in RelocationParameters parameters) => _headers.UpdateOffsets(parameters);
 
         /// <inheritdoc />
         public uint GetPhysicalSize() => _headers.GetPhysicalSize();

--- a/src/AsmResolver.PE/Debug/CustomDebugDataSegment.cs
+++ b/src/AsmResolver.PE/Debug/CustomDebugDataSegment.cs
@@ -45,10 +45,10 @@ namespace AsmResolver.PE.Debug
         public bool CanUpdateOffsets => Contents?.CanUpdateOffsets ?? false;
 
         /// <inheritdoc />
-        public void UpdateOffsets(ulong newOffset, uint newRva)
+        public void UpdateOffsets(in RelocationParameters parameters)
         {
             if (Contents != null)
-                Contents.UpdateOffsets(newOffset, newRva);
+                Contents.UpdateOffsets(parameters);
             else
                 throw new ArgumentNullException(nameof(Contents));
         }

--- a/src/AsmResolver.PE/DotNet/Builder/DotNetSegmentBuffer.cs
+++ b/src/AsmResolver.PE/DotNet/Builder/DotNetSegmentBuffer.cs
@@ -73,7 +73,7 @@ namespace AsmResolver.PE.DotNet.Builder
         }
 
         /// <inheritdoc />
-        public void UpdateOffsets(ulong newOffset, uint newRva) => _segments.UpdateOffsets(newOffset, newRva);
+        public void UpdateOffsets(in RelocationParameters parameters) => _segments.UpdateOffsets(parameters);
 
         /// <inheritdoc />
         public uint GetPhysicalSize() => _segments.GetPhysicalSize();

--- a/src/AsmResolver.PE/DotNet/Builder/ManagedPEFileBuilder.cs
+++ b/src/AsmResolver.PE/DotNet/Builder/ManagedPEFileBuilder.cs
@@ -262,7 +262,7 @@ namespace AsmResolver.PE.DotNet.Builder
                 if (entrypointSymbol is null)
                     throw new InvalidOperationException("Entrypoint symbol was required but not imported.");
 
-                context.Bootstrapper = context.Platform.CreateThunkStub(image.ImageBase, entrypointSymbol);
+                context.Bootstrapper = context.Platform.CreateThunkStub(entrypointSymbol);
             }
         }
 

--- a/src/AsmResolver.PE/DotNet/Builder/MethodBodyTableBuffer.cs
+++ b/src/AsmResolver.PE/DotNet/Builder/MethodBodyTableBuffer.cs
@@ -53,7 +53,7 @@ namespace AsmResolver.PE.DotNet.Builder
         public void AddNativeBody(ISegment body, uint alignment) => _nativeBodies.Add(body, alignment);
 
         /// <inheritdoc />
-        public void UpdateOffsets(ulong newOffset, uint newRva) => _segments.UpdateOffsets(newOffset, newRva);
+        public void UpdateOffsets(in RelocationParameters parameters) => _segments.UpdateOffsets(parameters);
 
         /// <inheritdoc />
         public uint GetPhysicalSize()

--- a/src/AsmResolver.PE/DotNet/Cil/CilRawFatMethodBody.cs
+++ b/src/AsmResolver.PE/DotNet/Cil/CilRawFatMethodBody.cs
@@ -176,17 +176,19 @@ namespace AsmResolver.PE.DotNet.Cil
         {
             base.UpdateOffsets(parameters);
 
-            var current = parameters.Advance(12);
+            var current = parameters.WithAdvance(12);
+
             Code.UpdateOffsets(current);
             if (HasSections)
             {
                 uint codeSize = Code.GetPhysicalSize();
-                current = current.Advance(codeSize).Align(4);
+                current.Advance(codeSize);
+                current.Align(4);
 
                 for (int i = 0; i < ExtraSections.Count; i++)
                 {
                     ExtraSections[i].UpdateOffsets(current);
-                    current = current.Advance(ExtraSections[i].GetPhysicalSize());
+                    current.Advance(ExtraSections[i].GetPhysicalSize());
                 }
             }
         }

--- a/src/AsmResolver.PE/DotNet/Cil/CilRawFatMethodBody.cs
+++ b/src/AsmResolver.PE/DotNet/Cil/CilRawFatMethodBody.cs
@@ -153,7 +153,7 @@ namespace AsmResolver.PE.DotNet.Cil
 
             // Create body.
             var body = new CilRawFatMethodBody(flags, maxStack, localVarSigToken, code);
-            body.UpdateOffsets(fileOffset, rva);
+            body.UpdateOffsets(new RelocationParameters(fileOffset, rva));
 
             // Read any extra sections.
             if (body.HasSections)
@@ -172,18 +172,22 @@ namespace AsmResolver.PE.DotNet.Cil
         }
 
         /// <inheritdoc />
-        public override void UpdateOffsets(ulong newOffset, uint newRva)
+        public override void UpdateOffsets(in RelocationParameters parameters)
         {
-            base.UpdateOffsets(newOffset, newRva);
-            Code.UpdateOffsets(newOffset + 12, newRva + 12);
+            base.UpdateOffsets(parameters);
+
+            var current = parameters.Advance(12);
+            Code.UpdateOffsets(current);
             if (HasSections)
             {
                 uint codeSize = Code.GetPhysicalSize();
-                newOffset = (Code.Offset + codeSize).Align(4);
-                newRva = (Code.Rva + codeSize).Align(4);
+                current = current.Advance(codeSize).Align(4);
 
                 for (int i = 0; i < ExtraSections.Count; i++)
-                    ExtraSections[i].UpdateOffsets(newOffset, newRva);
+                {
+                    ExtraSections[i].UpdateOffsets(current);
+                    current = current.Advance(ExtraSections[i].GetPhysicalSize());
+                }
             }
         }
 

--- a/src/AsmResolver.PE/DotNet/Cil/CilRawTinyMethodBody.cs
+++ b/src/AsmResolver.PE/DotNet/Cil/CilRawTinyMethodBody.cs
@@ -58,15 +58,15 @@ namespace AsmResolver.PE.DotNet.Cil
 
             uint codeSize = (uint) flag >> 2;
             var methodBody = new CilRawTinyMethodBody(reader.ReadSegment(codeSize));
-            methodBody.UpdateOffsets(fileOffset, rva);
+            methodBody.UpdateOffsets(new RelocationParameters(fileOffset, rva));
             return methodBody;
         }
 
         /// <inheritdoc />
-        public override void UpdateOffsets(ulong newOffset, uint newRva)
+        public override void UpdateOffsets(in RelocationParameters parameters)
         {
-            base.UpdateOffsets(newOffset, newRva);
-            Code.UpdateOffsets(newOffset + 1, newRva + 1);
+            base.UpdateOffsets(parameters);
+            Code.UpdateOffsets(parameters.Advance(1));
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Cil/CilRawTinyMethodBody.cs
+++ b/src/AsmResolver.PE/DotNet/Cil/CilRawTinyMethodBody.cs
@@ -66,7 +66,7 @@ namespace AsmResolver.PE.DotNet.Cil
         public override void UpdateOffsets(in RelocationParameters parameters)
         {
             base.UpdateOffsets(parameters);
-            Code.UpdateOffsets(parameters.Advance(1));
+            Code.UpdateOffsets(parameters.WithAdvance(1));
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/CustomMetadataStream.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/CustomMetadataStream.cs
@@ -68,7 +68,7 @@ namespace AsmResolver.PE.DotNet.Metadata
         }
 
         /// <inheritdoc />
-        public void UpdateOffsets(ulong newOffset, uint newRva) => Contents.UpdateOffsets(newOffset, newRva);
+        public void UpdateOffsets(in RelocationParameters parameters) => Contents.UpdateOffsets(parameters);
 
         /// <inheritdoc />
         public uint GetPhysicalSize() => Contents.GetPhysicalSize();

--- a/src/AsmResolver.PE/DotNet/SerializedDotNetDirectory.cs
+++ b/src/AsmResolver.PE/DotNet/SerializedDotNetDirectory.cs
@@ -126,7 +126,7 @@ namespace AsmResolver.PE.DotNet
             }
 
             var vtables = new VTableFixupsDirectory();
-            vtables.UpdateOffsets(directoryReader.Offset, directoryReader.Rva);
+            vtables.UpdateOffsets(_context.GetRelocation(directoryReader.Offset, directoryReader.Rva));
 
             for (int i = 0; i < directoryReader.Length / 8; i++)
             {

--- a/src/AsmResolver.PE/DotNet/VTableFixups/VTableFixup.cs
+++ b/src/AsmResolver.PE/DotNet/VTableFixups/VTableFixup.cs
@@ -41,8 +41,8 @@ namespace AsmResolver.PE.DotNet.VTableFixups
 
             ushort entries = reader.ReadUInt16();
             var vtable = new VTableFixup((VTableType) reader.ReadUInt16());
-            vtable.UpdateOffsets(offset, rva);
-            vtable.Tokens.UpdateOffsets(tableReader.Offset, tableReader.Rva);
+            vtable.UpdateOffsets(context.GetRelocation(offset, rva));
+            vtable.Tokens.UpdateOffsets(context.GetRelocation(tableReader.Offset, tableReader.Rva));
 
             for (int i = 0; i < entries; i++)
             {

--- a/src/AsmResolver.PE/DotNet/VTableFixups/VTableFixupsDirectory.cs
+++ b/src/AsmResolver.PE/DotNet/VTableFixups/VTableFixupsDirectory.cs
@@ -27,10 +27,10 @@ namespace AsmResolver.PE.DotNet.VTableFixups
         public bool CanUpdateOffsets => true;
 
         /// <inheritdoc />
-        public void UpdateOffsets(ulong newOffset, uint newRva)
+        public void UpdateOffsets(in RelocationParameters parameters)
         {
-            Offset = newOffset;
-            Rva = newRva;
+            Offset = parameters.Offset;
+            Rva = parameters.Rva;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/VTableFixups/VTableTokenCollection.cs
+++ b/src/AsmResolver.PE/DotNet/VTableFixups/VTableTokenCollection.cs
@@ -45,10 +45,10 @@ namespace AsmResolver.PE.DotNet.VTableFixups
         }
 
         /// <inheritdoc />
-        public void UpdateOffsets(ulong newOffset, uint newRva)
+        public void UpdateOffsets(in RelocationParameters parameters)
         {
-            Offset = newOffset;
-            Rva = newRva;
+            Offset = parameters.Offset;
+            Rva = parameters.Rva;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/Exceptions/X64/X64UnwindInfo.cs
+++ b/src/AsmResolver.PE/Exceptions/X64/X64UnwindInfo.cs
@@ -1,5 +1,6 @@
 using System;
 using AsmResolver.IO;
+using AsmResolver.PE.File.Headers;
 
 namespace AsmResolver.PE.Exceptions.X64
 {
@@ -151,7 +152,7 @@ namespace AsmResolver.PE.Exceptions.X64
         public static X64UnwindInfo FromReader(PEReaderContext context, ref BinaryStreamReader reader)
         {
             var result = new X64UnwindInfo();
-            result.UpdateOffsets(reader.Offset, reader.Rva);
+            result.UpdateOffsets(context.GetRelocation(reader.Offset, reader.Rva));
 
             result._firstByte = reader.ReadByte();
             result.SizeOfProlog = reader.ReadByte();

--- a/src/AsmResolver.PE/Exports/Builder/ExportDirectoryBuffer.cs
+++ b/src/AsmResolver.PE/Exports/Builder/ExportDirectoryBuffer.cs
@@ -86,7 +86,7 @@ namespace AsmResolver.PE.Exports.Builder
         public override void UpdateOffsets(in RelocationParameters parameters)
         {
             base.UpdateOffsets(parameters);
-            _contentsBuilder.UpdateOffsets(parameters.Advance(ExportDirectoryHeaderSize));
+            _contentsBuilder.UpdateOffsets(parameters.WithAdvance(ExportDirectoryHeaderSize));
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/Exports/Builder/ExportDirectoryBuffer.cs
+++ b/src/AsmResolver.PE/Exports/Builder/ExportDirectoryBuffer.cs
@@ -83,10 +83,10 @@ namespace AsmResolver.PE.Exports.Builder
         }
 
         /// <inheritdoc />
-        public override void UpdateOffsets(ulong newOffset, uint newRva)
+        public override void UpdateOffsets(in RelocationParameters parameters)
         {
-            base.UpdateOffsets(newOffset, newRva);
-            _contentsBuilder.UpdateOffsets(newOffset + ExportDirectoryHeaderSize, newRva + ExportDirectoryHeaderSize);
+            base.UpdateOffsets(parameters);
+            _contentsBuilder.UpdateOffsets(parameters.Advance(ExportDirectoryHeaderSize));
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/Imports/Builder/HintNameTableBuffer.cs
+++ b/src/AsmResolver.PE/Imports/Builder/HintNameTableBuffer.cs
@@ -15,23 +15,23 @@ namespace AsmResolver.PE.Imports.Builder
         private uint _length;
 
         /// <inheritdoc />
-        public override void UpdateOffsets(ulong newOffset, uint newRva)
+        public override void UpdateOffsets(in RelocationParameters parameters)
         {
-            base.UpdateOffsets(newOffset, newRva);
+            base.UpdateOffsets(parameters);
 
-            ulong currentOffset = newOffset;
+            ulong currentOffset = parameters.Offset;
             foreach (var module in _modules)
             {
                 foreach (var entry in module.Symbols)
                 {
                     if (entry.IsImportByName)
                     {
-                        _hintNameOffsets[entry] = (uint) (currentOffset - newOffset);
+                        _hintNameOffsets[entry] = (uint) (currentOffset - parameters.Offset);
                         currentOffset += (uint) (sizeof(ushort) + Encoding.ASCII.GetByteCount(entry.Name) + 1);
                         currentOffset = currentOffset.Align(2);
                     }
                 }
-                _moduleNameOffsets[module] = (uint) (currentOffset - newOffset);
+                _moduleNameOffsets[module] = (uint) (currentOffset - parameters.Offset);
                 if (module.Name is not null)
                     currentOffset += (uint) Encoding.ASCII.GetByteCount(module.Name);
 
@@ -39,7 +39,7 @@ namespace AsmResolver.PE.Imports.Builder
                 currentOffset++;
             }
 
-            _length = (uint) (currentOffset - newOffset);
+            _length = (uint) (currentOffset - parameters.Offset);
         }
 
         /// <summary>

--- a/src/AsmResolver.PE/Imports/Builder/ImportAddressDirectoryBuffer.cs
+++ b/src/AsmResolver.PE/Imports/Builder/ImportAddressDirectoryBuffer.cs
@@ -29,7 +29,7 @@ namespace AsmResolver.PE.Imports.Builder
                 var thunkTable = GetModuleThunkTable(module);
                 uint size = thunkTable.GetPhysicalSize();
                 thunkTable.UpdateOffsets(current);
-                current = current.Advance(size);
+                current.Advance(size);
             }
         }
 

--- a/src/AsmResolver.PE/Imports/Builder/ImportAddressDirectoryBuffer.cs
+++ b/src/AsmResolver.PE/Imports/Builder/ImportAddressDirectoryBuffer.cs
@@ -17,17 +17,19 @@ namespace AsmResolver.PE.Imports.Builder
         }
 
         /// <inheritdoc />
-        public override void UpdateOffsets(ulong newOffset, uint newRva)
+        public override void UpdateOffsets(in RelocationParameters parameters)
         {
-            base.UpdateOffsets(newOffset, newRva);
+            base.UpdateOffsets(parameters);
 
-            foreach (var module in Modules)
+            var current = parameters;
+            for (int i = 0; i < Modules.Count; i++)
             {
+                var module = Modules[i];
+
                 var thunkTable = GetModuleThunkTable(module);
                 uint size = thunkTable.GetPhysicalSize();
-                thunkTable.UpdateOffsets(newOffset, newRva);
-                newOffset += size;
-                newRva += size;
+                thunkTable.UpdateOffsets(current);
+                current = current.Advance(size);
             }
         }
 

--- a/src/AsmResolver.PE/Imports/Builder/ImportDirectoryBuffer.cs
+++ b/src/AsmResolver.PE/Imports/Builder/ImportDirectoryBuffer.cs
@@ -46,7 +46,7 @@ namespace AsmResolver.PE.Imports.Builder
         {
             base.UpdateOffsets(parameters);
 
-            var current = parameters.Advance(_entriesLength);
+            var current = parameters.WithAdvance(_entriesLength);
 
             foreach (var module in Modules)
             {
@@ -54,7 +54,7 @@ namespace AsmResolver.PE.Imports.Builder
                 uint size = thunkTable.GetPhysicalSize();
                 thunkTable.UpdateOffsets(current);
 
-                current = current.Advance(size);
+                current.Advance(size);
             }
 
             HintNameTable.UpdateOffsets(current);

--- a/src/AsmResolver.PE/Imports/Builder/ImportDirectoryBuffer.cs
+++ b/src/AsmResolver.PE/Imports/Builder/ImportDirectoryBuffer.cs
@@ -42,23 +42,22 @@ namespace AsmResolver.PE.Imports.Builder
         }
 
         /// <inheritdoc />
-        public override void UpdateOffsets(ulong newOffset, uint newRva)
+        public override void UpdateOffsets(in RelocationParameters parameters)
         {
-            base.UpdateOffsets(newOffset, newRva);
+            base.UpdateOffsets(parameters);
 
-            newOffset += _entriesLength;
-            newRva += _entriesLength;
+            var current = parameters.Advance(_entriesLength);
 
             foreach (var module in Modules)
             {
                 var thunkTable = GetModuleThunkTable(module);
                 uint size = thunkTable.GetPhysicalSize();
-                thunkTable.UpdateOffsets(newOffset, newRva);
-                newOffset += size;
-                newRva += size;
+                thunkTable.UpdateOffsets(current);
+
+                current = current.Advance(size);
             }
 
-            HintNameTable.UpdateOffsets(newOffset, newRva);
+            HintNameTable.UpdateOffsets(current);
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/PEReaderContext.cs
+++ b/src/AsmResolver.PE/PEReaderContext.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using AsmResolver.PE.File;
+using AsmResolver.PE.File.Headers;
 
 namespace AsmResolver.PE
 {
@@ -29,7 +30,7 @@ namespace AsmResolver.PE
             File = file;
             Parameters = parameters;
         }
-        
+
         /// <summary>
         /// Gets the original PE file that is being parsed.
         /// </summary>
@@ -44,6 +45,18 @@ namespace AsmResolver.PE
         public PEReaderParameters Parameters
         {
             get;
+        }
+
+        /// <summary>
+        /// Creates relocation parameters based on the current PE file that is being read.
+        /// </summary>
+        /// <param name="offset">The offset of the segment.</param>
+        /// <param name="rva">The relative virtual address of the segment.</param>
+        /// <returns>The created relocation parameters.</returns>
+        public RelocationParameters GetRelocation(ulong offset, uint rva)
+        {
+            return new RelocationParameters(File.OptionalHeader.ImageBase, offset, rva,
+                File.OptionalHeader.Magic == OptionalHeaderMagic.Pe32);
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/Platforms/Amd64Platform.cs
+++ b/src/AsmResolver.PE/Platforms/Amd64Platform.cs
@@ -25,9 +25,9 @@ namespace AsmResolver.PE.Platforms
         public override bool IsClrBootstrapperRequired => false;
 
         /// <inheritdoc />
-        public override RelocatableSegment CreateThunkStub(ulong imageBase, ISymbol entrypoint)
+        public override RelocatableSegment CreateThunkStub(ISymbol entrypoint)
         {
-            var segment = new CodeSegment(imageBase, new byte[]
+            var segment = new CodeSegment(new byte[]
             {
                 0x48, 0xA1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // rex.w rex.b mov rax, [&symbol]
                 0xFF, 0xE0                                                  // jmp [rax]

--- a/src/AsmResolver.PE/Platforms/I386Platform.cs
+++ b/src/AsmResolver.PE/Platforms/I386Platform.cs
@@ -25,11 +25,11 @@ namespace AsmResolver.PE.Platforms
         public override bool IsClrBootstrapperRequired => true;
 
         /// <inheritdoc />
-        public override RelocatableSegment CreateThunkStub(ulong imageBase, ISymbol entrypoint)
+        public override RelocatableSegment CreateThunkStub(ISymbol entrypoint)
         {
-            var segment = new CodeSegment(imageBase, new byte[]
+            var segment = new CodeSegment(new byte[]
             {
-                0xFF, 0x25, 0x00, 0x00, 0x00, 0x00  // jmp [&symbol]
+                0xFF, 0x25, 0x00, 0x00, 0x00, 0x00 // jmp [&symbol]
             });
             segment.AddressFixups.Add(new AddressFixup(2, AddressFixupType.Absolute32BitAddress, entrypoint));
 

--- a/src/AsmResolver.PE/Platforms/Platform.cs
+++ b/src/AsmResolver.PE/Platforms/Platform.cs
@@ -69,10 +69,9 @@ namespace AsmResolver.PE.Platforms
         /// <summary>
         /// Creates a new thunk stub that transfers control to the provided symbol.
         /// </summary>
-        /// <param name="imageBase">The image base of the image.</param>
         /// <param name="entrypoint">The symbol to jump to.</param>
         /// <returns>The created stub.</returns>
-        public abstract RelocatableSegment CreateThunkStub(ulong imageBase, ISymbol entrypoint);
+        public abstract RelocatableSegment CreateThunkStub(ISymbol entrypoint);
 
         /// <summary>
         /// Attempts to extract the original RVA from the code at the provided thunk address reader.

--- a/src/AsmResolver.PE/Relocations/Builder/RelocationsDirectoryBuffer.cs
+++ b/src/AsmResolver.PE/Relocations/Builder/RelocationsDirectoryBuffer.cs
@@ -58,9 +58,9 @@ namespace AsmResolver.PE.Relocations.Builder
         }
 
         /// <inheritdoc />
-        public override void UpdateOffsets(ulong newOffset, uint newRva)
+        public override void UpdateOffsets(in RelocationParameters parameters)
         {
-            base.UpdateOffsets(newOffset, newRva);
+            base.UpdateOffsets(parameters);
             _blocks = null;
         }
 

--- a/src/AsmResolver.PE/Tls/ITlsDirectory.cs
+++ b/src/AsmResolver.PE/Tls/ITlsDirectory.cs
@@ -55,24 +55,6 @@ namespace AsmResolver.PE.Tls
         }
 
         /// <summary>
-        /// Gets or sets the image base address that the TLS directory assumes.
-        /// </summary>
-        public ulong ImageBase
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the TLS directory assumes a 32-bit or 64-bit format.
-        /// </summary>
-        public bool Is32Bit
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
         /// Obtains a collection of base address relocations that need to be applied to the TLS data directory
         /// after the image was loaded into memory.
         /// </summary>

--- a/src/AsmResolver.PE/Tls/SerializedTlsDirectory.cs
+++ b/src/AsmResolver.PE/Tls/SerializedTlsDirectory.cs
@@ -22,18 +22,16 @@ namespace AsmResolver.PE.Tls
         {
             _context = context;
 
-            ulong imageBase = context.File.OptionalHeader.ImageBase;
-            bool is32Bit = context.File.OptionalHeader.Magic == OptionalHeaderMagic.Pe32;
+            var relocation = context.GetRelocation(reader.Offset, reader.Rva);
 
-            _templateStart = reader.ReadNativeInt(is32Bit);
-            _templateEnd = reader.ReadNativeInt(is32Bit);
-            Index = context.File.GetReferenceToRva((uint)(reader.ReadNativeInt(is32Bit) - imageBase));
-            _addressOfCallbacks = reader.ReadNativeInt(is32Bit);
+            _templateStart = reader.ReadNativeInt(relocation.Is32Bit);
+            _templateEnd = reader.ReadNativeInt(relocation.Is32Bit);
+            Index = context.File.GetReferenceToRva((uint)(reader.ReadNativeInt(relocation.Is32Bit) - relocation.ImageBase));
+            _addressOfCallbacks = reader.ReadNativeInt(relocation.Is32Bit);
             SizeOfZeroFill = reader.ReadUInt32();
             Characteristics = (TlsCharacteristics) reader.ReadUInt32();
 
-            ImageBase = imageBase;
-            Is32Bit = is32Bit;
+            UpdateOffsets(relocation);
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/Tls/TlsCallbackCollection.cs
+++ b/src/AsmResolver.PE/Tls/TlsCallbackCollection.cs
@@ -33,10 +33,10 @@ namespace AsmResolver.PE.Tls
         public bool CanUpdateOffsets => true;
 
         /// <inheritdoc />
-        public void UpdateOffsets(ulong newOffset, uint newRva)
+        public void UpdateOffsets(in RelocationParameters parameters)
         {
-            Offset = newOffset;
-            Rva = newRva;
+            Offset = parameters.Offset;
+            Rva = parameters.Rva;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/Tls/TlsCallbackCollection.cs
+++ b/src/AsmResolver.PE/Tls/TlsCallbackCollection.cs
@@ -9,6 +9,8 @@ namespace AsmResolver.PE.Tls
     public class TlsCallbackCollection : Collection<ISegmentReference>, ISegment
     {
         private readonly ITlsDirectory _owner;
+        private ulong _imageBase = 0x00400000;
+        private bool _is32Bit = true;
 
         internal TlsCallbackCollection(ITlsDirectory owner)
         {
@@ -37,12 +39,14 @@ namespace AsmResolver.PE.Tls
         {
             Offset = parameters.Offset;
             Rva = parameters.Rva;
+            _imageBase = parameters.ImageBase;
+            _is32Bit = parameters.Is32Bit;
         }
 
         /// <inheritdoc />
         public uint GetPhysicalSize()
         {
-            uint pointerSize = (uint) (_owner.Is32Bit ? sizeof(uint) : sizeof(ulong));
+            uint pointerSize = (uint) (_is32Bit ? sizeof(uint) : sizeof(ulong));
             return (uint) (pointerSize * (Count + 1));
         }
 
@@ -52,8 +56,8 @@ namespace AsmResolver.PE.Tls
         /// <inheritdoc />
         public void Write(IBinaryStreamWriter writer)
         {
-            ulong imageBase = _owner.ImageBase;
-            bool is32Bit = _owner.Is32Bit;
+            ulong imageBase = _imageBase;
+            bool is32Bit = _is32Bit;
 
             for (int i = 0; i < Items.Count; i++)
                 writer.WriteNativeInt(imageBase + Items[i].Rva, is32Bit);

--- a/src/AsmResolver.PE/Tls/TlsDirectory.cs
+++ b/src/AsmResolver.PE/Tls/TlsDirectory.cs
@@ -12,6 +12,8 @@ namespace AsmResolver.PE.Tls
     {
         private readonly LazyVariable<IReadableSegment?> _templateData;
         private TlsCallbackCollection? _callbackFunctions;
+        private ulong _imageBase = 0x00400000;
+        private bool _is32Bit = true;
 
         /// <summary>
         /// Initializes a new empty TLS data directory.
@@ -61,19 +63,12 @@ namespace AsmResolver.PE.Tls
             set;
         }
 
-        /// <inheritdoc />
-        public ulong ImageBase
+        public override void UpdateOffsets(in RelocationParameters parameters)
         {
-            get;
-            set;
-        } = 0x00400000;
-
-        /// <inheritdoc />
-        public bool Is32Bit
-        {
-            get;
-            set;
-        } = true;
+            _imageBase = parameters.ImageBase;
+            _is32Bit = parameters.Is32Bit;
+            base.UpdateOffsets(in parameters);
+        }
 
         /// <summary>
         /// Obtains the block of template data.
@@ -96,29 +91,30 @@ namespace AsmResolver.PE.Tls
         /// <inheritdoc />
         public IEnumerable<BaseRelocation> GetRequiredBaseRelocations()
         {
-            int pointerSize = Is32Bit ? sizeof(uint) : sizeof(ulong);
-            var type = Is32Bit ? RelocationType.HighLow : RelocationType.Dir64;
+            int pointerSize = _is32Bit ? sizeof(uint) : sizeof(ulong);
+            var type = _is32Bit ? RelocationType.HighLow : RelocationType.Dir64;
 
             var result = new List<BaseRelocation>(4 + CallbackFunctions.Count);
             for (int i = 0; i < 4; i++)
                 result.Add(new BaseRelocation(type, this.ToReference(i * pointerSize)));
             for (int i = 0; i < CallbackFunctions.Count; i++)
                 result.Add(new BaseRelocation(type, CallbackFunctions.ToReference(i * pointerSize)));
+
             return result;
         }
 
         /// <inheritdoc />
         public override uint GetPhysicalSize()
         {
-            int pointerSize = Is32Bit ? sizeof(uint) : sizeof(ulong);
+            int pointerSize = _is32Bit ? sizeof(uint) : sizeof(ulong);
             return (uint) (pointerSize * 4 + 2 * sizeof(uint));
         }
 
         /// <inheritdoc />
         public override void Write(IBinaryStreamWriter writer)
         {
-            ulong imageBase = ImageBase;
-            bool is32Bit = Is32Bit;
+            ulong imageBase = _imageBase;
+            bool is32Bit = _is32Bit;
 
             if (TemplateData is { } data)
             {

--- a/src/AsmResolver.PE/Win32Resources/Builder/ResourceDirectoryBuffer.cs
+++ b/src/AsmResolver.PE/Win32Resources/Builder/ResourceDirectoryBuffer.cs
@@ -104,7 +104,7 @@ namespace AsmResolver.PE.Win32Resources.Builder
         }
 
         /// <inheritdoc />
-        public void UpdateOffsets(ulong newOffset, uint newRva) => _segments.UpdateOffsets(newOffset, newRva);
+        public void UpdateOffsets(in RelocationParameters parameters) => _segments.UpdateOffsets(parameters);
 
         /// <inheritdoc />
         public uint GetPhysicalSize() => _segments.GetPhysicalSize();

--- a/src/AsmResolver/DataSourceSegment.cs
+++ b/src/AsmResolver/DataSourceSegment.cs
@@ -25,11 +25,11 @@ namespace AsmResolver
         }
 
         /// <inheritdoc />
-        public override void UpdateOffsets(ulong newOffset, uint newRva)
+        public override void UpdateOffsets(in RelocationParameters parameters)
         {
-            base.UpdateOffsets(newOffset, newRva);
+            base.UpdateOffsets(parameters);
 
-            long displacement = (long) newOffset - (long) _originalOffset;
+            long displacement = (long) parameters.Offset - (long) _originalOffset;
             _displacedDataSource = displacement != 0
                 ? new DisplacedDataSource(_dataSource, displacement)
                 : null;

--- a/src/AsmResolver/IOffsetProvider.cs
+++ b/src/AsmResolver/IOffsetProvider.cs
@@ -20,20 +20,6 @@ namespace AsmResolver
         {
             get;
         }
-
-        /// <summary>
-        /// Determines whether this structure can be relocated to another offset or virtual address.
-        /// </summary>
-        bool CanUpdateOffsets
-        {
-            get;
-        }
-
-        /// <summary>
-        /// Assigns a new file and virtual offset to the segment and all its sub-components.
-        /// </summary>
-        /// <param name="newOffset">The new file offset.</param>
-        /// <param name="newRva">The new virtual offset.</param>
-        void UpdateOffsets(ulong newOffset, uint newRva);
     }
+
 }

--- a/src/AsmResolver/ISegment.cs
+++ b/src/AsmResolver/ISegment.cs
@@ -10,10 +10,24 @@ namespace AsmResolver
     public interface ISegment : IOffsetProvider, IWritable
     {
         /// <summary>
+        /// Determines whether this structure can be relocated to another offset or virtual address.
+        /// </summary>
+        bool CanUpdateOffsets
+        {
+            get;
+        }
+
+        /// <summary>
         /// Computes the number of bytes the segment will contain when it is mapped into memory.
         /// </summary>
         /// <returns>The number of bytes.</returns>
         uint GetVirtualSize();
+
+        /// <summary>
+        /// Assigns a new file and virtual offset to the segment and all its sub-components.
+        /// </summary>
+        /// <param name="parameters">The parameters containing the new offset information for the segment.</param>
+        void UpdateOffsets(in RelocationParameters parameters);
 
     }
 

--- a/src/AsmResolver/RelativeReference.cs
+++ b/src/AsmResolver/RelativeReference.cs
@@ -42,13 +42,6 @@ namespace AsmResolver
         public uint Rva => (uint) (Base.Rva + Additive);
 
         /// <inheritdoc />
-        public bool CanUpdateOffsets => Base.CanUpdateOffsets;
-
-        /// <inheritdoc />
-        public void UpdateOffsets(ulong newOffset, uint newRva) =>
-            Base.UpdateOffsets( newOffset - (ulong) Additive, (uint) (newRva - Additive));
-
-        /// <inheritdoc />
         public bool CanRead => Base is ISegmentReference reference && reference.CanRead;
 
         /// <inheritdoc />

--- a/src/AsmResolver/RelocationParameters.cs
+++ b/src/AsmResolver/RelocationParameters.cs
@@ -1,0 +1,118 @@
+namespace AsmResolver
+{
+    /// <summary>
+    /// Provides parameters for relocating a segment to a new offset-rva pair.
+    /// </summary>
+    public readonly struct RelocationParameters
+    {
+        /// <summary>
+        /// Creates new relocation parameters.
+        /// </summary>
+        /// <param name="offset">The new offset of the segment.</param>
+        /// <param name="rva">The new virtual address of the segment, relative to the image base.</param>
+        public RelocationParameters(ulong offset, uint rva)
+            : this(0, offset, rva, true)
+        {
+        }
+
+        /// <summary>
+        /// Creates new relocation parameters.
+        /// </summary>
+        /// <param name="imageBase">The base address of the image the segment is located in.</param>
+        /// <param name="offset">The new offset of the segment.</param>
+        /// <param name="rva">The new virtual address of the segment, relative to the image base.</param>
+        /// <param name="is32Bit"><c>true</c> if the image is targeting 32-bit images, <c>false</c> for 64-bit images.</param>
+        public RelocationParameters(ulong imageBase, ulong offset, uint rva, bool is32Bit)
+        {
+            ImageBase = imageBase;
+            Offset = offset;
+            Rva = rva;
+            Is32Bit = is32Bit;
+        }
+
+        /// <summary>
+        /// Gets the image base that is assumed when relocating the segment.
+        /// </summary>
+        public ulong ImageBase
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Gets the new physical offset of the segment.
+        /// </summary>
+        public ulong Offset
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Gets the new virtual address of the segment, relative to the image base.
+        /// </summary>
+        public uint Rva
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the image is targeting 32-bit machines.
+        /// </summary>
+        public bool Is32Bit
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the image is targeting 64-bit machines.
+        /// </summary>
+        public bool Is64Bit => !Is32Bit;
+
+        /// <summary>
+        /// Copies the current relocation parameters, and assigns a new offset and relative virtual address.
+        /// </summary>
+        /// <param name="offset">The new offset.</param>
+        /// <param name="rva">The new relative virtual address.</param>
+        /// <returns>The new relocation parameters.</returns>
+        public RelocationParameters WithOffsetRva(ulong offset, uint rva)
+        {
+            return new RelocationParameters(ImageBase, offset, rva, Is32Bit);
+        }
+
+        /// <summary>
+        /// Aligns the current offset and virtual address to the nearest multiple of the provided alignment.
+        /// </summary>
+        /// <param name="alignment">The alignment.</param>
+        /// <returns>The new relocation parameters.</returns>
+        public RelocationParameters Align(uint alignment)
+        {
+            return WithOffsetRva(Offset.Align(alignment), Rva.Align(alignment));
+        }
+
+        /// <summary>
+        /// Advances the current offset and virtual address by the provided byte count.
+        /// </summary>
+        /// <param name="count">The number of bytes to advance with.</param>
+        /// <returns>The new relocation parameters.</returns>
+        public RelocationParameters Advance(uint count)
+        {
+            return WithOffsetRva(Offset + count, Rva + count);
+        }
+
+        /// <summary>
+        /// Advances the current offset and virtual address by the provided byte count.
+        /// </summary>
+        /// <param name="physicalCount">The number of bytes to advance the physical offset with.</param>
+        /// <param name="virtualCount">The number of bytes to advance the virtual address with.</param>
+        /// <returns>The new relocation parameters.</returns>
+        public RelocationParameters Advance(uint physicalCount, uint virtualCount)
+        {
+            return WithOffsetRva(Offset + physicalCount, Rva + virtualCount);
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"{nameof(ImageBase)}: {ImageBase:X8}, {nameof(Offset)}: {Offset:X8}, {nameof(Rva)}: {Rva:X8}";
+        }
+    }
+}

--- a/src/AsmResolver/RelocationParameters.cs
+++ b/src/AsmResolver/RelocationParameters.cs
@@ -3,7 +3,7 @@ namespace AsmResolver
     /// <summary>
     /// Provides parameters for relocating a segment to a new offset-rva pair.
     /// </summary>
-    public readonly struct RelocationParameters
+    public struct RelocationParameters
     {
         /// <summary>
         /// Creates new relocation parameters.
@@ -44,6 +44,7 @@ namespace AsmResolver
         public ulong Offset
         {
             get;
+            set;
         }
 
         /// <summary>
@@ -52,6 +53,7 @@ namespace AsmResolver
         public uint Rva
         {
             get;
+            set;
         }
 
         /// <summary>
@@ -72,7 +74,6 @@ namespace AsmResolver
         /// </summary>
         /// <param name="offset">The new offset.</param>
         /// <param name="rva">The new relative virtual address.</param>
-        /// <returns>The new relocation parameters.</returns>
         public RelocationParameters WithOffsetRva(ulong offset, uint rva)
         {
             return new RelocationParameters(ImageBase, offset, rva, Is32Bit);
@@ -82,10 +83,10 @@ namespace AsmResolver
         /// Aligns the current offset and virtual address to the nearest multiple of the provided alignment.
         /// </summary>
         /// <param name="alignment">The alignment.</param>
-        /// <returns>The new relocation parameters.</returns>
-        public RelocationParameters Align(uint alignment)
+        public void Align(uint alignment)
         {
-            return WithOffsetRva(Offset.Align(alignment), Rva.Align(alignment));
+            Offset = Offset.Align(alignment);
+            Rva = Rva.Align(alignment);
         }
 
         /// <summary>
@@ -93,9 +94,20 @@ namespace AsmResolver
         /// </summary>
         /// <param name="count">The number of bytes to advance with.</param>
         /// <returns>The new relocation parameters.</returns>
-        public RelocationParameters Advance(uint count)
+        public readonly RelocationParameters WithAdvance(uint count)
         {
-            return WithOffsetRva(Offset + count, Rva + count);
+            return new RelocationParameters(ImageBase, Offset + count, Rva + count, Is32Bit);
+        }
+
+        /// <summary>
+        /// Advances the current offset and virtual address by the provided byte count.
+        /// </summary>
+        /// <param name="count">The number of bytes to advance with.</param>
+        /// <returns>The new relocation parameters.</returns>
+        public void Advance(uint count)
+        {
+            Offset += count;
+            Rva += count;
         }
 
         /// <summary>
@@ -103,10 +115,10 @@ namespace AsmResolver
         /// </summary>
         /// <param name="physicalCount">The number of bytes to advance the physical offset with.</param>
         /// <param name="virtualCount">The number of bytes to advance the virtual address with.</param>
-        /// <returns>The new relocation parameters.</returns>
-        public RelocationParameters Advance(uint physicalCount, uint virtualCount)
+        public void Advance(uint physicalCount, uint virtualCount)
         {
-            return WithOffsetRva(Offset + physicalCount, Rva + virtualCount);
+            Offset += physicalCount;
+            Rva += virtualCount;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver/SegmentBase.cs
+++ b/src/AsmResolver/SegmentBase.cs
@@ -25,10 +25,10 @@ namespace AsmResolver
         public bool CanUpdateOffsets => true;
 
         /// <inheritdoc />
-        public virtual void UpdateOffsets(ulong newOffset, uint newRva)
+        public virtual void UpdateOffsets(in RelocationParameters parameters)
         {
-            Offset = newOffset;
-            Rva = newRva;
+            Offset = parameters.Offset;
+            Rva = parameters.Rva;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver/SegmentBuilder.cs
+++ b/src/AsmResolver/SegmentBuilder.cs
@@ -55,31 +55,25 @@ namespace AsmResolver
         }
 
         /// <inheritdoc />
-        public void UpdateOffsets(ulong newOffset, uint newRva)
+        public void UpdateOffsets(in RelocationParameters parameters)
         {
-            Offset = newOffset;
-            Rva = newRva;
-            _physicalSize = 0;
-            _virtualSize = 0;
+            Offset = parameters.Offset;
+            Rva = parameters.Rva;
 
+            var current = parameters;
             foreach (var item in _items)
             {
-                uint physicalPadding = (uint) (newOffset.Align(item.Alignment) - newOffset);
-                uint virtualPadding = newRva.Align(item.Alignment) - newRva;
-
-                newOffset += physicalPadding;
-                newRva += virtualPadding;
-
-                item.Segment.UpdateOffsets(newOffset, newRva);
+                current = current.Align(item.Alignment);
+                item.Segment.UpdateOffsets(current);
 
                 uint physicalSize = item.Segment.GetPhysicalSize();
                 uint virtualSize = item.Segment.GetVirtualSize();
 
-                newOffset += physicalSize;
-                newRva += virtualSize;
-                _physicalSize += physicalPadding + physicalSize;
-                _virtualSize += virtualPadding + virtualSize;
+                current = current.Advance(physicalSize, virtualSize);
             }
+
+            _physicalSize = (uint) (current.Offset - parameters.Offset);
+            _virtualSize = (uint) (current.Rva - parameters.Rva);
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver/SegmentBuilder.cs
+++ b/src/AsmResolver/SegmentBuilder.cs
@@ -63,17 +63,17 @@ namespace AsmResolver
             var current = parameters;
             foreach (var item in _items)
             {
-                current = current.Align(item.Alignment);
+                current.Align(item.Alignment);
                 item.Segment.UpdateOffsets(current);
 
                 uint physicalSize = item.Segment.GetPhysicalSize();
                 uint virtualSize = item.Segment.GetVirtualSize();
 
-                current = current.Advance(physicalSize, virtualSize);
+                current.Advance(physicalSize, virtualSize);
             }
 
             _physicalSize = (uint) (current.Offset - parameters.Offset);
-            _virtualSize = (uint) (current.Rva - parameters.Rva);
+            _virtualSize = current.Rva - parameters.Rva;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver/SegmentReference.cs
+++ b/src/AsmResolver/SegmentReference.cs
@@ -33,9 +33,6 @@ namespace AsmResolver
         public uint Rva => Segment?.Rva ?? 0;
 
         /// <inheritdoc />
-        public bool CanUpdateOffsets => Segment?.CanUpdateOffsets ?? false;
-
-        /// <inheritdoc />
         public bool IsBounded => true;
 
         /// <inheritdoc />

--- a/src/AsmResolver/SegmentReference.cs
+++ b/src/AsmResolver/SegmentReference.cs
@@ -51,9 +51,6 @@ namespace AsmResolver
         }
 
         /// <inheritdoc />
-        public void UpdateOffsets(ulong newOffset, uint newRva) => Segment?.UpdateOffsets(newOffset, newRva);
-
-        /// <inheritdoc />
         public BinaryStreamReader CreateReader()
         {
             return CanRead

--- a/src/AsmResolver/VirtualSegment.cs
+++ b/src/AsmResolver/VirtualSegment.cs
@@ -44,15 +44,7 @@ namespace AsmResolver
         public ulong Offset => PhysicalContents?.Offset ?? 0;
 
         /// <inheritdoc />
-        public uint Rva
-        {
-            get => _rva;
-            set
-            {
-                _rva = value;
-                PhysicalContents?.UpdateOffsets(Offset, value);
-            }
-        }
+        public uint Rva => _rva;
 
         /// <inheritdoc />
         public bool CanUpdateOffsets => PhysicalContents?.CanUpdateOffsets ?? false;
@@ -64,10 +56,10 @@ namespace AsmResolver
         public bool IsReadable => PhysicalContents is IReadableSegment;
 
         /// <inheritdoc />
-        public void UpdateOffsets(ulong newOffset, uint newRva)
+        public void UpdateOffsets(in RelocationParameters parameters)
         {
-            _rva = newRva;
-            PhysicalContents?.UpdateOffsets(newOffset, newRva);
+            _rva = parameters.Rva;
+            PhysicalContents?.UpdateOffsets(parameters);
         }
 
         /// <inheritdoc />

--- a/test/AsmResolver.PE.Tests/DotNet/Builder/MixedModeAssemblyTest.cs
+++ b/test/AsmResolver.PE.Tests/DotNet/Builder/MixedModeAssemblyTest.cs
@@ -89,7 +89,7 @@ namespace AsmResolver.PE.Tests.DotNet.Builder
             // Read image
             var image = PEImage.FromBytes(Properties.Resources.TheAnswer_NetFx);
 
-            ReplaceBodyWithNativeCode(image, new CodeSegment(image.ImageBase, new byte[]
+            ReplaceBodyWithNativeCode(image, new CodeSegment(new byte[]
             {
                 0xb8, 0x39, 0x05, 0x00, 0x00,      // mov rax, 1337
                 0xc3                               // ret
@@ -120,7 +120,7 @@ namespace AsmResolver.PE.Tests.DotNet.Builder
             var function = new ImportedSymbol(0x4fc, "puts");
             module.Symbols.Add(function);
 
-            var body = new CodeSegment(image.ImageBase, new byte[]
+            var body = new CodeSegment(new byte[]
             {
                 /* 00: */ 0x48, 0x83, 0xEC, 0x28,                     // sub rsp, 0x28
                 /* 04: */ 0x48, 0x8D, 0x0D, 0x10, 0x00, 0x00, 0x00,   // lea rcx, qword [rel str]
@@ -170,7 +170,7 @@ namespace AsmResolver.PE.Tests.DotNet.Builder
             var function = new ImportedSymbol(0x4fc, "puts");
             module.Symbols.Add(function);
 
-            var body = new CodeSegment(image.ImageBase, new byte[]
+            var body = new CodeSegment(new byte[]
             {
                 /* 00: */  0x55,                                 // push ebp
                 /* 01: */  0x89, 0xE5,                           // mov ebp,esp

--- a/test/AsmResolver.PE.Tests/Tls/TlsDirectoryTest.cs
+++ b/test/AsmResolver.PE.Tests/Tls/TlsDirectoryTest.cs
@@ -162,8 +162,6 @@ namespace AsmResolver.PE.Tests.Tls
 
             var directory = new TlsDirectory
             {
-                ImageBase = file.OptionalHeader.ImageBase,
-                Is32Bit = file.OptionalHeader.Magic == OptionalHeaderMagic.Pe32,
                 TemplateData = templateData,
                 Index = indexSegment.ToReference(),
                 Characteristics = TlsCharacteristics.Align4Bytes,

--- a/test/AsmResolver.PE.Tests/VirtualAddress.cs
+++ b/test/AsmResolver.PE.Tests/VirtualAddress.cs
@@ -17,10 +17,6 @@ namespace AsmResolver.PE.Tests
             get;
         }
 
-        bool IOffsetProvider.CanUpdateOffsets => false;
-
-        void IOffsetProvider.UpdateOffsets(ulong newOffset, uint newRva) => throw new InvalidOperationException();
-
         public bool CanRead => false;
 
         bool ISegmentReference.IsBounded => false;

--- a/test/AsmResolver.Tests/SegmentBuilderTest.cs
+++ b/test/AsmResolver.Tests/SegmentBuilderTest.cs
@@ -8,8 +8,6 @@ namespace AsmResolver.Tests
     {
         private static byte[] ToBytes(ISegment segment)
         {
-            segment.UpdateOffsets(0, 0);
-
             using var stream = new MemoryStream();
 
             var writer = new BinaryStreamWriter(stream);
@@ -22,7 +20,7 @@ namespace AsmResolver.Tests
         {
             var collection = new SegmentBuilder();
 
-            collection.UpdateOffsets(0x400, 0x1000);
+            collection.UpdateOffsets(new RelocationParameters(0x400000, 0x400, 0x1000, false));
 
             Assert.Equal(0x400u, collection.Offset);
             Assert.Equal(0x1000u, collection.Rva);
@@ -39,7 +37,7 @@ namespace AsmResolver.Tests
 
             var collection = new SegmentBuilder {segment};
 
-            collection.UpdateOffsets(0x400, 0x1000);
+            collection.UpdateOffsets(new RelocationParameters(0x400000, 0x400, 0x1000, false));
 
             Assert.Equal(0x400u, segment.Offset);
             Assert.Equal(0x1000u, segment.Rva);
@@ -61,7 +59,7 @@ namespace AsmResolver.Tests
 
             var collection = new SegmentBuilder {segment1, segment2, segment3};
 
-            collection.UpdateOffsets(0x400, 0x1000);
+            collection.UpdateOffsets(new RelocationParameters(0x400000, 0x400, 0x1000, false));
 
             Assert.Equal(0x400u, segment1.Offset);
             Assert.Equal(0x1000u, segment1.Rva);
@@ -88,7 +86,7 @@ namespace AsmResolver.Tests
 
             var builder = new SegmentBuilder {segment};
 
-            builder.UpdateOffsets(0x400, 0x1000);
+            builder.UpdateOffsets(new RelocationParameters(0x400000, 0x400, 0x1000, false));
 
             Assert.Equal(0x400u, segment.Offset);
 
@@ -115,7 +113,7 @@ namespace AsmResolver.Tests
                 {segment3, 8}
             };
 
-            builder.UpdateOffsets(0x400, 0x1000);
+            builder.UpdateOffsets(new RelocationParameters(0x400000, 0x400, 0x1000, false));
 
             Assert.Equal(0x400u, segment1.Offset);
             Assert.Equal(0x1000u, segment1.Rva);


### PR DESCRIPTION
- Refactors `ISegment::UpdateOffset` to take a new structure `RelocationParameters`, containing new offset and rva of the segment, but also additional metadata such as the new image base that the image is relocated to.
- Removes many redundant `ImageBase` properties and parameters throughout the project.

Closes #236 