### PR TITLE
Add Parameter.CreateParameterDefinition helper method

### DIFF
--- a/src/AsmResolver.DotNet/Collections/Parameter.cs
+++ b/src/AsmResolver.DotNet/Collections/Parameter.cs
@@ -76,6 +76,11 @@ namespace AsmResolver.DotNet.Collections
         /// <inheritdoc />
         public string Name => Definition?.Name ?? GetDummyArgumentName(MethodSignatureIndex);
 
+        /// <summary>
+        /// Creates a <see cref="ParameterDefinition"/> for this parameter and adds it to the method definition if it does not exist.
+        /// </summary>
+        public void CreateParameterDefinition() => _parentCollection?.CreateParameterDefinition(this);
+
         [SuppressMessage("ReSharper", "InconsistentlySynchronizedField")]
         private static string GetDummyArgumentName(int index)
         {

--- a/src/AsmResolver.DotNet/Collections/Parameter.cs
+++ b/src/AsmResolver.DotNet/Collections/Parameter.cs
@@ -80,8 +80,12 @@ namespace AsmResolver.DotNet.Collections
         /// Creates a or returns the existing <see cref="ParameterDefinition"/> corresponding to this parameter.
         /// If a <see cref="ParameterDefinition"/> is created it is automatically added to the method definition.
         /// </summary>
-        /// <returns>The created or existing <see cref="ParameterDefinition"/> or null if this parameter is virtual.</returns>
-        public ParameterDefinition? GetOrCreateDefinition() => _parentCollection?.GetOrCreateParameterDefinition(this);
+        public ParameterDefinition GetOrCreateDefinition()
+        {
+            if (_parentCollection is null)
+                throw new InvalidOperationException("Cannot create a parameter definition for a parameter that has been removed from its parent collection.");
+            return _parentCollection.GetOrCreateParameterDefinition(this);
+        }
 
         [SuppressMessage("ReSharper", "InconsistentlySynchronizedField")]
         private static string GetDummyArgumentName(int index)

--- a/src/AsmResolver.DotNet/Collections/Parameter.cs
+++ b/src/AsmResolver.DotNet/Collections/Parameter.cs
@@ -77,9 +77,11 @@ namespace AsmResolver.DotNet.Collections
         public string Name => Definition?.Name ?? GetDummyArgumentName(MethodSignatureIndex);
 
         /// <summary>
-        /// Creates a <see cref="ParameterDefinition"/> for this parameter and adds it to the method definition if it does not exist.
+        /// Creates a or returns the existing <see cref="ParameterDefinition"/> corresponding to this parameter.
+        /// If a <see cref="ParameterDefinition"/> is created it is automatically added to the method definition.
         /// </summary>
-        public void CreateParameterDefinition() => _parentCollection?.CreateParameterDefinition(this);
+        /// <returns>The created or existing <see cref="ParameterDefinition"/> or null if this parameter is virtual.</returns>
+        public ParameterDefinition? GetOrCreateDefinition() => _parentCollection?.GetOrCreateParameterDefinition(this);
 
         [SuppressMessage("ReSharper", "InconsistentlySynchronizedField")]
         private static string GetDummyArgumentName(int index)

--- a/src/AsmResolver.DotNet/Collections/ParameterCollection.cs
+++ b/src/AsmResolver.DotNet/Collections/ParameterCollection.cs
@@ -155,7 +155,8 @@ namespace AsmResolver.DotNet.Collections
             return _owner.ParameterDefinitions.FirstOrDefault(p => p.Sequence == sequence);
         }
 
-        internal void CreateParameterDefinition(Parameter parameter) {
+        internal void CreateParameterDefinition(Parameter parameter)
+        {
             if (parameter == ThisParameter || parameter.Definition is not null)
                 return;
             _owner.ParameterDefinitions.Add(new ParameterDefinition(parameter.Sequence, Utf8String.Empty, 0));

--- a/src/AsmResolver.DotNet/Collections/ParameterCollection.cs
+++ b/src/AsmResolver.DotNet/Collections/ParameterCollection.cs
@@ -127,11 +127,24 @@ namespace AsmResolver.DotNet.Collections
 
         private TypeSignature? GetThisParameterType()
         {
-            if (_owner.DeclaringType is null)
+            var declaringType = _owner.DeclaringType;
+            if (declaringType is null)
                 return null;
 
-            var result = _owner.DeclaringType.ToTypeSignature();
-            if (_owner.DeclaringType.IsValueType)
+            TypeSignature result;
+            if (declaringType.GenericParameters.Count > 0)
+            {
+                var genArgs = new TypeSignature[declaringType.GenericParameters.Count];
+                for (int i = 0; i < genArgs.Length; i++)
+                    genArgs[i] = new GenericParameterSignature(_owner.Module, GenericParameterType.Type, i);
+                result = declaringType.MakeGenericInstanceType(genArgs);
+            }
+            else
+            {
+                result = declaringType.ToTypeSignature();
+            }
+
+            if (declaringType.IsValueType)
                 result = result.MakeByReferenceType();
 
             return result;

--- a/src/AsmResolver.DotNet/Collections/ParameterCollection.cs
+++ b/src/AsmResolver.DotNet/Collections/ParameterCollection.cs
@@ -155,11 +155,15 @@ namespace AsmResolver.DotNet.Collections
             return _owner.ParameterDefinitions.FirstOrDefault(p => p.Sequence == sequence);
         }
 
-        internal void CreateParameterDefinition(Parameter parameter)
+        internal ParameterDefinition? GetOrCreateParameterDefinition(Parameter parameter)
         {
-            if (parameter == ThisParameter || parameter.Definition is not null)
-                return;
-            _owner.ParameterDefinitions.Add(new ParameterDefinition(parameter.Sequence, Utf8String.Empty, 0));
+            if (parameter == ThisParameter)
+                return null;
+            if (parameter.Definition is not null)
+                return parameter.Definition;
+            var parameterDefinition = new ParameterDefinition(parameter.Sequence, Utf8String.Empty, 0);
+            _owner.ParameterDefinitions.Add(parameterDefinition);
+            return parameterDefinition;
         }
 
         internal void PushParameterUpdateToSignature(Parameter parameter)

--- a/src/AsmResolver.DotNet/Collections/ParameterCollection.cs
+++ b/src/AsmResolver.DotNet/Collections/ParameterCollection.cs
@@ -155,12 +155,13 @@ namespace AsmResolver.DotNet.Collections
             return _owner.ParameterDefinitions.FirstOrDefault(p => p.Sequence == sequence);
         }
 
-        internal ParameterDefinition? GetOrCreateParameterDefinition(Parameter parameter)
+        internal ParameterDefinition GetOrCreateParameterDefinition(Parameter parameter)
         {
             if (parameter == ThisParameter)
-                return null;
+                throw new InvalidOperationException("Cannot retrieve a parameter definition for the virtual this parameter.");
             if (parameter.Definition is not null)
                 return parameter.Definition;
+
             var parameterDefinition = new ParameterDefinition(parameter.Sequence, Utf8String.Empty, 0);
             _owner.ParameterDefinitions.Add(parameterDefinition);
             return parameterDefinition;

--- a/src/AsmResolver.DotNet/Collections/ParameterCollection.cs
+++ b/src/AsmResolver.DotNet/Collections/ParameterCollection.cs
@@ -142,6 +142,12 @@ namespace AsmResolver.DotNet.Collections
             return _owner.ParameterDefinitions.FirstOrDefault(p => p.Sequence == sequence);
         }
 
+        internal void CreateParameterDefinition(Parameter parameter) {
+            if (parameter == ThisParameter || parameter.Definition is not null)
+                return;
+            _owner.ParameterDefinitions.Add(new ParameterDefinition(parameter.Sequence, Utf8String.Empty, 0));
+        }
+
         internal void PushParameterUpdateToSignature(Parameter parameter)
         {
             if (_owner.Signature is null)

--- a/src/AsmResolver.DotNet/Signatures/MethodSignatureBase.cs
+++ b/src/AsmResolver.DotNet/Signatures/MethodSignatureBase.cs
@@ -175,7 +175,7 @@ namespace AsmResolver.DotNet.Signatures
         public int GetTotalParameterCount()
         {
             int count = ParameterTypes.Count + SentinelParameterTypes.Count;
-            if (HasThis || ExplicitThis)
+            if (HasThis && !ExplicitThis)
                 count++;
             return count;
         }

--- a/src/AsmResolver.DotNet/Signatures/Types/GenericParameterSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/GenericParameterSignature.cs
@@ -26,7 +26,7 @@ namespace AsmResolver.DotNet.Signatures.Types
         /// <param name="module">The module in which this generic parameter signature resides.</param>
         /// <param name="parameterType">Indicates the parameter signature is declared by a type or a method.</param>
         /// <param name="index">The index of the referenced parameter.</param>
-        public GenericParameterSignature(ModuleDefinition module, GenericParameterType parameterType, int index)
+        public GenericParameterSignature(ModuleDefinition? module, GenericParameterType parameterType, int index)
         {
             Scope = module;
             ParameterType = parameterType;

--- a/test/AsmResolver.DotNet.Tests/Collections/ParameterCollectionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Collections/ParameterCollectionTest.cs
@@ -24,6 +24,13 @@ namespace AsmResolver.DotNet.Tests.Collections
             return type.Methods.First(m => m.Name == name);
         }
 
+        private static MethodDefinition ObtainGenericInstanceTestMethod(string name)
+        {
+            var module = ModuleDefinition.FromFile(typeof(GenericInstanceMethods<,>).Assembly.Location);
+            var type = module.TopLevelTypes.First(t => t.Name == "GenericInstanceMethods`2");
+            return type.Methods.First(m => m.Name == name);
+        }
+
         [Fact]
         public void ReadEmptyParametersFromStaticMethod()
         {
@@ -109,6 +116,18 @@ namespace AsmResolver.DotNet.Tests.Collections
 
             Assert.NotNull(method.Parameters.ThisParameter);
             Assert.Equal(nameof(InstanceMethods), method.Parameters.ThisParameter.ParameterType.Name);
+        }
+
+        [Fact]
+        public void ReadEmptyParametersFromGenericInstanceMethod()
+        {
+            var method = ObtainGenericInstanceTestMethod(nameof(GenericInstanceMethods<int, int>.InstanceParameterlessMethod));
+            Assert.Empty(method.Parameters);
+            Assert.NotNull(method.Parameters.ThisParameter);
+            var genericInstanceType = method.Parameters.ThisParameter.ParameterType as GenericInstanceTypeSignature;
+            Assert.NotNull(genericInstanceType);
+            Assert.True(genericInstanceType.TypeArguments.Count == 2);
+            Assert.Equal("GenericInstanceMethods`2", genericInstanceType.GenericType.Name);
         }
 
         [Fact]

--- a/test/AsmResolver.DotNet.Tests/Collections/ParameterCollectionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Collections/ParameterCollectionTest.cs
@@ -124,10 +124,15 @@ namespace AsmResolver.DotNet.Tests.Collections
             var method = ObtainGenericInstanceTestMethod(nameof(GenericInstanceMethods<int, int>.InstanceParameterlessMethod));
             Assert.Empty(method.Parameters);
             Assert.NotNull(method.Parameters.ThisParameter);
-            var genericInstanceType = method.Parameters.ThisParameter.ParameterType as GenericInstanceTypeSignature;
-            Assert.NotNull(genericInstanceType);
-            Assert.True(genericInstanceType.TypeArguments.Count == 2);
+            var genericInstanceType = Assert.IsAssignableFrom<GenericInstanceTypeSignature>(method.Parameters.ThisParameter.ParameterType);
             Assert.Equal("GenericInstanceMethods`2", genericInstanceType.GenericType.Name);
+            Assert.Equal(2, genericInstanceType.TypeArguments.Count);
+            Assert.All(genericInstanceType.TypeArguments, (typeArgument, i) =>
+            {
+                var genericParameterSignature = Assert.IsAssignableFrom<GenericParameterSignature>(typeArgument);
+                Assert.Equal(GenericParameterType.Type, genericParameterSignature.ParameterType);
+                Assert.Equal(i, genericParameterSignature.Index);
+            });
         }
 
         [Fact]

--- a/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Methods/GenericInstanceMethods.cs
+++ b/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Methods/GenericInstanceMethods.cs
@@ -1,0 +1,9 @@
+﻿namespace AsmResolver.DotNet.TestCases.Methods
+{
+    public class GenericInstanceMethods<T, U>
+    {
+        public void InstanceParameterlessMethod()
+        {
+        }
+    }
+}


### PR DESCRIPTION
Changes:
* Added a new method to `Parameter` to make the creation of `ParameterDefinition` objects easier
* Don't use unbound generic types in virtual hidden this parameter.
* Fixed a bug that resulted in incorrect parameter count calculation for signatures with `ExplicitThis` flag set to true.