### PR TITLE
Better DynamicILInfo support

### DIFF
--- a/src/AsmResolver.DotNet.Dynamic/DynamicMethodDefinition.cs
+++ b/src/AsmResolver.DotNet.Dynamic/DynamicMethodDefinition.cs
@@ -25,8 +25,8 @@ namespace AsmResolver.DotNet.Dynamic
         public DynamicMethodDefinition(ModuleDefinition module, object dynamicMethodObj) :
             base(new MetadataToken(TableIndex.Method, 0))
         {
-            dynamicMethodObj = DynamicMethodHelper.ResolveDynamicResolver(dynamicMethodObj);
-            var methodBase = FieldReader.ReadField<MethodBase>(dynamicMethodObj, "m_method");
+            object resolver = DynamicMethodHelper.ResolveDynamicResolver(dynamicMethodObj);
+            var methodBase = FieldReader.ReadField<MethodBase>(resolver, "m_method");
             if (methodBase is null)
             {
                 throw new ArgumentException(
@@ -37,7 +37,7 @@ namespace AsmResolver.DotNet.Dynamic
             Name = methodBase.Name;
             Attributes = (MethodAttributes)methodBase.Attributes;
             Signature = module.DefaultImporter.ImportMethodSignature(ResolveSig(methodBase, module));
-            CilMethodBody = CreateDynamicMethodBody(this, dynamicMethodObj);
+            CilMethodBody = CreateDynamicMethodBody(this, resolver);
         }
 
         private MethodSignature ResolveSig(MethodBase methodBase, ModuleDefinition module)
@@ -73,55 +73,58 @@ namespace AsmResolver.DotNet.Dynamic
                 throw new ArgumentException("Method body should reference a serialized module.");
 
             var result = new CilMethodBody(method);
-            dynamicMethodObj = DynamicMethodHelper.ResolveDynamicResolver(dynamicMethodObj);
+            object resolver = DynamicMethodHelper.ResolveDynamicResolver(dynamicMethodObj);
 
-            // Attempt to get the code field.
-            byte[]? code = FieldReader.ReadField<byte[]>(dynamicMethodObj, "m_code");
-
+            // We prefer to extract the information from DynamicILInfo if it is there, as it has more accurate info
+            // if the DynamicMethod code is not flushed yet into the resolver (e.g., it hasn't been invoked yet).
             object? dynamicILInfo = null;
+            if (FieldReader.TryReadField<MethodBase>(resolver, "m_method", out var m) && m is not null)
+                FieldReader.TryReadField(m, "m_DynamicILInfo", out dynamicILInfo);
 
-            // If it is still null, it might still be set using DynamicILInfo::SetCode.
-            // Find the code stored in the DynamicILInfo if available.
-            if (code is null
-                && FieldReader.TryReadField<MethodBase>(dynamicMethodObj, "m_method", out var methodBase)
-                && methodBase is not null
-                && FieldReader.TryReadField(methodBase, "m_DynamicILInfo", out dynamicILInfo)
-                && dynamicILInfo is not null)
+            // Extract all required information to construct the body.
+            byte[]? code;
+            object scope;
+            List<object?> tokenList;
+            byte[]? localSig;
+            byte[]? ehHeader;
+            IList<object>? ehInfos;
+
+            if (resolver.GetType().FullName != "System.Reflection.Emit.DynamicILInfo" && dynamicILInfo is { })
             {
                 code = FieldReader.ReadField<byte[]>(dynamicILInfo, "m_code");
-            }
-
-            if (code is null)
-                throw new InvalidOperationException("Dynamic method does not have a CIL code stream.");
-
-            // Get remaining fields.
-
-            object scope;
-
-            if (dynamicMethodObj.GetType().FullName != "System.Reflection.Emit.DynamicILInfo" && dynamicILInfo is { })
-            {
                 scope = FieldReader.ReadField<object>(dynamicILInfo, "m_scope")!;
+                tokenList = FieldReader.ReadField<List<object?>>(scope, "m_tokens")!;
+                localSig = FieldReader.ReadField<byte[]>(dynamicILInfo, "m_localSignature");
+                ehHeader = FieldReader.ReadField<byte[]>(dynamicILInfo, "m_exceptions");
+
+                // DynamicILInfo does not have EH info. Try recover it from the resolver.
+                ehInfos = FieldReader.ReadField<IList<object>>(resolver, "m_exceptions");
             }
             else
             {
-                scope = FieldReader.ReadField<object>(dynamicMethodObj, "m_scope")!;
+                code = FieldReader.ReadField<byte[]>(resolver, "m_code");
+                scope = FieldReader.ReadField<object>(resolver, "m_scope")!;
+                tokenList = FieldReader.ReadField<List<object?>>(scope, "m_tokens")!;
+                localSig = FieldReader.ReadField<byte[]>(resolver, "m_localSignature");
+                ehHeader = FieldReader.ReadField<byte[]>(resolver, "m_exceptionHeader");
+                ehInfos = FieldReader.ReadField<IList<object>>(resolver, "m_exceptions");
             }
 
-            var tokenList = FieldReader.ReadField<List<object?>>(scope, "m_tokens")!;
-            byte[] localSig = FieldReader.ReadField<byte[]>(dynamicMethodObj, "m_localSignature")!;
-            byte[] ehHeader = FieldReader.ReadField<byte[]>(dynamicMethodObj, "m_exceptionHeader")!;
-            var ehInfos = FieldReader.ReadField<IList<object>>(dynamicMethodObj, "m_exceptions")!;
-
-            //Local Variables
-            DynamicMethodHelper.ReadLocalVariables(result, method, localSig);
+            // Interpret local variables signatures.
+            if (localSig is not null)
+                DynamicMethodHelper.ReadLocalVariables(result, method, localSig);
 
             // Read raw instructions.
-            var reader = new BinaryStreamReader(code);
-            var disassembler = new CilDisassembler(reader, new DynamicCilOperandResolver(module, result, tokenList));
-            result.Instructions.AddRange(disassembler.ReadInstructions());
+            if (code is not null)
+            {
+                var reader = new BinaryStreamReader(code);
+                var disassembler =
+                    new CilDisassembler(reader, new DynamicCilOperandResolver(module, result, tokenList));
+                result.Instructions.AddRange(disassembler.ReadInstructions());
+            }
 
-            //Exception Handlers
-            DynamicMethodHelper.ReadReflectionExceptionHandlers(result, ehInfos, ehHeader, module.DefaultImporter);
+            // Interpret exception handler information or header.
+            DynamicMethodHelper.ReadReflectionExceptionHandlers(result, ehHeader, ehInfos, module.DefaultImporter);
 
             return result;
         }

--- a/src/AsmResolver.DotNet.Dynamic/DynamicMethodDefinition.cs
+++ b/src/AsmResolver.DotNet.Dynamic/DynamicMethodDefinition.cs
@@ -43,7 +43,7 @@ namespace AsmResolver.DotNet.Dynamic
         /// <summary>
         /// Determines whether dynamic method reading is fully supported in the current host's .NET environment.
         /// </summary>
-        public static bool IsSupported => DynamicMethodHelper.IsSupported;
+        public static bool IsSupported => DynamicTypeSignatureResolver.IsSupported;
 
         /// <inheritdoc />
         public override ModuleDefinition Module { get; }

--- a/src/AsmResolver.DotNet.Dynamic/DynamicMethodHelper.cs
+++ b/src/AsmResolver.DotNet.Dynamic/DynamicMethodHelper.cs
@@ -1,102 +1,33 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Serialized;
 using AsmResolver.DotNet.Signatures;
-using AsmResolver.DotNet.Signatures.Types;
 using AsmResolver.IO;
 using AsmResolver.PE.DotNet.Cil;
-using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
 namespace AsmResolver.DotNet.Dynamic
 {
     internal static class DynamicMethodHelper
     {
-        private static readonly MethodInfo? GetTypeFromHandleUnsafeMethod;
-
-        static DynamicMethodHelper()
-        {
-            // We need to use reflection for this to stay compatible with .netstandard 2.0.
-            GetTypeFromHandleUnsafeMethod = typeof(Type)
-                .GetMethod("GetTypeFromHandleUnsafe",
-                    (BindingFlags) (-1),
-                    null,
-                    new[] {typeof(IntPtr)},
-                    null);
-        }
-
-        [MemberNotNullWhen(true, nameof(GetTypeFromHandleUnsafeMethod))]
-        public static bool IsSupported => GetTypeFromHandleUnsafeMethod is not null;
-
         public static void ReadLocalVariables(CilMethodBody methodBody, MethodDefinition method, byte[] localSig)
         {
             if (method.Module is not SerializedModuleDefinition module)
                 throw new ArgumentException("Method body should reference a serialized module.");
 
             var reader = new BinaryStreamReader(localSig);
-            if (ReadLocalVariableSignature(new BlobReadContext(module.ReaderContext), ref reader)
-                is not { } localsSignature)
+            var context = new BlobReadContext(module.ReaderContext, DynamicTypeSignatureResolver.Instance);
+            if (CallingConventionSignature.FromReader(context, ref reader)
+                is not LocalVariablesSignature localsSignature)
             {
                 throw new ArgumentException("Invalid local variables signature.");
             }
 
             for (int i = 0; i < localsSignature.VariableTypes.Count; i++)
                 methodBody.LocalVariables.Add(new CilLocalVariable(localsSignature.VariableTypes[i]));
-        }
-
-        private static TypeSignature ReadTypeSignature(in BlobReadContext context, ref BinaryStreamReader reader)
-        {
-            return (ElementType) reader.PeekByte() == ElementType.Internal
-                ? ReadInternalTypeSignature(context, ref reader)
-                : TypeSignature.FromReader(in context, ref reader);
-        }
-
-        private static TypeSignature ReadInternalTypeSignature(in BlobReadContext context, ref BinaryStreamReader reader)
-        {
-            if (!IsSupported)
-                throw new PlatformNotSupportedException("The current platform does not support the translation of raw type handles to System.Type instances.");
-
-            // Consume INTERNAL element type.
-            reader.ReadByte();
-
-            // Read address.
-            var address = IntPtr.Size switch
-            {
-                4 => new IntPtr(reader.ReadInt32()),
-                _ => new IntPtr(reader.ReadInt64())
-            };
-
-            // Let the runtime translate the address to a type and import it.
-            var clrType = (Type?) GetTypeFromHandleUnsafeMethod.Invoke(null, new object[] { address });
-
-            var type = clrType is not null
-                ? new ReferenceImporter(context.ReaderContext.ParentModule).ImportType(clrType)
-                : InvalidTypeDefOrRef.Get(InvalidTypeSignatureError.IllegalTypeSpec);
-
-            return new TypeDefOrRefSignature(type);
-        }
-
-        private static LocalVariablesSignature ReadLocalVariableSignature(
-            in BlobReadContext context,
-            ref BinaryStreamReader reader)
-        {
-            var result = new LocalVariablesSignature();
-            result.Attributes = (CallingConventionAttributes) reader.ReadByte();
-
-            if (!reader.TryReadCompressedUInt32(out uint count))
-            {
-                context.ReaderContext.BadImage("Invalid number of local variables in local variable signature.");
-                return result;
-            }
-
-            for (int i = 0; i < count; i++)
-                result.VariableTypes.Add(ReadTypeSignature(context, ref reader));
-
-            return result;
         }
 
         public static void ReadReflectionExceptionHandlers(CilMethodBody methodBody,

--- a/src/AsmResolver.DotNet.Dynamic/DynamicMethodHelper.cs
+++ b/src/AsmResolver.DotNet.Dynamic/DynamicMethodHelper.cs
@@ -89,17 +89,22 @@ namespace AsmResolver.DotNet.Dynamic
         }
 
         public static void ReadReflectionExceptionHandlers(CilMethodBody methodBody,
-            IList<object>? ehInfos, byte[] ehHeader, ReferenceImporter importer)
+            byte[]? ehHeader, IList<object>? ehInfos, ReferenceImporter importer)
         {
-            //Sample needed!
-            if (ehHeader is { Length: > 4 })
-                throw new NotImplementedException("Exception handlers from ehHeader not supported yet.");
-
-            if (ehInfos is { Count: > 0 })
+            if (ehHeader is {Length: > 4})
+            {
+                InterpretEHSection(methodBody, importer, ehHeader);
+            }
+            else if (ehInfos is { Count: > 0 })
             {
                 foreach (var ehInfo in ehInfos)
                     InterpretEHInfo(methodBody, importer, ehInfo);
             }
+        }
+
+        private static void InterpretEHSection(CilMethodBody methodBody, ReferenceImporter importer, byte[] ehHeader)
+        {
+            throw new NotImplementedException("Raw exception data is not supported yet.");
         }
 
         private static void InterpretEHInfo(CilMethodBody methodBody, ReferenceImporter importer, object ehInfo)

--- a/src/AsmResolver.DotNet.Dynamic/DynamicTypeSignatureReader.cs
+++ b/src/AsmResolver.DotNet.Dynamic/DynamicTypeSignatureReader.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using AsmResolver.DotNet.Signatures;
+using AsmResolver.DotNet.Signatures.Types;
+
+namespace AsmResolver.DotNet.Dynamic
+{
+    /// <summary>
+    /// Provides an implementation for the <see cref="ITypeSignatureResolver"/> that resolves metadata tokens from
+    /// the underlying module's tables stream, and is able to transform addresses referencing method tables in the
+    /// current process to type signatures.
+    /// </summary>
+    public class DynamicTypeSignatureResolver : PhysicalTypeSignatureResolver
+    {
+        private static readonly MethodInfo? GetTypeFromHandleUnsafeMethod;
+
+        static DynamicTypeSignatureResolver()
+        {
+            // We need to use reflection for this to stay compatible with .netstandard 2.0.
+            GetTypeFromHandleUnsafeMethod = typeof(Type)
+                .GetMethod("GetTypeFromHandleUnsafe",
+                    (BindingFlags) (-1),
+                    null,
+                    new[] {typeof(IntPtr)},
+                    null);
+        }
+
+        /// <summary>
+        /// Gets the singleton instance of the <see cref="DynamicTypeSignatureResolver"/> class.
+        /// </summary>
+        public new static DynamicTypeSignatureResolver Instance
+        {
+            get;
+        } = new();
+
+        /// <summary>
+        /// Gets a value indicating whether dynamic resolution of method tables is supported.
+        /// </summary>
+        [MemberNotNullWhen(true, nameof(GetTypeFromHandleUnsafeMethod))]
+        public static bool IsSupported => GetTypeFromHandleUnsafeMethod is not null;
+
+        /// <inheritdoc />
+        public override TypeSignature ResolveRuntimeType(in BlobReadContext context, nint address)
+        {
+            if (!IsSupported)
+                throw new PlatformNotSupportedException("The current platform does not support the translation of raw type handles to System.Type instances.");
+
+            // Let the runtime translate the address to a type and import it.
+            var clrType = (Type?) GetTypeFromHandleUnsafeMethod.Invoke(null, new object[] { address });
+
+            var type = clrType is not null
+                ? new ReferenceImporter(context.ReaderContext.ParentModule).ImportType(clrType)
+                : InvalidTypeDefOrRef.Get(InvalidTypeSignatureError.IllegalTypeSpec);
+
+            return new TypeDefOrRefSignature(type);
+        }
+    }
+}

--- a/src/AsmResolver.DotNet/Code/Cil/OriginalMetadataTokenProvider.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/OriginalMetadataTokenProvider.cs
@@ -26,7 +26,7 @@ namespace AsmResolver.DotNet.Code.Cil
 
         private MetadataToken GetToken(IMetadataMember member)
         {
-            if (_module is not null && member is IModuleProvider provider && provider.Module == _module)
+            if (_module is not null && member is IModuleProvider provider && provider.Module != _module)
                 throw new MemberNotImportedException(member);
 
             return member.MetadataToken;

--- a/src/AsmResolver.DotNet/ReferenceImporter.cs
+++ b/src/AsmResolver.DotNet/ReferenceImporter.cs
@@ -523,7 +523,14 @@ namespace AsmResolver.DotNet
 
             var result = new MethodSignature(
                 method.IsStatic ? 0 : CallingConventionAttributes.HasThis,
-                returnType, parameterTypes);
+                returnType,
+                parameterTypes);
+
+            if (method.IsGenericMethodDefinition)
+            {
+                result.IsGeneric = true;
+                result.GenericParameterCount = method.GetGenericArguments().Length;
+            }
 
             if (method.DeclaringType == null)
                 throw new ArgumentException("Method's declaring type is null.");

--- a/src/AsmResolver.DotNet/ReferenceImporter.cs
+++ b/src/AsmResolver.DotNet/ReferenceImporter.cs
@@ -506,14 +506,26 @@ namespace AsmResolver.DotNet
             if (method is null)
                 throw new ArgumentNullException(nameof(method));
 
+            // We need to create a method spec if this method is a generic instantiation.
             if (method.IsGenericMethod && !method.IsGenericMethodDefinition)
                 return ImportGenericMethod((MethodInfo) method);
+
+            // Test whether we have a declaring type.
+            var originalDeclaringType = method.DeclaringType;
+            if (originalDeclaringType is null)
+                throw new ArgumentException("Method's declaring type is null.");
+
+            // System.Reflection substitutes all type parameters in the MethodInfo instance with their concrete
+            // arguments if the declaring type is a generic instantiation. However in metadata, we need the original
+            // parameter references. Thus, resolve the original method info first if required.
+            if (originalDeclaringType.IsGenericType && !originalDeclaringType.IsGenericTypeDefinition)
+                method = method.Module.ResolveMethod(method.MetadataToken)!;
 
             var returnType = method is MethodInfo info
                 ? ImportTypeSignature(info.ReturnType)
                 : TargetModule.CorLibTypeFactory.Void;
 
-            var parameters = method.DeclaringType is { IsConstructedGenericType: true }
+            var parameters = originalDeclaringType is { IsConstructedGenericType: true }
                 ? method.Module.ResolveMethod(method.MetadataToken)!.GetParameters()
                 : method.GetParameters();
 
@@ -532,10 +544,7 @@ namespace AsmResolver.DotNet
                 result.GenericParameterCount = method.GetGenericArguments().Length;
             }
 
-            if (method.DeclaringType == null)
-                throw new ArgumentException("Method's declaring type is null.");
-
-            return new MemberReference(ImportType(method.DeclaringType), method.Name, result);
+            return new MemberReference(ImportType(originalDeclaringType), method.Name, result);
         }
 
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Calls AsmResolver.DotNet.ReferenceImporter.ImportMethod(System.Reflection.MethodBase)")]

--- a/src/AsmResolver.DotNet/Signatures/BlobReadContext.cs
+++ b/src/AsmResolver.DotNet/Signatures/BlobReadContext.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using AsmResolver.DotNet.Serialized;
+using AsmResolver.DotNet.Signatures.Types;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
 namespace AsmResolver.DotNet.Signatures
@@ -16,7 +17,7 @@ namespace AsmResolver.DotNet.Signatures
         /// </summary>
         /// <param name="readerContext">The original read context.</param>
         public BlobReadContext(ModuleReaderContext readerContext)
-            : this(readerContext, Enumerable.Empty<MetadataToken>())
+            : this(readerContext, PhysicalTypeSignatureResolver.Instance, Enumerable.Empty<MetadataToken>())
         {
         }
 
@@ -24,10 +25,22 @@ namespace AsmResolver.DotNet.Signatures
         /// Creates a new instance of the <see cref="BlobReadContext"/> structure.
         /// </summary>
         /// <param name="readerContext">The original read context.</param>
+        /// <param name="resolver">The object responsible for resolving raw type metadata tokens and addresses.</param>
+        public BlobReadContext(ModuleReaderContext readerContext, ITypeSignatureResolver resolver)
+            : this(readerContext, resolver, Enumerable.Empty<MetadataToken>())
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="BlobReadContext"/> structure.
+        /// </summary>
+        /// <param name="readerContext">The original read context.</param>
+        /// <param name="resolver">The object responsible for resolving raw type metadata tokens and addresses.</param>
         /// <param name="traversedTokens">A collection of traversed metadata tokens.</param>
-        public BlobReadContext(ModuleReaderContext readerContext, IEnumerable<MetadataToken> traversedTokens)
+        public BlobReadContext(ModuleReaderContext readerContext, ITypeSignatureResolver resolver, IEnumerable<MetadataToken> traversedTokens)
         {
             ReaderContext = readerContext;
+            TypeSignatureResolver = resolver;
             TraversedTokens = new HashSet<MetadataToken>(traversedTokens);
         }
 
@@ -35,6 +48,14 @@ namespace AsmResolver.DotNet.Signatures
         /// Gets the module reader context.
         /// </summary>
         public ModuleReaderContext ReaderContext
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Gets the object responsible for resolving raw type metadata tokens and addresses.
+        /// </summary>
+        public ITypeSignatureResolver TypeSignatureResolver
         {
             get;
         }

--- a/src/AsmResolver.DotNet/Signatures/Types/ITypeSignatureResolver.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/ITypeSignatureResolver.cs
@@ -1,0 +1,27 @@
+using AsmResolver.PE.DotNet.Metadata.Tables;
+
+namespace AsmResolver.DotNet.Signatures.Types
+{
+    /// <summary>
+    /// Provides members for resolving raw metadata tokens and addresses to types.
+    /// </summary>
+    public interface ITypeSignatureResolver
+    {
+        /// <summary>
+        /// Resolves a metadata token to a type.
+        /// </summary>
+        /// <param name="context">The blob reading context the type is situated in.</param>
+        /// <param name="token">The token to resolve.</param>
+        /// <returns>The type.</returns>
+        ITypeDefOrRef ResolveToken(in BlobReadContext context, MetadataToken token);
+
+        /// <summary>
+        /// Resolves an address to a runtime method table to a type signature.
+        /// </summary>
+        /// <param name="context">The blob reading context the type is situated in.</param>
+        /// <param name="address">The address to resolve.</param>
+        /// <returns>The type.</returns>
+        TypeSignature ResolveRuntimeType(in BlobReadContext context, nint address);
+    }
+
+}

--- a/src/AsmResolver.DotNet/Signatures/Types/PhysicalTypeSignatureResolver.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/PhysicalTypeSignatureResolver.cs
@@ -1,0 +1,57 @@
+using System;
+using AsmResolver.PE.DotNet.Metadata.Tables;
+
+namespace AsmResolver.DotNet.Signatures.Types
+{
+    /// <summary>
+    /// Provides an implementation for the <see cref="ITypeSignatureResolver"/> that resolves metadata tokens from
+    /// the underlying module's tables stream.
+    /// </summary>
+    public class PhysicalTypeSignatureResolver : ITypeSignatureResolver
+    {
+        /// <summary>
+        /// Gets the singleton instance of the <see cref="PhysicalTypeSignatureResolver"/> class.
+        /// </summary>
+        public static PhysicalTypeSignatureResolver Instance
+        {
+            get;
+        } = new();
+
+        /// <inheritdoc />
+        public virtual ITypeDefOrRef ResolveToken(in BlobReadContext context, MetadataToken token)
+        {
+            switch (token.Table)
+            {
+                // Check for infinite recursion.
+                case TableIndex.TypeSpec when !context.TraversedTokens.Add(token):
+                    context.ReaderContext.BadImage("Infinite metadata loop was detected.");
+                    return InvalidTypeDefOrRef.Get(InvalidTypeSignatureError.MetadataLoop);
+
+                // Any other type is legal.
+                case TableIndex.TypeSpec:
+                case TableIndex.TypeDef:
+                case TableIndex.TypeRef:
+                    if (context.ReaderContext.ParentModule.TryLookupMember(token, out var member)
+                        && member is ITypeDefOrRef typeDefOrRef)
+                    {
+                        return typeDefOrRef;
+                    }
+
+                    context.ReaderContext.BadImage($"Metadata token in type signature refers to a non-existing TypeDefOrRef member {token}.");
+                    return InvalidTypeDefOrRef.Get(InvalidTypeSignatureError.InvalidCodedIndex);
+
+                default:
+                    context.ReaderContext.BadImage("Invalid coded index.");
+                    return InvalidTypeDefOrRef.Get(InvalidTypeSignatureError.InvalidCodedIndex);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual TypeSignature ResolveRuntimeType(in BlobReadContext context, nint address)
+        {
+            throw new NotSupportedException(
+                "Encountered an COR_ELEMENT_TYPE_INTERNAL type signature which is not supported by this "
+                + " type signature reader. Use the AsmResolver.DotNet.Dynamic extension package instead.");
+        }
+    }
+}

--- a/test/AsmResolver.DotNet.Dynamic.Tests/AsmResolver.DotNet.Dynamic.Tests.csproj
+++ b/test/AsmResolver.DotNet.Dynamic.Tests/AsmResolver.DotNet.Dynamic.Tests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\AsmResolver.DotNet.Dynamic\AsmResolver.DotNet.Dynamic.csproj" />
+    <ProjectReference Include="..\TestBinaries\DotNet\AsmResolver.DotNet.TestCases.Generics\AsmResolver.DotNet.TestCases.Generics.csproj" />
     <ProjectReference Include="..\TestBinaries\DotNet\AsmResolver.DotNet.TestCases.Methods\AsmResolver.DotNet.TestCases.Methods.csproj" />
   </ItemGroup>
 

--- a/test/AsmResolver.DotNet.Dynamic.Tests/DynamicMethodDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Dynamic.Tests/DynamicMethodDefinitionTest.cs
@@ -164,6 +164,7 @@ namespace AsmResolver.DotNet.Dynamic.Tests
             helper.AddArgument(typeof(int));
             helper.AddArgument(typeof(bool));
             helper.AddArgument(typeof(Stream));
+            helper.AddArgument(typeof(Stream[]));
             info.SetLocalSignature(helper.GetSignature());
 
             // Write some IL.
@@ -176,10 +177,11 @@ namespace AsmResolver.DotNet.Dynamic.Tests
             // Verify
             Assert.NotNull(definition.CilMethodBody);
             var locals = definition.CilMethodBody.LocalVariables;
-            Assert.Equal(3, locals.Count);
+            Assert.Equal(4, locals.Count);
             Assert.Equal("Int32", locals[0].VariableType.Name);
             Assert.Equal("Boolean", locals[1].VariableType.Name);
             Assert.Equal("Stream", locals[2].VariableType.Name);
+            Assert.Equal("Stream", Assert.IsAssignableFrom<SzArrayTypeSignature>(locals[3].VariableType).BaseType.Name);
         }
 
         internal static class NestedClass

--- a/test/AsmResolver.DotNet.Dynamic.Tests/DynamicMethodDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Dynamic.Tests/DynamicMethodDefinitionTest.cs
@@ -163,7 +163,7 @@ namespace AsmResolver.DotNet.Dynamic.Tests
             var helper = SignatureHelper.GetLocalVarSigHelper();
             helper.AddArgument(typeof(int));
             helper.AddArgument(typeof(bool));
-            helper.AddArgument(typeof(string));
+            helper.AddArgument(typeof(Stream));
             info.SetLocalSignature(helper.GetSignature());
 
             // Write some IL.
@@ -179,7 +179,7 @@ namespace AsmResolver.DotNet.Dynamic.Tests
             Assert.Equal(3, locals.Count);
             Assert.Equal("Int32", locals[0].VariableType.Name);
             Assert.Equal("Boolean", locals[1].VariableType.Name);
-            Assert.Equal("String", locals[2].VariableType.Name);
+            Assert.Equal("Stream", locals[2].VariableType.Name);
         }
 
         internal static class NestedClass

--- a/test/AsmResolver.DotNet.Tests/ReferenceImporterTest.cs
+++ b/test/AsmResolver.DotNet.Tests/ReferenceImporterTest.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Types;
 using AsmResolver.DotNet.TestCases.Fields;
+using AsmResolver.DotNet.TestCases.Generics;
 using AsmResolver.DotNet.TestCases.NestedClasses;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 using Xunit;
@@ -500,6 +501,35 @@ namespace AsmResolver.DotNet.Tests
 
             Assert.NotNull(resolved);
             Assert.Equal(field, Assert.IsAssignableFrom<IFieldDescriptor>(resolved), Comparer);
+        }
+
+        [Fact]
+        public void ImportGenericTypeInstantiationViaReflection()
+        {
+            var type = typeof(GenericType<int, string, Stream>);
+
+            var imported = Assert.IsAssignableFrom<TypeSpecification>(_importer.ImportType(type));
+            var signature = Assert.IsAssignableFrom<GenericInstanceTypeSignature>(imported.Signature);
+            Assert.Equal("Int32",  signature.TypeArguments[0].Name);
+            Assert.Equal("String", signature.TypeArguments[1].Name);
+            Assert.Equal("Stream", signature.TypeArguments[2].Name);
+        }
+
+        [Fact]
+        public void ImportGenericMethodInstantiationViaReflection()
+        {
+            var method = typeof(NonGenericType)
+                .GetMethod(nameof(NonGenericType.GenericMethodInNonGenericType))!
+                .MakeGenericMethod(typeof(int), typeof(string), typeof(Stream));
+
+            var imported = Assert.IsAssignableFrom<MethodSpecification>(_importer.ImportMethod(method));
+            Assert.Equal(nameof(NonGenericType.GenericMethodInNonGenericType), imported.Name);
+            Assert.NotNull(imported.Signature);
+            Assert.True(imported.Method!.Signature!.IsGeneric);
+            Assert.Equal(3, imported.Method!.Signature!.GenericParameterCount);
+            Assert.Equal("Int32", imported.Signature.TypeArguments[0].Name);
+            Assert.Equal("String", imported.Signature.TypeArguments[1].Name);
+            Assert.Equal("Stream", imported.Signature.TypeArguments[2].Name);
         }
     }
 }

--- a/test/AsmResolver.DotNet.Tests/ReferenceImporterTest.cs
+++ b/test/AsmResolver.DotNet.Tests/ReferenceImporterTest.cs
@@ -531,5 +531,18 @@ namespace AsmResolver.DotNet.Tests
             Assert.Equal("String", imported.Signature.TypeArguments[1].Name);
             Assert.Equal("Stream", imported.Signature.TypeArguments[2].Name);
         }
+
+        [Fact]
+        public void ImportGenericMethodInstantiationWithReturnTypeViaReflection()
+        {
+            var method = typeof(GenericType<int, bool, Stream>)
+                .GetMethod(nameof(GenericType<int, bool, Stream>.NonGenericMethodWithReturnType))!;
+
+            var imported = Assert.IsAssignableFrom<IMethodDescriptor>(_importer.ImportMethod(method));
+            Assert.Equal(nameof(GenericType<int, bool, Stream>.NonGenericMethodWithReturnType), imported.Name);
+            Assert.NotNull(imported.Signature);
+            var signature = Assert.IsAssignableFrom<GenericParameterSignature>(imported.Signature.ReturnType);
+            Assert.Equal(2, signature.Index);
+        }
     }
 }

--- a/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Generics/GenericType.cs
+++ b/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Generics/GenericType.cs
@@ -7,9 +7,14 @@ namespace AsmResolver.DotNet.TestCases.Generics
         public static void NonGenericMethodInGenericType()
         {
         }
-        
+
         public static void GenericMethodInGenericType<U1, U2, U3>()
         {
+        }
+
+        public static T3 NonGenericMethodWithReturnType()
+        {
+            return default;
         }
     }
 }

--- a/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Generics/NonGenericType.cs
+++ b/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Generics/NonGenericType.cs
@@ -7,7 +7,7 @@ namespace AsmResolver.DotNet.TestCases.Generics
         public static void NonGenericMethodInNonGenericType()
         {
         }
-        
+
         public static void GenericMethodInNonGenericType<U1, U2, U3>()
         {
         }
@@ -16,8 +16,14 @@ namespace AsmResolver.DotNet.TestCases.Generics
             where T1 : IFoo
             where T2 : IFoo, IBar
         {
-            
+
         }
+
+        public static T GenericMethodWithReturnType<T>()
+        {
+            return default;
+        }
+
     }
 
     public interface IFoo


### PR DESCRIPTION
Transforms the dynamic method body reader to read as much from the underlying DynamicILInfo object as possible. Covers method bodies that are initialized via `SetCode` and `SetLocalSignature`. This PR does not include raw exception handler support.