### PR TITLE
Various CIL body parsing hardening improvements

### DIFF
--- a/src/AsmResolver.DotNet.Dynamic/DynamicMethodHelper.cs
+++ b/src/AsmResolver.DotNet.Dynamic/DynamicMethodHelper.cs
@@ -108,7 +108,7 @@ namespace AsmResolver.DotNet.Dynamic
             for (int i = 0; i < FieldReader.ReadField<int>(ehInfo, "m_currentCatch"); i++)
             {
                 // Get ExceptionHandlerInfo Field Values
-                var endFinally = FieldReader.ReadField<int>(ehInfo, "m_endFinally");
+                int endFinally = FieldReader.ReadField<int>(ehInfo, "m_endFinally");
                 var instructions = methodBody.Instructions;
 
                 var endFinallyLabel = endFinally >= 0
@@ -155,17 +155,21 @@ namespace AsmResolver.DotNet.Dynamic
 
             if (dynamicMethodObj.GetType().FullName == "System.Reflection.Emit.DynamicMethod")
             {
-                var resolver = FieldReader.ReadField<object>(dynamicMethodObj, "m_resolver");
+                object? resolver = FieldReader.ReadField<object>(dynamicMethodObj, "m_resolver");
                 if (resolver != null)
                     dynamicMethodObj = resolver;
             }
             //Create Resolver if it does not exist.
             if (dynamicMethodObj.GetType().FullName == "System.Reflection.Emit.DynamicMethod")
             {
-                var dynamicResolver = typeof(OpCode).Module.GetTypes()
+                var dynamicResolver = typeof(OpCode).Module
+                    .GetTypes()
                     .First(t => t.Name == "DynamicResolver");
 
-                var ilGenerator = dynamicMethodObj.GetType().GetRuntimeMethods().First(q => q.Name == "GetILGenerator")
+                object? ilGenerator = dynamicMethodObj
+                    .GetType()
+                    .GetRuntimeMethods()
+                    .First(q => q.Name == "GetILGenerator")
                     .Invoke(dynamicMethodObj, null);
 
                 //Create instance of dynamicResolver

--- a/src/AsmResolver.DotNet/Code/Cil/CilMethodBody.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilMethodBody.cs
@@ -147,15 +147,13 @@ namespace AsmResolver.DotNet.Code.Cil
         {
             var result = new CilMethodBody(method);
 
-            operandResolver ??= new PhysicalCilOperandResolver(context.ParentModule, result);
-
             // Interpret body header.
             var fatBody = rawBody as CilRawFatMethodBody;
             if (fatBody is not null)
             {
                 result.MaxStack = fatBody.MaxStack;
                 result.InitializeLocals = fatBody.InitLocals;
-                ReadLocalVariables(context.ParentModule, result, fatBody);
+                ReadLocalVariables(context, result, fatBody);
             }
             else
             {
@@ -164,55 +162,88 @@ namespace AsmResolver.DotNet.Code.Cil
             }
 
             // Parse instructions.
-            ReadInstructions(result, operandResolver, rawBody);
+            operandResolver ??= new PhysicalCilOperandResolver(context.ParentModule, result);
+            ReadInstructions(context, result, operandResolver, rawBody);
 
             // Read exception handlers.
             if (fatBody is not null)
-                ReadExceptionHandlers(fatBody, result);
+                ReadExceptionHandlers(context, fatBody, result);
 
             return result;
         }
 
         private static void ReadLocalVariables(
-            ModuleDefinition module,
+            ModuleReaderContext context,
             CilMethodBody result,
             CilRawFatMethodBody fatBody)
         {
-            if (fatBody.LocalVarSigToken != MetadataToken.Zero
-                && module.TryLookupMember(fatBody.LocalVarSigToken, out var member)
-                && member is StandAloneSignature {Signature: LocalVariablesSignature localVariablesSignature})
+            // Method bodies can have 0 tokens if there are no locals defined.
+            if (fatBody.LocalVarSigToken == MetadataToken.Zero)
+                return;
+
+            // If there is a non-zero token however, it needs to point to a stand-alone signature with a
+            // local variable signature stored in it.
+            if (!context.ParentModule.TryLookupMember(fatBody.LocalVarSigToken, out var member)
+                || member is not StandAloneSignature { Signature: LocalVariablesSignature localVariablesSignature })
             {
-                var variableTypes = localVariablesSignature.VariableTypes;
-                for (int i = 0; i < variableTypes.Count; i++)
-                    result.LocalVariables.Add(new CilLocalVariable(variableTypes[i]));
+                context.BadImage($"Method body of {result.Owner.SafeToString()} contains an invalid local variable signature token.");
+                return;
             }
+
+            // Copy over the local variable types from the signature into the method body.
+            var variableTypes = localVariablesSignature.VariableTypes;
+            for (int i = 0; i < variableTypes.Count; i++)
+                result.LocalVariables.Add(new CilLocalVariable(variableTypes[i]));
         }
 
         private static void ReadInstructions(
+            ModuleReaderContext context,
             CilMethodBody result,
             ICilOperandResolver operandResolver,
             CilRawMethodBody rawBody)
         {
-            var reader = rawBody.Code.CreateReader();
-            var disassembler = new CilDisassembler(reader, operandResolver);
-            result.Instructions.AddRange(disassembler.ReadInstructions());
+            try
+            {
+                var reader = rawBody.Code.CreateReader();
+                var disassembler = new CilDisassembler(reader, operandResolver);
+                result.Instructions.AddRange(disassembler.ReadInstructions());
+            }
+            catch (Exception ex)
+            {
+                context.RegisterException(new BadImageFormatException(
+                    $"Method body of {result.Owner.SafeToString()} contains an invalid CIL code stream.", ex));
+            }
         }
 
-        private static void ReadExceptionHandlers(CilRawFatMethodBody fatBody, CilMethodBody result)
+        private static void ReadExceptionHandlers(
+            ModuleReaderContext context,
+            CilRawFatMethodBody fatBody,
+            CilMethodBody result)
         {
-            for (int i = 0; i < fatBody.ExtraSections.Count; i++)
+            try
             {
-                var section = fatBody.ExtraSections[i];
-                if (section.IsEHTable)
+                for (int i = 0; i < fatBody.ExtraSections.Count; i++)
                 {
-                    var reader = ByteArrayDataSource.CreateReader(section.Data);
-                    uint size = section.IsFat
-                        ? CilExceptionHandler.FatExceptionHandlerSize
-                        : CilExceptionHandler.TinyExceptionHandlerSize;
+                    var section = fatBody.ExtraSections[i];
+                    if (section.IsEHTable)
+                    {
+                        var reader = ByteArrayDataSource.CreateReader(section.Data);
+                        uint size = section.IsFat
+                            ? CilExceptionHandler.FatExceptionHandlerSize
+                            : CilExceptionHandler.TinyExceptionHandlerSize;
 
-                    while (reader.CanRead(size))
-                        result.ExceptionHandlers.Add(CilExceptionHandler.FromReader(result, ref reader, section.IsFat));
+                        while (reader.CanRead(size))
+                        {
+                            var handler = CilExceptionHandler.FromReader(result, ref reader, section.IsFat);
+                            result.ExceptionHandlers.Add(handler);
+                        }
+                    }
                 }
+            }
+            catch (Exception ex)
+            {
+                context.RegisterException(new BadImageFormatException(
+                    $"Method body of {result.Owner.SafeToString()} contains invalid extra sections.", ex));
             }
         }
 

--- a/src/AsmResolver.DotNet/Code/Cil/CilMethodBodySerializer.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilMethodBodySerializer.cs
@@ -23,7 +23,7 @@ namespace AsmResolver.DotNet.Code.Cil
         /// </summary>
         /// <remarks>
         /// <para>
-        /// When this property is set to <c>true</c>, the maximum stack depth of all method bodies will be recaculated.
+        /// When this property is set to <c>true</c>, the maximum stack depth of all method bodies will be recalculated.
         /// </para>
         /// <para>
         /// When this property is set to <c>false</c>, the maximum stack depth of all method bodies will be preserved.
@@ -37,7 +37,7 @@ namespace AsmResolver.DotNet.Code.Cil
         {
             get;
             set;
-        }
+        } = null;
 
         /// <summary>
         /// Gets or sets the value of an override switch indicating whether labels should always be verified for
@@ -64,7 +64,7 @@ namespace AsmResolver.DotNet.Code.Cil
         /// <inheritdoc />
         public ISegmentReference SerializeMethodBody(MethodBodySerializationContext context, MethodDefinition method)
         {
-            if (method.CilMethodBody == null)
+            if (method.CilMethodBody is null)
                 return SegmentReference.Null;
 
             var body = method.CilMethodBody;

--- a/src/AsmResolver.DotNet/Code/Cil/CilOperandBuilder.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilOperandBuilder.cs
@@ -31,8 +31,7 @@ namespace AsmResolver.DotNet.Code.Cil
                 CilLocalVariable localVariable => localVariable.Index,
                 byte raw => raw,
                 ushort raw => raw,
-                _ => _errorListener.RegisterExceptionAndReturnDefault<int>(
-                    new NotSupportedException($"Invalid or unsupported variable operand ({operand.SafeToString()})."))
+                _ => _errorListener.NotSupportedAndReturn<int>($"Invalid or unsupported variable operand ({operand.SafeToString()}).")
             };
         }
 
@@ -44,8 +43,7 @@ namespace AsmResolver.DotNet.Code.Cil
                 Parameter parameter => parameter.MethodSignatureIndex,
                 byte raw => raw,
                 ushort raw => raw,
-                _ => _errorListener.RegisterExceptionAndReturnDefault<int>(
-                    new NotSupportedException($"Invalid or unsupported argument operand ({operand.SafeToString()})."))
+                _ => _errorListener.NotSupportedAndReturn<int>($"Invalid or unsupported argument operand ({operand.SafeToString()}).")
             };
         }
 
@@ -55,9 +53,9 @@ namespace AsmResolver.DotNet.Code.Cil
             return operand switch
             {
                 string value => 0x70000000 | _provider.GetUserStringIndex(value),
+                MetadataToken token => token.ToUInt32(),
                 uint raw => raw,
-                _ => _errorListener.RegisterExceptionAndReturnDefault<uint>(
-                    new NotSupportedException($"Invalid or unsupported string operand ({operand.SafeToString()})."))
+                _ => _errorListener.NotSupportedAndReturn<uint>($"Invalid or unsupported string operand ({operand.SafeToString()}).")
             };
         }
 
@@ -69,8 +67,7 @@ namespace AsmResolver.DotNet.Code.Cil
                 IMetadataMember member => GetMemberToken(member),
                 MetadataToken token => token,
                 uint raw => raw,
-                _ => _errorListener.RegisterExceptionAndReturnDefault<uint>(
-                    new NotSupportedException($"Invalid or unsupported member operand ({operand.SafeToString()})."))
+                _ => _errorListener.NotSupportedAndReturn<uint>($"Invalid or unsupported member operand ({operand.SafeToString()}).")
             };
         }
 

--- a/src/AsmResolver.DotNet/Code/Cil/OriginalMetadataTokenProvider.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/OriginalMetadataTokenProvider.cs
@@ -1,0 +1,74 @@
+using AsmResolver.DotNet.Builder.Metadata;
+using AsmResolver.PE.DotNet.Metadata.Tables;
+using AsmResolver.PE.DotNet.Metadata.UserStrings;
+
+namespace AsmResolver.DotNet.Code.Cil
+{
+    /// <summary>
+    /// Provides an implementation for the <see cref="IMetadataTokenProvider"/> interface that always returns the
+    /// original metadata token that was assigned to the provided metadata member or string.
+    /// </summary>
+    public class OriginalMetadataTokenProvider : IMetadataTokenProvider
+    {
+        private readonly ModuleDefinition? _module;
+
+        /// <summary>
+        /// Creates a new token provider.
+        /// </summary>
+        /// <param name="module">
+        /// The module to pull the original tokens from, or <c>null</c> if no verification should be done on the
+        /// declaring module.
+        /// </param>
+        public OriginalMetadataTokenProvider(ModuleDefinition? module)
+        {
+            _module = module;
+        }
+
+        private MetadataToken GetToken(IMetadataMember member)
+        {
+            if (_module is not null && member is IModuleProvider provider && provider.Module == _module)
+                throw new MemberNotImportedException(member);
+
+            return member.MetadataToken;
+        }
+
+        /// <inheritdoc />
+        public MetadataToken GetTypeReferenceToken(TypeReference type) => GetToken(type);
+
+        /// <inheritdoc />
+        public MetadataToken GetTypeDefinitionToken(TypeDefinition type) => GetToken(type);
+
+        /// <inheritdoc />
+        public MetadataToken GetFieldDefinitionToken(FieldDefinition field) => GetToken(field);
+
+        /// <inheritdoc />
+        public MetadataToken GetMethodDefinitionToken(MethodDefinition method) => GetToken(method);
+
+        /// <inheritdoc />
+        public MetadataToken GetMemberReferenceToken(MemberReference member) => GetToken(member);
+
+        /// <inheritdoc />
+        public MetadataToken GetStandAloneSignatureToken(StandAloneSignature signature) => GetToken(signature);
+
+        /// <inheritdoc />
+        public MetadataToken GetAssemblyReferenceToken(AssemblyReference assembly) => GetToken(assembly);
+
+        /// <inheritdoc />
+        public MetadataToken GetTypeSpecificationToken(TypeSpecification type) => GetToken(type);
+
+        /// <inheritdoc />
+        public MetadataToken GetMethodSpecificationToken(MethodSpecification method) => GetToken(method);
+
+        /// <inheritdoc />
+        public uint GetUserStringIndex(string value)
+        {
+            if (_module?.DotNetDirectory?.Metadata?.TryGetStream(out UserStringsStream? stream) ?? false)
+            {
+                if (stream.TryFindStringIndex(value, out uint offset))
+                    return offset;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/AsmResolver.DotNet/Code/Native/NativeMethodBodySerializer.cs
+++ b/src/AsmResolver.DotNet/Code/Native/NativeMethodBodySerializer.cs
@@ -12,6 +12,12 @@ namespace AsmResolver.DotNet.Code.Native
         /// <inheritdoc />
         public ISegmentReference SerializeMethodBody(MethodBodySerializationContext context, MethodDefinition method)
         {
+            // We treat any non-conventional bounded method body as a plain native method body that we
+            // don't need to process further.
+            if (method.MethodBody is {Address.IsBounded: true} plainBody)
+                return plainBody.Address;
+
+            // We only support special treatment of native method bodies.
             if (method.MethodBody is not NativeMethodBody nativeMethodBody)
                 return SegmentReference.Null;
 

--- a/src/AsmResolver.PE/DotNet/Cil/CilDisassembler.cs
+++ b/src/AsmResolver.PE/DotNet/Cil/CilDisassembler.cs
@@ -162,7 +162,7 @@ namespace AsmResolver.PE.DotNet.Cil
                     return _reader.ReadInt32();
 
                 case CilOperandType.InlineBrTarget:
-                    return new CilOffsetLabel(_reader.ReadInt32() + (int) (_reader.Offset - _reader.StartOffset));
+                    return new CilOffsetLabel(_reader.ReadInt32() + (int) _reader.RelativeOffset);
 
                 case CilOperandType.ShortInlineR:
                     return _reader.ReadSingle();

--- a/test/AsmResolver.DotNet.Dynamic.Tests/DynamicMethodDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Dynamic.Tests/DynamicMethodDefinitionTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -71,6 +72,22 @@ namespace AsmResolver.DotNet.Dynamic.Tests
             {
                 module.CorLibTypeFactory.String,
             }, dynamicMethod.CilMethodBody.LocalVariables.Select(v => v.VariableType));
+        }
+
+        [Fact]
+        public void ReadDynamicMethodInitializedByDynamicILInfo()
+        {
+            var method = new DynamicMethod("Test", typeof(void), Type.EmptyTypes);
+            var info = method.GetDynamicILInfo();
+            info.SetLocalSignature(new byte[] { 0x7, 0x0 });
+            info.SetCode(new byte[] {0x2a}, 1);
+
+            var contextModule = ModuleDefinition.FromFile(typeof(DynamicMethodDefinitionTest).Assembly.Location);
+            var definition = new DynamicMethodDefinition(contextModule, method);
+
+            Assert.NotNull(definition.CilMethodBody);
+            var instruction = Assert.Single(definition.CilMethodBody.Instructions);
+            Assert.Equal(CilOpCodes.Ret, instruction.OpCode);
         }
     }
 }


### PR DESCRIPTION
Includes:
- Individual components in a CIL body are now read (and error handled) separately.
- `CilMethodBody.FromReader` now uses the reader context's error listener to report parser errors.
- Bugfix: `CilMaxStackCalculator` now respects raw branch operand deltas.
- Bugfix: `CilOperandBuilder` now supports writing the raw string metadata tokens produced by `CilDisassembler` if it wasn't resolved before.
- Bugfix: `DynamicMethodDefinition` now correctly pulls code from underlying `DynamicILInfo` object if necessary.
- Add `OriginalMetadataTokenProvider` class.