### PR TITLE
Fix docs order of instructions

### DIFF
--- a/docs/dotnet/managed-method-bodies.rst
+++ b/docs/dotnet/managed-method-bodies.rst
@@ -194,8 +194,9 @@ Below an example on how to use the ``ReferenceImporter`` to emit a call to ``Con
 .. code-block:: csharp
 
     var importer = new ReferenceImporter(targetModule);
-    var writeLine = importer.ImportMethod(typeof(Console).GetMethod("WriteLine", new[] { typeof(string) } );
+    var writeLine = importer.ImportMethod(typeof(Console).GetMethod(nameof(Console.WriteLine), new[] { typeof(string) } );
 
+    body.Instructions.Add(new CilInstruction(CilOpCodes.Ldstr, "Hello, world!"));
     body.Instructions.Add(new CilInstruction(CilOpCodes.Call, writeLine));
 
 

--- a/docs/dotnet/managed-method-bodies.rst
+++ b/docs/dotnet/managed-method-bodies.rst
@@ -194,7 +194,7 @@ Below an example on how to use the ``ReferenceImporter`` to emit a call to ``Con
 .. code-block:: csharp
 
     var importer = new ReferenceImporter(targetModule);
-    var writeLine = importer.ImportMethod(typeof(Console).GetMethod(nameof(Console.WriteLine), new[] { typeof(string) } );
+    var writeLine = importer.ImportMethod(typeof(Console).GetMethod("WriteLine", new[] { typeof(string) } );
 
     body.Instructions.Add(new CilInstruction(CilOpCodes.Ldstr, "Hello, world!"));
     body.Instructions.Add(new CilInstruction(CilOpCodes.Call, writeLine));

--- a/docs/dotnet/managed-method-bodies.rst
+++ b/docs/dotnet/managed-method-bodies.rst
@@ -194,9 +194,8 @@ Below an example on how to use the ``ReferenceImporter`` to emit a call to ``Con
 .. code-block:: csharp
 
     var importer = new ReferenceImporter(targetModule);
-    var writeLine = importer.ImportMethod(typeof(Console).GetMethod(nameof(Console.WriteLine), new[] { typeof(string) } );
+    var writeLine = importer.ImportMethod(typeof(Console).GetMethod("WriteLine", new[] { typeof(string) } );
 
-    body.Instructions.Add(new CilInstruction(CilOpCodes.Ldstr, "Hello, world!"));
     body.Instructions.Add(new CilInstruction(CilOpCodes.Call, writeLine));
 
 


### PR DESCRIPTION
[#Referencing members](https://asmresolver.readthedocs.io/en/development/dotnet/managed-method-bodies.html#referencing-members) has wrong instructions order (Console.WriteLine() without Ldstr when in Type[] it asks for string argument)