### PR TITLE
Lazy custom attribute signatures

### DIFF
--- a/src/AsmResolver.DotNet/CustomAttribute.cs
+++ b/src/AsmResolver.DotNet/CustomAttribute.cs
@@ -29,6 +29,17 @@ namespace AsmResolver.DotNet
         /// Creates a new custom attribute.
         /// </summary>
         /// <param name="constructor">The constructor of the attribute to call.</param>
+        public CustomAttribute(ICustomAttributeType? constructor)
+            : this(new MetadataToken(TableIndex.CustomAttribute, 0))
+        {
+            Constructor = constructor;
+            Signature = new CustomAttributeSignature();
+        }
+
+        /// <summary>
+        /// Creates a new custom attribute.
+        /// </summary>
+        /// <param name="constructor">The constructor of the attribute to call.</param>
         /// <param name="signature">The signature containing the arguments to the constructor.</param>
         public CustomAttribute(ICustomAttributeType? constructor, CustomAttributeSignature? signature)
             : this(new MetadataToken(TableIndex.CustomAttribute, 0))

--- a/src/AsmResolver.DotNet/Serialized/SerializedCustomAttribute.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedCustomAttribute.cs
@@ -65,10 +65,7 @@ namespace AsmResolver.DotNet.Serialized
                     $"Invalid signature blob index in custom attribute {MetadataToken}.");
             }
 
-            return CustomAttributeSignature.FromReader(
-                new BlobReadContext(_context),
-                Constructor,
-                ref reader);
+            return CustomAttributeSignature.FromReader(new BlobReadContext(_context), Constructor, reader);
         }
     }
 }

--- a/src/AsmResolver.DotNet/Signatures/CustomAttributeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/CustomAttributeSignature.cs
@@ -112,16 +112,15 @@ namespace AsmResolver.DotNet.Signatures
             if (IsInitialized)
                 return;
 
+            var fixedArguments = new List<CustomAttributeArgument>();
+            var namedArguments = new List<CustomAttributeNamedArgument>();
+
+            Initialize(fixedArguments, namedArguments);
+
             lock (this)
             {
                 if (IsInitialized)
                     return;
-
-                var fixedArguments = new List<CustomAttributeArgument>();
-                var namedArguments = new List<CustomAttributeNamedArgument>();
-
-                Initialize(fixedArguments, namedArguments);
-
                 _fixedArguments = fixedArguments;
                 _namedArguments = namedArguments;
             }

--- a/src/AsmResolver.DotNet/Signatures/CustomAttributeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/CustomAttributeSignature.cs
@@ -31,6 +31,14 @@ namespace AsmResolver.DotNet.Signatures
         /// <summary>
         /// Creates a new custom attribute signature with the provided fixed arguments.
         /// </summary>
+        public CustomAttributeSignature(params CustomAttributeArgument[] fixedArguments)
+            : this(fixedArguments, Enumerable.Empty<CustomAttributeNamedArgument>())
+        {
+        }
+
+        /// <summary>
+        /// Creates a new custom attribute signature with the provided fixed arguments.
+        /// </summary>
         public CustomAttributeSignature(IEnumerable<CustomAttributeArgument> fixedArguments)
             : this(fixedArguments, Enumerable.Empty<CustomAttributeNamedArgument>())
         {

--- a/src/AsmResolver.DotNet/Signatures/CustomAttributeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/CustomAttributeSignature.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using AsmResolver.DotNet.Signatures.Types;
 using AsmResolver.IO;
@@ -12,55 +13,18 @@ namespace AsmResolver.DotNet.Signatures
     /// </summary>
     public class CustomAttributeSignature : ExtendableBlobSignature
     {
-        private readonly List<CustomAttributeArgument> _fixedArguments;
-        private readonly List<CustomAttributeNamedArgument> _namedArguments;
-        private const ushort CustomAttributeSignaturePrologue = 0x0001;
-
         /// <summary>
-        /// Reads a single custom attribute signature from the input stream.
+        /// The header value of every custom attribute signature.
         /// </summary>
-        /// <param name="context">The blob reader context.</param>
-        /// <param name="ctor">The constructor that was called.</param>
-        /// <param name="reader">The input stream.</param>
-        /// <returns>The signature.</returns>
-        /// <exception cref="FormatException">Occurs when the input stream does not point to a valid signature.</exception>
-        public static CustomAttributeSignature? FromReader(in BlobReadContext context, ICustomAttributeType ctor, ref BinaryStreamReader reader)
-        {
-            ushort prologue = reader.ReadUInt16();
-            if (prologue != CustomAttributeSignaturePrologue)
-            {
-                context.ReaderContext.BadImage("Input stream does not point to a valid custom attribute signature.");
-                return null;
-            }
+        protected const ushort CustomAttributeSignaturePrologue = 0x0001;
 
-            var result = new CustomAttributeSignature();
-
-            // Read fixed arguments.
-            var parameterTypes = ctor.Signature?.ParameterTypes ?? Array.Empty<TypeSignature>();
-            result._fixedArguments.Capacity = parameterTypes.Count;
-            for (int i = 0; i < parameterTypes.Count; i++)
-            {
-                var argument = CustomAttributeArgument.FromReader(context, parameterTypes[i], ref reader);
-                result._fixedArguments.Add(argument);
-            }
-
-            // Read named arguments.
-            ushort namedArgumentCount = reader.ReadUInt16();
-            result._namedArguments.Capacity = namedArgumentCount;
-            for (int i = 0; i < namedArgumentCount; i++)
-            {
-                var argument = CustomAttributeNamedArgument.FromReader(context, ref reader);
-                result._namedArguments.Add(argument);
-            }
-
-            return result;
-        }
+        private List<CustomAttributeArgument>? _fixedArguments;
+        private List<CustomAttributeNamedArgument>? _namedArguments;
 
         /// <summary>
         /// Creates a new empty custom attribute signature.
         /// </summary>
         public CustomAttributeSignature()
-            : this(Enumerable.Empty<CustomAttributeArgument>(), Enumerable.Empty<CustomAttributeNamedArgument>())
         {
         }
 
@@ -84,12 +48,87 @@ namespace AsmResolver.DotNet.Signatures
         /// <summary>
         /// Gets a collection of fixed arguments that are passed onto the constructor of the attribute.
         /// </summary>
-        public IList<CustomAttributeArgument> FixedArguments => _fixedArguments;
+        public IList<CustomAttributeArgument> FixedArguments
+        {
+            get
+            {
+                EnsureIsInitialized();
+                return _fixedArguments;
+            }
+        }
 
         /// <summary>
         /// Gets a collection of values that are assigned to fields and/or members of the attribute class.
         /// </summary>
-        public IList<CustomAttributeNamedArgument> NamedArguments => _namedArguments;
+        public IList<CustomAttributeNamedArgument> NamedArguments
+        {
+            get
+            {
+                EnsureIsInitialized();
+                return _namedArguments;
+            }
+        }
+
+        /// <summary>
+        /// Reads a single custom attribute signature from the input stream.
+        /// </summary>
+        /// <param name="context">The blob reader context.</param>
+        /// <param name="ctor">The constructor that was called.</param>
+        /// <param name="reader">The input stream.</param>
+        /// <returns>The signature.</returns>
+        /// <exception cref="FormatException">Occurs when the input stream does not point to a valid signature.</exception>
+        public static CustomAttributeSignature FromReader(
+            in BlobReadContext context,
+            ICustomAttributeType ctor,
+            in BinaryStreamReader reader)
+        {
+            var argumentTypes = ctor.Signature?.ParameterTypes ?? Array.Empty<TypeSignature>();
+            return new SerializedCustomAttributeSignature(context, argumentTypes, reader);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="FixedArguments"/> and <see cref="NamedArguments"/> collections
+        /// are initialized or not.
+        /// </summary>
+        [MemberNotNullWhen(true, nameof(_fixedArguments))]
+        [MemberNotNullWhen(true, nameof(_namedArguments))]
+        protected bool IsInitialized => _fixedArguments is not null && _namedArguments is not null;
+
+        /// <summary>
+        /// Ensures that the <see cref="FixedArguments"/> and <see cref="NamedArguments"/> are initialized.
+        /// </summary>
+        [MemberNotNull(nameof(_fixedArguments))]
+        [MemberNotNull(nameof(_namedArguments))]
+        protected void EnsureIsInitialized()
+        {
+            if (IsInitialized)
+                return;
+
+            lock (this)
+            {
+                if (IsInitialized)
+                    return;
+
+                var fixedArguments = new List<CustomAttributeArgument>();
+                var namedArguments = new List<CustomAttributeNamedArgument>();
+
+                Initialize(fixedArguments, namedArguments);
+
+                _fixedArguments = fixedArguments;
+                _namedArguments = namedArguments;
+            }
+        }
+
+        /// <summary>
+        /// Initializes the argument collections of the signature.
+        /// </summary>
+        /// <param name="fixedArguments">The collection that will receive the fixed arguments.</param>
+        /// <param name="namedArguments">The collection that will receive the named arguments.</param>
+        protected virtual void Initialize(
+            IList<CustomAttributeArgument> fixedArguments,
+            IList<CustomAttributeNamedArgument> namedArguments)
+        {
+        }
 
         /// <inheritdoc />
         public override string ToString()
@@ -110,4 +149,5 @@ namespace AsmResolver.DotNet.Signatures
                 NamedArguments[i].Write(context);
         }
     }
+
 }

--- a/src/AsmResolver.DotNet/Signatures/SerializedCustomAttributeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/SerializedCustomAttributeSignature.cs
@@ -1,0 +1,73 @@
+using System.Linq;
+using System.Collections.Generic;
+using AsmResolver.DotNet.Signatures.Types;
+using AsmResolver.IO;
+
+namespace AsmResolver.DotNet.Signatures
+{
+    /// <summary>
+    /// Provides a lazy initialized implementation of the <see cref="CustomAttributeSignature"/> class.
+    /// </summary>
+    public class SerializedCustomAttributeSignature : CustomAttributeSignature
+    {
+        private readonly BlobReadContext _context;
+        private readonly TypeSignature[] _fixedArgTypes;
+        private readonly BinaryStreamReader _reader;
+
+        /// <summary>
+        /// Initializes a new lazy custom attribute signature from an input blob stream reader.
+        /// </summary>
+        /// <param name="context">The blob reading context the signature is situated in.</param>
+        /// <param name="fixedArgTypes">The types of all fixed arguments.</param>
+        /// <param name="reader">The input blob reader.</param>
+        public SerializedCustomAttributeSignature(
+            in BlobReadContext context,
+            IEnumerable<TypeSignature> fixedArgTypes,
+            in BinaryStreamReader reader)
+        {
+            _context = context;
+            _fixedArgTypes = fixedArgTypes.ToArray();
+            _reader = reader;
+        }
+
+        /// <inheritdoc />
+        protected override void Initialize(
+            IList<CustomAttributeArgument> fixedArguments,
+            IList<CustomAttributeNamedArgument> namedArguments)
+        {
+            var reader = _reader.Fork();
+
+            // Verify magic header.
+            ushort prologue = reader.ReadUInt16();
+            if (prologue != CustomAttributeSignaturePrologue)
+                _context.ReaderContext.BadImage("Input stream does not point to a valid custom attribute signature.");
+
+            // Read fixed arguments.
+            for (int i = 0; i < _fixedArgTypes.Length; i++)
+                fixedArguments.Add(CustomAttributeArgument.FromReader(_context, _fixedArgTypes[i], ref reader));
+
+            // Read named arguments.
+            ushort namedArgumentCount = reader.ReadUInt16();
+            for (int i = 0; i < namedArgumentCount; i++)
+                namedArguments.Add(CustomAttributeNamedArgument.FromReader(_context, ref reader));
+        }
+
+        /// <inheritdoc />
+        protected override void WriteContents(BlobSerializationContext context)
+        {
+            // If the arguments are not initialized yet, it means nobody accessed the fixed or named arguments of the
+            // signature. In such a case, we can safely assume nothing has changed to the signature.
+            //
+            // Since custom attribute signatures reference types by their fully qualified name, they do not contain
+            // any metadata tokens or type indices. Thus, regardless of whether the assembly changed or not, we can
+            // always just use the raw blob signature without risking breaking any references into the assembly.
+            // This can save a lot of processing time, given the fact that many custom attribute arguments are Enum
+            // typed arguments, which would require an expensive type resolution to determine the size of an element.
+
+            if (IsInitialized)
+                base.WriteContents(context);
+            else
+                _reader.Fork().WriteToOutput(context.Writer);
+        }
+    }
+}

--- a/test/AsmResolver.DotNet.Tests/CustomAttributeTest.cs
+++ b/test/AsmResolver.DotNet.Tests/CustomAttributeTest.cs
@@ -1,15 +1,12 @@
 using System;
 using System.IO;
 using System.Linq;
-using AsmResolver.DotNet.Builder;
-using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Types;
 using AsmResolver.DotNet.TestCases.CustomAttributes;
 using AsmResolver.DotNet.TestCases.Properties;
 using AsmResolver.IO;
 using AsmResolver.PE;
-using AsmResolver.PE.DotNet.Cil;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 using Xunit;
@@ -18,7 +15,7 @@ namespace AsmResolver.DotNet.Tests
 {
     public class CustomAttributeTest
     {
-        private readonly SignatureComparer _comparer = new SignatureComparer();
+        private readonly SignatureComparer _comparer = new();
 
         [Fact]
         public void ReadConstructor()
@@ -27,7 +24,7 @@ namespace AsmResolver.DotNet.Tests
             var type = module.TopLevelTypes.First(t => t.Name == nameof(CustomAttributesTestClass));
 
             Assert.All(type.CustomAttributes, a =>
-                Assert.Equal(nameof(TestCaseAttribute), a.Constructor.DeclaringType.Name));
+                Assert.Equal(nameof(TestCaseAttribute), a.Constructor!.DeclaringType!.Name));
         }
 
         [Fact]
@@ -41,7 +38,7 @@ namespace AsmResolver.DotNet.Tests
 
             var type = module.TopLevelTypes.First(t => t.Name == nameof(CustomAttributesTestClass));
             Assert.All(type.CustomAttributes, a =>
-                Assert.Equal(nameof(TestCaseAttribute), a.Constructor.DeclaringType.Name));
+                Assert.Equal(nameof(TestCaseAttribute), a.Constructor!.DeclaringType!.Name));
         }
 
         [Fact]
@@ -51,7 +48,7 @@ namespace AsmResolver.DotNet.Tests
             string filePath = typeof(CustomAttributesTestClass).Assembly.Location;
 
             var image = PEImage.FromFile(filePath);
-            var tablesStream = image.DotNetDirectory.Metadata.GetStream<TablesStream>();
+            var tablesStream = image.DotNetDirectory!.Metadata!.GetStream<TablesStream>();
             var encoder = tablesStream.GetIndexEncoder(CodedIndex.HasCustomAttribute);
             var attributeTable = tablesStream.GetTable<CustomAttributeRow>(TableIndex.CustomAttribute);
 
@@ -73,13 +70,19 @@ namespace AsmResolver.DotNet.Tests
             Assert.Equal(parentToken, attribute.Parent.MetadataToken);
         }
 
-        private static CustomAttribute GetCustomAttributeTestCase(string methodName, bool rebuild = false)
+        private static CustomAttribute GetCustomAttributeTestCase(string methodName, bool rebuild = false, bool access = false)
         {
             var module = ModuleDefinition.FromFile(typeof(CustomAttributesTestClass).Assembly.Location);
             var type = module.TopLevelTypes.First(t => t.Name == nameof(CustomAttributesTestClass));
             var method = type.Methods.First(m => m.Name == methodName);
             var attribute = method.CustomAttributes
-                .First(c => c.Constructor.DeclaringType.Name == nameof(TestCaseAttribute));
+                .First(c => c.Constructor!.DeclaringType!.Name == nameof(TestCaseAttribute));
+
+            if (access)
+            {
+                _ = attribute.Signature!.FixedArguments;
+                _ = attribute.Signature.NamedArguments;
+            }
 
             if (rebuild)
                 attribute = RebuildAndLookup(attribute);
@@ -89,24 +92,28 @@ namespace AsmResolver.DotNet.Tests
         private static CustomAttribute RebuildAndLookup(CustomAttribute attribute)
         {
             var stream = new MemoryStream();
-            var method = (MethodDefinition) attribute.Parent;
-            method.Module.Write(stream);
+            var method = (MethodDefinition) attribute.Parent!;
+            method.Module!.Write(stream);
             var newModule = ModuleDefinition.FromBytes(stream.ToArray());
 
             return newModule
-                .TopLevelTypes.First(t => t.FullName == method.DeclaringType.FullName)
+                .TopLevelTypes.First(t => t.FullName == method.DeclaringType!.FullName)
                 .Methods.First(f => f.Name == method.Name)
                 .CustomAttributes[0];
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void FixedInt32Argument(bool rebuild)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void FixedInt32Argument(bool rebuild, bool access)
         {
-            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedInt32Argument), rebuild);
+            var attribute = GetCustomAttributeTestCase(
+                nameof(CustomAttributesTestClass.FixedInt32Argument),
+                rebuild,
+                access);
 
-            Assert.Single(attribute.Signature.FixedArguments);
+            Assert.Single(attribute.Signature!.FixedArguments);
             Assert.Empty(attribute.Signature.NamedArguments);
 
             var argument = attribute.Signature.FixedArguments[0];
@@ -114,12 +121,13 @@ namespace AsmResolver.DotNet.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void FixedStringArgument(bool rebuild)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void FixedStringArgument(bool rebuild, bool access)
         {
-            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedStringArgument), rebuild);
-            Assert.Single(attribute.Signature.FixedArguments);
+            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedStringArgument),rebuild, access);
+            Assert.Single(attribute.Signature!.FixedArguments);
             Assert.Empty(attribute.Signature.NamedArguments);
 
             var argument = attribute.Signature.FixedArguments[0];
@@ -127,12 +135,13 @@ namespace AsmResolver.DotNet.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void FixedEnumArgument(bool rebuild)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void FixedEnumArgument(bool rebuild, bool access)
         {
-            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedEnumArgument), rebuild);
-            Assert.Single(attribute.Signature.FixedArguments);
+            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedEnumArgument),rebuild, access);
+            Assert.Single(attribute.Signature!.FixedArguments);
             Assert.Empty(attribute.Signature.NamedArguments);
 
             var argument = attribute.Signature.FixedArguments[0];
@@ -140,41 +149,44 @@ namespace AsmResolver.DotNet.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void FixedNullTypeArgument(bool rebuild)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void FixedNullTypeArgument(bool rebuild, bool access)
         {
-            var attribute =  GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedNullTypeArgument), rebuild);
-            var fixedArg = Assert.Single(attribute.Signature.FixedArguments);
+            var attribute =  GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedNullTypeArgument),rebuild, access);
+            var fixedArg = Assert.Single(attribute.Signature!.FixedArguments);
             Assert.Null(fixedArg.Element);
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void FixedTypeArgument(bool rebuild)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void FixedTypeArgument(bool rebuild, bool access)
         {
-            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedTypeArgument), rebuild);
-            Assert.Single(attribute.Signature.FixedArguments);
+            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedTypeArgument),rebuild, access);
+            Assert.Single(attribute.Signature!.FixedArguments);
             Assert.Empty(attribute.Signature.NamedArguments);
 
             var argument = attribute.Signature.FixedArguments[0];
             Assert.Equal(
-                attribute.Constructor.Module.CorLibTypeFactory.String,
+                attribute.Constructor!.Module!.CorLibTypeFactory.String,
                 argument.Element as TypeSignature, _comparer);
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void FixedComplexTypeArgument(bool rebuild)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void FixedComplexTypeArgument(bool rebuild, bool access)
         {
-            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedComplexTypeArgument), rebuild);
-            Assert.Single(attribute.Signature.FixedArguments);
+            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedComplexTypeArgument),rebuild, access);
+            Assert.Single(attribute.Signature!.FixedArguments);
             Assert.Empty(attribute.Signature.NamedArguments);
 
             var argument = attribute.Signature.FixedArguments[0];
-            var factory = attribute.Constructor.Module.CorLibTypeFactory;
+            var factory = attribute.Constructor!.Module!.CorLibTypeFactory;
 
             var listRef = new TypeReference(factory.CorLibScope, "System.Collections.Generic", "KeyValuePair`2");
             var instance = new GenericInstanceTypeSignature(listRef, false,
@@ -185,12 +197,13 @@ namespace AsmResolver.DotNet.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void NamedInt32Argument(bool rebuild)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void NamedInt32Argument(bool rebuild, bool access)
         {
-            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.NamedInt32Argument), rebuild);
-            Assert.Empty(attribute.Signature.FixedArguments);
+            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.NamedInt32Argument),rebuild, access);
+            Assert.Empty(attribute.Signature!.FixedArguments);
             Assert.Single(attribute.Signature.NamedArguments);
 
             var argument = attribute.Signature.NamedArguments[0];
@@ -199,12 +212,13 @@ namespace AsmResolver.DotNet.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void NamedStringArgument(bool rebuild)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void NamedStringArgument(bool rebuild, bool access)
         {
-            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.NamedStringArgument), rebuild);
-            Assert.Empty(attribute.Signature.FixedArguments);
+            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.NamedStringArgument),rebuild, access);
+            Assert.Empty(attribute.Signature!.FixedArguments);
             Assert.Single(attribute.Signature.NamedArguments);
 
             var argument = attribute.Signature.NamedArguments[0];
@@ -213,12 +227,13 @@ namespace AsmResolver.DotNet.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void NamedEnumArgument(bool rebuild)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void NamedEnumArgument(bool rebuild, bool access)
         {
-            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.NamedEnumArgument), rebuild);
-            Assert.Empty(attribute.Signature.FixedArguments);
+            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.NamedEnumArgument),rebuild, access);
+            Assert.Empty(attribute.Signature!.FixedArguments);
             Assert.Single(attribute.Signature.NamedArguments);
 
             var argument = attribute.Signature.NamedArguments[0];
@@ -227,16 +242,17 @@ namespace AsmResolver.DotNet.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void NamedTypeArgument(bool rebuild)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void NamedTypeArgument(bool rebuild, bool access)
         {
-            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.NamedTypeArgument), rebuild);
-            Assert.Empty(attribute.Signature.FixedArguments);
+            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.NamedTypeArgument),rebuild, access);
+            Assert.Empty(attribute.Signature!.FixedArguments);
             Assert.Single(attribute.Signature.NamedArguments);
 
             var expected = new TypeReference(
-                attribute.Constructor.Module.CorLibTypeFactory.CorLibScope,
+                attribute.Constructor!.Module!.CorLibTypeFactory.CorLibScope,
                 "System", "Int32");
 
             var argument = attribute.Signature.NamedArguments[0];
@@ -250,22 +266,23 @@ namespace AsmResolver.DotNet.Tests
             var module = ModuleDefinition.FromFile(typeof(SingleProperty).Assembly.Location);
             var type = module.TopLevelTypes.First(t => t.Name == nameof(SingleProperty));
             var property = type.Properties.First();
-            var setMethod = property.SetMethod;
+            var setMethod = property.SetMethod!;
 
             Assert.True(setMethod.IsCompilerGenerated());
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void GenericTypeArgument(bool rebuild)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void GenericTypeArgument(bool rebuild, bool access)
         {
             // https://github.com/Washi1337/AsmResolver/issues/92
 
-            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.GenericType), rebuild);
-            var argument = attribute.Signature.FixedArguments[0];
+            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.GenericType),rebuild, access);
+            var argument = attribute.Signature!.FixedArguments[0];
 
-            var module = attribute.Constructor.Module;
+            var module = attribute.Constructor!.Module!;
             var nestedClass = (TypeDefinition) module.LookupMember(typeof(TestGenericType<>).MetadataToken);
             var expected = new GenericInstanceTypeSignature(nestedClass, false, module.CorLibTypeFactory.Object);
 
@@ -274,16 +291,17 @@ namespace AsmResolver.DotNet.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void ArrayGenericTypeArgument(bool rebuild)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void ArrayGenericTypeArgument(bool rebuild, bool access)
         {
             // https://github.com/Washi1337/AsmResolver/issues/92
 
-            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.GenericTypeArray), rebuild);
-            var argument = attribute.Signature.FixedArguments[0];
+            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.GenericTypeArray),rebuild, access);
+            var argument = attribute.Signature!.FixedArguments[0];
 
-            var module = attribute.Constructor.Module;
+            var module = attribute.Constructor!.Module!;
             var nestedClass = (TypeDefinition) module.LookupMember(typeof(TestGenericType<>).MetadataToken);
             var expected = new SzArrayTypeSignature(
                 new GenericInstanceTypeSignature(nestedClass, false, module.CorLibTypeFactory.Object)
@@ -294,64 +312,69 @@ namespace AsmResolver.DotNet.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void IntPassedOnAsObject(bool rebuild)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void IntPassedOnAsObject(bool rebuild, bool access)
         {
             // https://github.com/Washi1337/AsmResolver/issues/92
 
-            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.Int32PassedAsObject), rebuild);
-            var argument = attribute.Signature.FixedArguments[0];
+            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.Int32PassedAsObject),rebuild, access);
+            var argument = attribute.Signature!.FixedArguments[0];
 
             Assert.IsAssignableFrom<BoxedArgument>(argument.Element);
             Assert.Equal(123, ((BoxedArgument) argument.Element).Value);
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void TypePassedOnAsObject(bool rebuild)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void TypePassedOnAsObject(bool rebuild, bool access)
         {
             // https://github.com/Washi1337/AsmResolver/issues/92
 
-            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.TypePassedAsObject), rebuild);
-            var argument = attribute.Signature.FixedArguments[0];
+            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.TypePassedAsObject),rebuild, access);
+            var argument = attribute.Signature!.FixedArguments[0];
 
-            var module = attribute.Constructor.Module;
+            var module = attribute.Constructor!.Module!;
             Assert.IsAssignableFrom<BoxedArgument>(argument.Element);
             Assert.Equal(module.CorLibTypeFactory.Int32, (ITypeDescriptor) ((BoxedArgument) argument.Element).Value, _comparer);
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void FixedInt32NullArray(bool rebuild)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void FixedInt32NullArray(bool rebuild, bool access)
         {
-            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedInt32ArrayNullArgument), rebuild);
-            var argument = attribute.Signature.FixedArguments[0];
+            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedInt32ArrayNullArgument),rebuild, access);
+            var argument = attribute.Signature!.FixedArguments[0];
 
             Assert.True(argument.IsNullArray);
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void FixedInt32EmptyArray(bool rebuild)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void FixedInt32EmptyArray(bool rebuild, bool access)
         {
-            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedInt32ArrayEmptyArgument), rebuild);
-            var argument = attribute.Signature.FixedArguments[0];
+            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedInt32ArrayEmptyArgument),rebuild, access);
+            var argument = attribute.Signature!.FixedArguments[0];
 
             Assert.False(argument.IsNullArray);
             Assert.Empty(argument.Elements);
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void FixedInt32Array(bool rebuild)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void FixedInt32Array(bool rebuild, bool access)
         {
-            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedInt32ArrayArgument), rebuild);
-            var argument = attribute.Signature.FixedArguments[0];
+            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedInt32ArrayArgument),rebuild, access);
+            var argument = attribute.Signature!.FixedArguments[0];
 
             Assert.Equal(new[]
             {
@@ -360,12 +383,13 @@ namespace AsmResolver.DotNet.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void FixedInt32ArrayNullAsObject(bool rebuild)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void FixedInt32ArrayNullAsObject(bool rebuild, bool access)
         {
-            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedInt32ArrayAsObjectNullArgument), rebuild);
-            var argument = attribute.Signature.FixedArguments[0];
+            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedInt32ArrayAsObjectNullArgument),rebuild, access);
+            var argument = attribute.Signature!.FixedArguments[0];
 
             Assert.IsAssignableFrom<BoxedArgument>(argument.Element);
             var boxedArgument = (BoxedArgument) argument.Element;
@@ -373,25 +397,27 @@ namespace AsmResolver.DotNet.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void FixedInt32EmptyArrayAsObject(bool rebuild)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void FixedInt32EmptyArrayAsObject(bool rebuild, bool access)
         {
-            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedInt32ArrayAsObjectEmptyArgument), rebuild);
-            var argument = attribute.Signature.FixedArguments[0];
+            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedInt32ArrayAsObjectEmptyArgument),rebuild, access);
+            var argument = attribute.Signature!.FixedArguments[0];
 
             Assert.IsAssignableFrom<BoxedArgument>(argument.Element);
             var boxedArgument = (BoxedArgument) argument.Element;
-            Assert.Equal(new object[0], boxedArgument.Value);
+            Assert.Equal(Array.Empty<object>(), boxedArgument.Value);
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void FixedInt32ArrayAsObject(bool rebuild)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void FixedInt32ArrayAsObject(bool rebuild, bool access)
         {
-            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedInt32ArrayAsObjectArgument), rebuild);
-            var argument = attribute.Signature.FixedArguments[0];
+            var attribute = GetCustomAttributeTestCase(nameof(CustomAttributesTestClass.FixedInt32ArrayAsObjectArgument),rebuild, access);
+            var argument = attribute.Signature!.FixedArguments[0];
 
             Assert.IsAssignableFrom<BoxedArgument>(argument.Element);
             var boxedArgument = (BoxedArgument) argument.Element;

--- a/test/AsmResolver.DotNet.Tests/CustomAttributeTest.cs
+++ b/test/AsmResolver.DotNet.Tests/CustomAttributeTest.cs
@@ -400,5 +400,43 @@ namespace AsmResolver.DotNet.Tests
                 1, 2, 3, 4
             }, boxedArgument.Value);
         }
+
+        [Fact]
+        public void CreateNewWithFixedArgumentsViaConstructor()
+        {
+            var module = new ModuleDefinition("Module.exe");
+
+            var attribute = new CustomAttribute(module.CorLibTypeFactory.CorLibScope
+                    .CreateTypeReference("System", "ObsoleteAttribute")
+                    .CreateMemberReference(".ctor", MethodSignature.CreateInstance(
+                        module.CorLibTypeFactory.Void,
+                        module.CorLibTypeFactory.String)),
+                new CustomAttributeSignature(new CustomAttributeArgument(
+                    module.CorLibTypeFactory.String,
+                    "My Message")));
+
+            Assert.NotNull(attribute.Signature);
+            var argument = Assert.Single(attribute.Signature.FixedArguments);
+            Assert.Equal("My Message", argument.Element);
+        }
+
+        [Fact]
+        public void CreateNewWithFixedArgumentsViaProperty()
+        {
+            var module = new ModuleDefinition("Module.exe");
+
+            var attribute = new CustomAttribute(module.CorLibTypeFactory.CorLibScope
+                .CreateTypeReference("System", "ObsoleteAttribute")
+                .CreateMemberReference(".ctor", MethodSignature.CreateInstance(
+                    module.CorLibTypeFactory.Void,
+                    module.CorLibTypeFactory.String)));
+            attribute.Signature!.FixedArguments.Add(new CustomAttributeArgument(
+                module.CorLibTypeFactory.String,
+                "My Message"));
+
+            Assert.NotNull(attribute.Signature);
+            var argument = Assert.Single(attribute.Signature.FixedArguments);
+            Assert.Equal("My Message", argument.Element);
+        }
     }
 }

--- a/test/AsmResolver.DotNet.Tests/ModuleDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/ModuleDefinitionTest.cs
@@ -359,5 +359,41 @@ namespace AsmResolver.DotNet.Tests
             var reference = Assert.Single(module.AssemblyReferences);
             Assert.Equal(KnownCorLibs.NetStandard_v2_0_0_0, reference, Comparer);
         }
+
+        [Fact]
+        public void RewriteSystemPrivateCoreLib()
+        {
+            string runtimePath = DotNetCorePathProvider.Default
+                .GetRuntimePathCandidates("Microsoft.NETCore.App", new Version(3, 1, 0))
+                .FirstOrDefault() ?? throw new InvalidOperationException(".NET Core 3.1 is not installed.");
+            var module = ModuleDefinition.FromFile(Path.Combine(runtimePath, "System.Private.CoreLib.dll"));
+
+            using var stream = new MemoryStream();
+            module.Write(stream);
+        }
+
+        [Fact]
+        public void RewriteSystemRuntime()
+        {
+            string runtimePath = DotNetCorePathProvider.Default
+                .GetRuntimePathCandidates("Microsoft.NETCore.App", new Version(3, 1, 0))
+                .FirstOrDefault() ?? throw new InvalidOperationException(".NET Core 3.1 is not installed.");
+            var module = ModuleDefinition.FromFile(Path.Combine(runtimePath, "System.Runtime.dll"));
+
+            using var stream = new MemoryStream();
+            module.Write(stream);
+        }
+
+        [Fact]
+        public void RewriteSystemPrivateXml()
+        {
+            string runtimePath = DotNetCorePathProvider.Default
+                .GetRuntimePathCandidates("Microsoft.NETCore.App", new Version(3, 1, 0))
+                .FirstOrDefault() ?? throw new InvalidOperationException(".NET Core 3.1 is not installed.");
+            var module = ModuleDefinition.FromFile(Path.Combine(runtimePath, "System.Private.Xml.dll"));
+
+            using var stream = new MemoryStream();
+            module.Write(stream);
+        }
     }
 }


### PR DESCRIPTION
Includes:
- `SerializedCustomAttributeSignature`, which is a lazy initialized version of `CustomAttributeSignature` that does not parse the arguments unless absolutely necessary.
- Adds convenience constructors to `CustomAttribute` and `CustomAttributeSignature`.

Closes #336 