### PR TITLE
TypeSignature Compatibility and Assignability Rules

### DIFF
--- a/docs/dotnet/type-signatures.rst
+++ b/docs/dotnet/type-signatures.rst
@@ -274,7 +274,7 @@ These rules are implemented in AsmResolver using the ``IsCompatibleWith`` and ``
 
 .. code-block:: csharp
 
-    if (comparer.IsCompatibleWith(type1, type2)) 
+    if (type1.IsCompatibleWith(type2)) 
     {
         // type1 can be converted to type2.
     }
@@ -282,7 +282,7 @@ These rules are implemented in AsmResolver using the ``IsCompatibleWith`` and ``
 
 .. code-block:: csharp
 
-    if (comparer.IsAssignableTo(type1, type2)) 
+    if (type1.IsAssignableTo(type2)) 
     {
         // Values of type1 can be assigned to variables of type2.
     }

--- a/docs/dotnet/type-signatures.rst
+++ b/docs/dotnet/type-signatures.rst
@@ -219,3 +219,70 @@ Below an overview of all factory shortcut methods:
 +-------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------+
 | ``MakeGenericInstanceType(TypeSignature[] typeArguments)``        | Wraps the type in a new ``GenericInstanceTypeSignature`` with the provided type arguments.                       |
 +-------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------+
+
+
+
+Comparing Type Signatures
+-------------------------
+
+Type signatures can be tested for semantic equivalence using the ``SignatureComparer`` class. 
+Most use-cases of this class will not require any customization. 
+In these cases, the default ``SignatureComparer`` can be used:
+
+.. code-block:: csharp
+
+    var comparer = SignatureComparer.Default;
+
+
+However, if you wish to configure the comparer (e.g., for relaxing some of the declaring assembly version comparison rules), it is possible to create a new instance instead:
+
+.. code-block:: csharp
+
+    var comparer = new SignatureComparer(SignatureComparisonFlags.AllowNewerVersions);
+
+
+Once a comparer is obtained, we can test for type equality using any of the overloaded ``Equals`` methods:
+
+.. code-block:: csharp
+
+    TypeSignature type1 = ...;
+    TypeSignature type2 = ...;
+
+    if (comparer.Equals(type1, type2)) 
+    {
+        // type1 and type2 are semantically equivalent.
+    }
+
+
+The ``SignatureComparer`` class implements various instances of the ``IEqualityComparer<T>`` interface, and as such, it can be used as a comparer for dictionaries and related types:
+
+.. code-block:: csharp
+
+    var dictionary = new Dictionary<TypeSignature, TValue>(comparer);
+
+
+.. note:: 
+
+    The ``SignatureComparer`` class also implements equality comparers for other kinds of metadata, such as field and method descriptors and their signatures.
+
+
+In some cases, however, exact type equivalence is too strict of a test.
+Since .NET facilitates an object oriented environment, many types will inherit or derive from each other, making it difficult to pinpoint exactly which types we would need to compare to test whether two types are compatible with each other.  
+
+Section I.8.7 of the ECMA-335 specification defines a set of rules that dictate whether values of a certain type are compatible with or assignable to variables of another type. 
+These rules are implemented in AsmResolver using the ``IsCompatibleWith`` and ``IsAssignableTo`` methods:
+
+.. code-block:: csharp
+
+    if (comparer.IsCompatibleWith(type1, type2)) 
+    {
+        // type1 can be converted to type2.
+    }
+
+
+.. code-block:: csharp
+
+    if (comparer.IsAssignableTo(type1, type2)) 
+    {
+        // Values of type1 can be assigned to variables of type2.
+    }

--- a/src/AsmResolver.DotNet/Signatures/Types/ArrayBaseTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/ArrayBaseTypeSignature.cs
@@ -34,9 +34,9 @@ namespace AsmResolver.DotNet.Signatures.Types
         public abstract IEnumerable<ArrayDimension> GetDimensions();
 
         /// <inheritdoc />
-        protected override bool IsDirectlyCompatibleWith(TypeSignature other)
+        protected override bool IsDirectlyCompatibleWith(TypeSignature other, SignatureComparer comparer)
         {
-            if (base.IsDirectlyCompatibleWith(other))
+            if (base.IsDirectlyCompatibleWith(other, comparer))
                 return true;
 
             TypeSignature? elementType = null;
@@ -59,8 +59,8 @@ namespace AsmResolver.DotNet.Signatures.Types
             var v = BaseType.GetUnderlyingType();
             var w = elementType.GetUnderlyingType();
 
-            return SignatureComparer.Default.Equals(v.GetReducedType(), w.GetReducedType())
-                   || v.IsCompatibleWith(w);
+            return comparer.Equals(v.GetReducedType(), w.GetReducedType())
+                   || v.IsCompatibleWith(w, comparer);
         }
     }
 }

--- a/src/AsmResolver.DotNet/Signatures/Types/ArrayBaseTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/ArrayBaseTypeSignature.cs
@@ -16,6 +16,9 @@ namespace AsmResolver.DotNet.Signatures.Types
         {
         }
 
+        /// <inheritdoc />
+        public override bool IsValueType => false;
+
         /// <summary>
         /// Gets the number of dimensions this array defines.
         /// </summary>

--- a/src/AsmResolver.DotNet/Signatures/Types/ArrayBaseTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/ArrayBaseTypeSignature.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+
+namespace AsmResolver.DotNet.Signatures.Types
+{
+    /// <summary>
+    /// Represents a type signature representing an array.
+    /// </summary>
+    public abstract class ArrayBaseTypeSignature : TypeSpecificationSignature
+    {
+        /// <summary>
+        /// Initializes an array type signature.
+        /// </summary>
+        /// <param name="baseType">The element type of the array.</param>
+        protected ArrayBaseTypeSignature(TypeSignature baseType)
+            : base(baseType)
+        {
+        }
+
+        /// <summary>
+        /// Gets the number of dimensions this array defines.
+        /// </summary>
+        public abstract int Rank
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Obtains the dimensions this array defines.
+        /// </summary>
+        /// <returns>The dimensions.</returns>
+        public abstract IEnumerable<ArrayDimension> GetDimensions();
+
+        /// <inheritdoc />
+        protected override bool IsDirectlyCompatibleWith(TypeSignature other)
+        {
+            if (base.IsDirectlyCompatibleWith(other))
+                return true;
+
+            TypeSignature? elementType = null;
+            if (other is ArrayBaseTypeSignature otherArrayType && Rank == otherArrayType.Rank)
+            {
+                // Arrays are only compatible if they have the same rank.
+                elementType = otherArrayType.BaseType;
+            }
+            else if (Rank == 1
+                     && other is GenericInstanceTypeSignature genericInstanceType
+                     && genericInstanceType.GenericType.IsTypeOf("System.Collections.Generic", "IList`1"))
+            {
+                // Arrays are also compatible with IList<T> if they've only one dimension.
+                elementType = genericInstanceType.TypeArguments[0];
+            }
+
+            if (elementType is null)
+                return false;
+
+            var v = BaseType.GetUnderlyingType();
+            var w = elementType.GetUnderlyingType();
+
+            return SignatureComparer.Default.Equals(v.GetReducedType(), w.GetReducedType())
+                   || v.IsCompatibleWith(w);
+        }
+    }
+}

--- a/src/AsmResolver.DotNet/Signatures/Types/ArrayTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/ArrayTypeSignature.cs
@@ -58,9 +58,6 @@ namespace AsmResolver.DotNet.Signatures.Types
         /// <inheritdoc />
         public override string Name => $"{BaseType.Name ?? NullTypeToString}{GetDimensionsString()}";
 
-        /// <inheritdoc />
-        public override bool IsValueType => false;
-
         /// <summary>
         /// Gets a collection of dimensions.
         /// </summary>

--- a/src/AsmResolver.DotNet/Signatures/Types/ArrayTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/ArrayTypeSignature.cs
@@ -192,6 +192,12 @@ namespace AsmResolver.DotNet.Signatures.Types
         }
 
         /// <inheritdoc />
+        public override TypeSignature? GetDirectBaseClass() => Module?.CorLibTypeFactory.CorLibScope
+            .CreateTypeReference("System", "Array")
+            .ToTypeSignature(false)
+            .ImportWith(Module.DefaultImporter);
+
+        /// <inheritdoc />
         public override TResult AcceptVisitor<TResult>(ITypeSignatureVisitor<TResult> visitor) =>
             visitor.VisitArrayType(this);
 

--- a/src/AsmResolver.DotNet/Signatures/Types/ArrayTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/ArrayTypeSignature.cs
@@ -13,7 +13,7 @@ namespace AsmResolver.DotNet.Signatures.Types
     /// <remarks>
     /// For simple single-dimension arrays, use <see cref="SzArrayTypeSignature"/> instead.
     /// </remarks>
-    public class ArrayTypeSignature : TypeSpecificationSignature
+    public class ArrayTypeSignature : ArrayBaseTypeSignature
     {
         /// <summary>
         /// Creates a new array type signature.
@@ -68,6 +68,12 @@ namespace AsmResolver.DotNet.Signatures.Types
         {
             get;
         }
+
+        /// <inheritdoc />
+        public override int Rank => Dimensions.Count;
+
+        /// <inheritdoc />
+        public override IEnumerable<ArrayDimension> GetDimensions() => Dimensions;
 
         internal new static ArrayTypeSignature FromReader(ref BlobReaderContext context, ref BinaryStreamReader reader)
         {

--- a/src/AsmResolver.DotNet/Signatures/Types/ByReferenceTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/ByReferenceTypeSignature.cs
@@ -1,3 +1,4 @@
+using System;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
 namespace AsmResolver.DotNet.Signatures.Types
@@ -24,6 +25,24 @@ namespace AsmResolver.DotNet.Signatures.Types
 
         /// <inheritdoc />
         public override bool IsValueType => false;
+
+        /// <inheritdoc />
+        public override TypeSignature GetVerificationType()
+        {
+            if (Module is null)
+                throw new InvalidOperationException("Cannot determine verification type of a non-imported type.");
+
+            var factory = Module.CorLibTypeFactory;
+            return BaseType.GetReducedType().ElementType switch
+            {
+                ElementType.I1 or ElementType.Boolean => factory.SByte.MakeByReferenceType(),
+                ElementType.I2 or ElementType.Char => factory.Int16.MakeByReferenceType(),
+                ElementType.I4 => factory.Int32.MakeByReferenceType(),
+                ElementType.I8 => factory.Int64.MakeByReferenceType(),
+                ElementType.I => factory.IntPtr.MakeByReferenceType(),
+                _ => base.GetVerificationType()
+            };
+        }
 
         /// <inheritdoc />
         public override TResult AcceptVisitor<TResult>(ITypeSignatureVisitor<TResult> visitor) =>

--- a/src/AsmResolver.DotNet/Signatures/Types/CorLibTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/CorLibTypeSignature.cs
@@ -103,6 +103,49 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override ITypeDefOrRef ToTypeDefOrRef() => Type;
 
         /// <inheritdoc />
+        public override TypeSignature GetReducedType()
+        {
+            var factory = Module!.CorLibTypeFactory;
+            return ElementType switch
+            {
+                ElementType.I1 or ElementType.U1 => factory.SByte,
+                ElementType.I2 or ElementType.U2 => factory.Int16,
+                ElementType.I4 or ElementType.U4 => factory.Int32,
+                ElementType.I8 or ElementType.U8 => factory.Int64,
+                ElementType.I or ElementType.U => factory.IntPtr,
+                _ => base.GetReducedType()
+            };
+        }
+
+        /// <inheritdoc />
+        public override TypeSignature GetVerificationType()
+        {
+            var factory = Module!.CorLibTypeFactory;
+            return GetReducedType().ElementType switch
+            {
+                ElementType.I1 or ElementType.Boolean => factory.SByte,
+                ElementType.I2 or ElementType.Char => factory.Int16,
+                ElementType.I4 => factory.Int32,
+                ElementType.I8 => factory.Int64,
+                ElementType.I => factory.IntPtr,
+                _ => base.GetVerificationType()
+            };
+        }
+
+        /// <inheritdoc />
+        public override TypeSignature GetIntermediateType()
+        {
+            var factory = Module!.CorLibTypeFactory;
+            var verificationType = GetVerificationType();
+            return verificationType.ElementType switch
+            {
+                ElementType.I1 or ElementType.I2 or ElementType.I4 => factory.Int32,
+                ElementType.R4 or ElementType.R8 => factory.Double, // Technically, this is F.
+                _ => verificationType
+            };
+        }
+
+        /// <inheritdoc />
         protected override void WriteContents(in BlobSerializationContext context) =>
             context.Writer.WriteByte((byte) ElementType);
 

--- a/src/AsmResolver.DotNet/Signatures/Types/CustomModifierTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/CustomModifierTypeSignature.cs
@@ -67,6 +67,18 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override bool IsValueType => BaseType.IsValueType;
 
         /// <inheritdoc />
+        public override TypeSignature GetReducedType() => BaseType.GetReducedType();
+
+        /// <inheritdoc />
+        public override TypeSignature GetVerificationType() => BaseType.GetVerificationType();
+
+        /// <inheritdoc />
+        public override TypeSignature GetIntermediateType() => BaseType.GetIntermediateType();
+
+        /// <inheritdoc />
+        public override TypeSignature? GetDirectBaseClass() => BaseType.GetDirectBaseClass();
+
+        /// <inheritdoc />
         public override TResult AcceptVisitor<TResult>(ITypeSignatureVisitor<TResult> visitor) =>
             visitor.VisitCustomModifierType(this);
 

--- a/src/AsmResolver.DotNet/Signatures/Types/CustomModifierTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/CustomModifierTypeSignature.cs
@@ -79,6 +79,9 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override TypeSignature? GetDirectBaseClass() => BaseType.GetDirectBaseClass();
 
         /// <inheritdoc />
+        public override TypeSignature StripModifiers() => BaseType.StripModifiers();
+
+        /// <inheritdoc />
         public override TResult AcceptVisitor<TResult>(ITypeSignatureVisitor<TResult> visitor) =>
             visitor.VisitCustomModifierType(this);
 

--- a/src/AsmResolver.DotNet/Signatures/Types/FunctionPointerTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/FunctionPointerTypeSignature.cs
@@ -52,22 +52,22 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override bool IsImportedInModule(ModuleDefinition module) => Signature.IsImportedInModule(module);
 
         /// <inheritdoc />
-        protected override bool IsDirectlyCompatibleWith(TypeSignature other)
+        protected override bool IsDirectlyCompatibleWith(TypeSignature other, SignatureComparer comparer)
         {
-            if (base.IsDirectlyCompatibleWith(other))
+            if (base.IsDirectlyCompatibleWith(other, comparer))
                 return true;
 
             if (other is not FunctionPointerTypeSignature {Signature: { } otherSignature}
                 || Signature.GenericParameterCount != otherSignature.GenericParameterCount
                 || Signature.ParameterTypes.Count != otherSignature.ParameterTypes.Count
-                || !Signature.ReturnType.IsAssignableTo(otherSignature.ReturnType))
+                || !Signature.ReturnType.IsAssignableTo(otherSignature.ReturnType, comparer))
             {
                 return false;
             }
 
             for (int i = 0; i < Signature.ParameterTypes.Count; i++)
             {
-                if (!Signature.ParameterTypes[i].IsAssignableTo(otherSignature.ParameterTypes[i]))
+                if (!Signature.ParameterTypes[i].IsAssignableTo(otherSignature.ParameterTypes[i], comparer))
                     return false;
             }
 

--- a/src/AsmResolver.DotNet/Signatures/Types/FunctionPointerTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/FunctionPointerTypeSignature.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
 namespace AsmResolver.DotNet.Signatures.Types
@@ -51,6 +50,29 @@ namespace AsmResolver.DotNet.Signatures.Types
 
         /// <inheritdoc />
         public override bool IsImportedInModule(ModuleDefinition module) => Signature.IsImportedInModule(module);
+
+        /// <inheritdoc />
+        protected override bool IsDirectlyCompatibleWith(TypeSignature other)
+        {
+            if (base.IsDirectlyCompatibleWith(other))
+                return true;
+
+            if (other is not FunctionPointerTypeSignature {Signature: { } otherSignature}
+                || Signature.GenericParameterCount != otherSignature.GenericParameterCount
+                || Signature.ParameterTypes.Count != otherSignature.ParameterTypes.Count
+                || !Signature.ReturnType.IsAssignableTo(otherSignature.ReturnType))
+            {
+                return false;
+            }
+
+            for (int i = 0; i < Signature.ParameterTypes.Count; i++)
+            {
+                if (!Signature.ParameterTypes[i].IsAssignableTo(otherSignature.ParameterTypes[i]))
+                    return false;
+            }
+
+            return true;
+        }
 
         /// <inheritdoc />
         protected override void WriteContents(in BlobSerializationContext context)

--- a/src/AsmResolver.DotNet/Signatures/Types/GenericInstanceTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/GenericInstanceTypeSignature.cs
@@ -163,14 +163,14 @@ namespace AsmResolver.DotNet.Signatures.Types
         }
 
         /// <inheritdoc />
-        protected override bool IsDirectlyCompatibleWith(TypeSignature other)
+        protected override bool IsDirectlyCompatibleWith(TypeSignature other, SignatureComparer comparer)
         {
-            if (base.IsDirectlyCompatibleWith(other))
+            if (base.IsDirectlyCompatibleWith(other, comparer))
                 return true;
 
             if (other is not GenericInstanceTypeSignature otherGenericInstance
                 || otherGenericInstance.TypeArguments.Count != TypeArguments.Count
-                || !SignatureComparer.Default.Equals(GenericType, otherGenericInstance.GenericType))
+                || !comparer.Equals(GenericType, otherGenericInstance.GenericType))
             {
                 return false;
             }
@@ -186,11 +186,11 @@ namespace AsmResolver.DotNet.Signatures.Types
                 bool argumentIsCompatible = variance switch
                 {
                     GenericParameterAttributes.NonVariant =>
-                        SignatureComparer.Default.Equals(TypeArguments[i].StripModifiers(), otherGenericInstance.TypeArguments[i].StripModifiers()),
+                        comparer.Equals(TypeArguments[i].StripModifiers(), otherGenericInstance.TypeArguments[i].StripModifiers()),
                     GenericParameterAttributes.Covariant =>
-                        TypeArguments[i].IsCompatibleWith(otherGenericInstance.TypeArguments[i]),
+                        TypeArguments[i].IsCompatibleWith(otherGenericInstance.TypeArguments[i], comparer),
                     GenericParameterAttributes.Contravariant =>
-                        otherGenericInstance.TypeArguments[i].IsCompatibleWith(TypeArguments[i]),
+                        otherGenericInstance.TypeArguments[i].IsCompatibleWith(TypeArguments[i], comparer),
                     _ => throw new ArgumentOutOfRangeException()
                 };
 

--- a/src/AsmResolver.DotNet/Signatures/Types/GenericInstanceTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/GenericInstanceTypeSignature.cs
@@ -165,13 +165,10 @@ namespace AsmResolver.DotNet.Signatures.Types
         /// <inheritdoc />
         protected override bool IsDirectlyCompatibleWith(TypeSignature other, SignatureComparer comparer)
         {
-            return base.IsDirectlyCompatibleWith(other, comparer)
-                   || IsDirectlyClassCompatibleWith(other, comparer)
-                   || IsDirectlyInterfaceCompatibleWith(other, comparer);
-        }
+            if (base.IsDirectlyCompatibleWith(other, comparer))
+                return true;
 
-        private bool IsDirectlyClassCompatibleWith(TypeSignature other, SignatureComparer comparer)
-        {
+            // Other type must be a generic instance with the same generic base type and type argument count.
             if (other is not GenericInstanceTypeSignature otherGenericInstance
                 || otherGenericInstance.TypeArguments.Count != TypeArguments.Count
                 || !comparer.Equals(GenericType, otherGenericInstance.GenericType))
@@ -201,18 +198,8 @@ namespace AsmResolver.DotNet.Signatures.Types
                 if (!argumentIsCompatible)
                     return false;
             }
+
             return true;
-        }
-
-        private bool IsDirectlyInterfaceCompatibleWith(TypeSignature other, SignatureComparer comparer)
-        {
-            foreach (var @interface in GetDirectlyImplementedInterfaces())
-            {
-                if (@interface.IsCompatibleWith(other, comparer))
-                    return true;
-            }
-
-            return false;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/Signatures/Types/GenericInstanceTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/GenericInstanceTypeSignature.cs
@@ -165,9 +165,13 @@ namespace AsmResolver.DotNet.Signatures.Types
         /// <inheritdoc />
         protected override bool IsDirectlyCompatibleWith(TypeSignature other, SignatureComparer comparer)
         {
-            if (base.IsDirectlyCompatibleWith(other, comparer))
-                return true;
+            return base.IsDirectlyCompatibleWith(other, comparer)
+                   || IsDirectlyClassCompatibleWith(other, comparer)
+                   || IsDirectlyInterfaceCompatibleWith(other, comparer);
+        }
 
+        private bool IsDirectlyClassCompatibleWith(TypeSignature other, SignatureComparer comparer)
+        {
             if (other is not GenericInstanceTypeSignature otherGenericInstance
                 || otherGenericInstance.TypeArguments.Count != TypeArguments.Count
                 || !comparer.Equals(GenericType, otherGenericInstance.GenericType))
@@ -197,8 +201,18 @@ namespace AsmResolver.DotNet.Signatures.Types
                 if (!argumentIsCompatible)
                     return false;
             }
-
             return true;
+        }
+
+        private bool IsDirectlyInterfaceCompatibleWith(TypeSignature other, SignatureComparer comparer)
+        {
+            foreach (var @interface in GetDirectlyImplementedInterfaces())
+            {
+                if (@interface.IsCompatibleWith(other, comparer))
+                    return true;
+            }
+
+            return false;
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/Signatures/Types/PinnedTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/PinnedTypeSignature.cs
@@ -27,6 +27,18 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override bool IsValueType => BaseType.IsValueType;
 
         /// <inheritdoc />
+        public override TypeSignature GetReducedType() => BaseType.GetReducedType();
+
+        /// <inheritdoc />
+        public override TypeSignature GetVerificationType() => BaseType.GetVerificationType();
+
+        /// <inheritdoc />
+        public override TypeSignature GetIntermediateType() => BaseType.GetIntermediateType();
+
+        /// <inheritdoc />
+        public override TypeSignature? GetDirectBaseClass() => BaseType.GetDirectBaseClass();
+
+        /// <inheritdoc />
         public override TResult AcceptVisitor<TResult>(ITypeSignatureVisitor<TResult> visitor) =>
             visitor.VisitPinnedType(this);
 

--- a/src/AsmResolver.DotNet/Signatures/Types/PinnedTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/PinnedTypeSignature.cs
@@ -39,6 +39,9 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override TypeSignature? GetDirectBaseClass() => BaseType.GetDirectBaseClass();
 
         /// <inheritdoc />
+        public override TypeSignature StripModifiers() => BaseType.StripModifiers();
+
+        /// <inheritdoc />
         public override TResult AcceptVisitor<TResult>(ITypeSignatureVisitor<TResult> visitor) =>
             visitor.VisitPinnedType(this);
 

--- a/src/AsmResolver.DotNet/Signatures/Types/PointerTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/PointerTypeSignature.cs
@@ -26,6 +26,20 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override bool IsValueType => false;
 
         /// <inheritdoc />
+        protected override bool IsDirectlyCompatibleWith(TypeSignature other)
+        {
+            if (base.IsDirectlyCompatibleWith(other))
+                return true;
+
+            if (other is not PointerTypeSignature otherPointer)
+                return false;
+
+            var v = BaseType.GetVerificationType();
+            var w = otherPointer.BaseType.GetVerificationType();
+            return SignatureComparer.Default.Equals(v, w);
+        }
+
+        /// <inheritdoc />
         public override TResult AcceptVisitor<TResult>(ITypeSignatureVisitor<TResult> visitor) =>
             visitor.VisitPointerType(this);
 

--- a/src/AsmResolver.DotNet/Signatures/Types/PointerTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/PointerTypeSignature.cs
@@ -26,9 +26,9 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override bool IsValueType => false;
 
         /// <inheritdoc />
-        protected override bool IsDirectlyCompatibleWith(TypeSignature other)
+        protected override bool IsDirectlyCompatibleWith(TypeSignature other, SignatureComparer comparer)
         {
-            if (base.IsDirectlyCompatibleWith(other))
+            if (base.IsDirectlyCompatibleWith(other, comparer))
                 return true;
 
             if (other is not PointerTypeSignature otherPointer)
@@ -36,7 +36,7 @@ namespace AsmResolver.DotNet.Signatures.Types
 
             var v = BaseType.GetVerificationType();
             var w = otherPointer.BaseType.GetVerificationType();
-            return SignatureComparer.Default.Equals(v, w);
+            return comparer.Equals(v, w);
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/Signatures/Types/SzArrayTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/SzArrayTypeSignature.cs
@@ -26,6 +26,12 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override bool IsValueType => false;
 
         /// <inheritdoc />
+        public override TypeSignature? GetDirectBaseClass() => Module?.CorLibTypeFactory.CorLibScope
+            .CreateTypeReference("System", "Array")
+            .ToTypeSignature(false)
+            .ImportWith(Module.DefaultImporter);
+
+        /// <inheritdoc />
         public override TResult AcceptVisitor<TResult>(ITypeSignatureVisitor<TResult> visitor) =>
             visitor.VisitSzArrayType(this);
 

--- a/src/AsmResolver.DotNet/Signatures/Types/SzArrayTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/SzArrayTypeSignature.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
 namespace AsmResolver.DotNet.Signatures.Types
@@ -5,8 +6,10 @@ namespace AsmResolver.DotNet.Signatures.Types
     /// <summary>
     /// Represents a type signature describing a single dimension array with 0 as a lower bound.
     /// </summary>
-    public class SzArrayTypeSignature : TypeSpecificationSignature
+    public class SzArrayTypeSignature : ArrayBaseTypeSignature
     {
+        private static readonly ArrayDimension[] SzDimensions = { new() };
+
         /// <summary>
         /// Creates a new single-dimension array signature with 0 as a lower bound.
         /// </summary>
@@ -26,10 +29,17 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override bool IsValueType => false;
 
         /// <inheritdoc />
+        public override int Rank => 1;
+
+        /// <inheritdoc />
+        public override IEnumerable<ArrayDimension> GetDimensions() => SzDimensions;
+
+        /// <inheritdoc />
         public override TypeSignature? GetDirectBaseClass() => Module?.CorLibTypeFactory.CorLibScope
             .CreateTypeReference("System", "Array")
             .ToTypeSignature(false)
             .ImportWith(Module.DefaultImporter);
+
 
         /// <inheritdoc />
         public override TResult AcceptVisitor<TResult>(ITypeSignatureVisitor<TResult> visitor) =>

--- a/src/AsmResolver.DotNet/Signatures/Types/SzArrayTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/SzArrayTypeSignature.cs
@@ -26,9 +26,6 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override string Name => $"{BaseType.Name ?? NullTypeToString}[]";
 
         /// <inheritdoc />
-        public override bool IsValueType => false;
-
-        /// <inheritdoc />
         public override int Rank => 1;
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/Signatures/Types/TypeDefOrRefSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/TypeDefOrRefSignature.cs
@@ -119,15 +119,15 @@ namespace AsmResolver.DotNet.Signatures.Types
         }
 
         /// <inheritdoc />
-        protected override bool IsDirectlyCompatibleWith(TypeSignature other)
+        protected override bool IsDirectlyCompatibleWith(TypeSignature other, SignatureComparer comparer)
         {
-            if (base.IsDirectlyCompatibleWith(other))
+            if (base.IsDirectlyCompatibleWith(other, comparer))
                 return true;
             if (IsValueType)
                 return false;
 
-            return SignatureComparer.Default.Equals(GetDirectBaseClass(), other)
-                   || GetDirectlyImplementedInterfaces().Contains(other, SignatureComparer.Default);
+            return comparer.Equals(GetDirectBaseClass(), other)
+                   || GetDirectlyImplementedInterfaces().Contains(other, comparer);
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/Signatures/Types/TypeDefOrRefSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/TypeDefOrRefSignature.cs
@@ -74,6 +74,26 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override ITypeDefOrRef? GetUnderlyingTypeDefOrRef() => Type;
 
         /// <inheritdoc />
+        public override TypeSignature GetUnderlyingType()
+        {
+            var type = Type.Resolve();
+
+            if (type is {IsEnum: true})
+                return type.GetEnumUnderlyingType() ?? this;
+
+            return this;
+        }
+
+        /// <inheritdoc />
+        public override TypeSignature GetReducedType()
+        {
+            var underlyingType = GetUnderlyingType();
+            return !ReferenceEquals(underlyingType, this)
+                ? underlyingType.GetReducedType()
+                : this;
+        }
+
+        /// <inheritdoc />
         public override TypeSignature? GetDirectBaseClass()
         {
             var type = Type.Resolve();

--- a/src/AsmResolver.DotNet/Signatures/Types/TypeDefOrRefSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/TypeDefOrRefSignature.cs
@@ -74,6 +74,19 @@ namespace AsmResolver.DotNet.Signatures.Types
         public override ITypeDefOrRef? GetUnderlyingTypeDefOrRef() => Type;
 
         /// <inheritdoc />
+        public override TypeSignature? GetDirectBaseClass()
+        {
+            var type = Type.Resolve();
+            if (type is null)
+                return null;
+
+            // Interfaces have System.Object as direct base class.
+            return type.IsInterface
+                ? Module!.CorLibTypeFactory.Object
+                : type.BaseType!.ToTypeSignature(false);
+        }
+
+        /// <inheritdoc />
         public override TResult AcceptVisitor<TResult>(ITypeSignatureVisitor<TResult> visitor) =>
             visitor.VisitTypeDefOrRef(this);
 

--- a/src/AsmResolver.DotNet/Signatures/Types/TypeDefOrRefSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/TypeDefOrRefSignature.cs
@@ -119,18 +119,6 @@ namespace AsmResolver.DotNet.Signatures.Types
         }
 
         /// <inheritdoc />
-        protected override bool IsDirectlyCompatibleWith(TypeSignature other, SignatureComparer comparer)
-        {
-            if (base.IsDirectlyCompatibleWith(other, comparer))
-                return true;
-            if (IsValueType)
-                return false;
-
-            return comparer.Equals(GetDirectBaseClass(), other)
-                   || GetDirectlyImplementedInterfaces().Contains(other, comparer);
-        }
-
-        /// <inheritdoc />
         public override TResult AcceptVisitor<TResult>(ITypeSignatureVisitor<TResult> visitor) =>
             visitor.VisitTypeDefOrRef(this);
 

--- a/src/AsmResolver.DotNet/Signatures/Types/TypeDefOrRefSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/TypeDefOrRefSignature.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
 namespace AsmResolver.DotNet.Signatures.Types
@@ -104,6 +106,28 @@ namespace AsmResolver.DotNet.Signatures.Types
             return type.IsInterface
                 ? Module!.CorLibTypeFactory.Object
                 : type.BaseType!.ToTypeSignature(false);
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<TypeSignature> GetDirectlyImplementedInterfaces()
+        {
+            var type = Type.Resolve();
+            if (type is null)
+                return Enumerable.Empty<TypeSignature>();
+
+            return type.Interfaces.Select(i => i.Interface!.ToTypeSignature(false));
+        }
+
+        /// <inheritdoc />
+        protected override bool IsDirectlyCompatibleWith(TypeSignature other)
+        {
+            if (base.IsDirectlyCompatibleWith(other))
+                return true;
+            if (IsValueType)
+                return false;
+
+            return SignatureComparer.Default.Equals(GetDirectBaseClass(), other)
+                   || GetDirectlyImplementedInterfaces().Contains(other, SignatureComparer.Default);
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/Signatures/Types/TypeDefOrRefSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/TypeDefOrRefSignature.cs
@@ -105,7 +105,7 @@ namespace AsmResolver.DotNet.Signatures.Types
             // Interfaces have System.Object as direct base class.
             return type.IsInterface
                 ? Module!.CorLibTypeFactory.Object
-                : type.BaseType!.ToTypeSignature(false);
+                : type.BaseType!.ToTypeSignature(false).StripModifiers();
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/Signatures/Types/TypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/TypeSignature.cs
@@ -310,7 +310,23 @@ namespace AsmResolver.DotNet.Signatures.Types
         /// Gets the underlying base type signature, without any extra adornments.
         /// </summary>
         /// <returns>The base signature.</returns>
+        /// <remarks>
+        /// This is not to be confused with <see cref="GetUnderlyingType"/>, which may resolve enum types to their
+        /// underlying type representation.
+        /// </remarks>
         public abstract ITypeDefOrRef? GetUnderlyingTypeDefOrRef();
+
+        /// <summary>
+        /// Obtains the underlying type of the type signature.
+        /// </summary>
+        /// <returns>The underlying type.</returns>
+        /// <remarks>
+        /// This method computes the underlying type as per ECMA-335 I.8.7, and may therefore attempt to resolve
+        /// assemblies to determine whether the type is an enum or not. It should not be confused with
+        /// <see cref="GetUnderlyingTypeDefOrRef"/>, which merely obtains the <see cref="ITypeDefOrRef"/> instance
+        /// behind the type signature.
+        /// </remarks>
+        public virtual TypeSignature GetUnderlyingType() => this;
 
         /// <summary>
         /// Obtains the reduced type of the type signature.

--- a/src/AsmResolver.DotNet/Signatures/Types/TypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/TypeSignature.cs
@@ -313,6 +313,48 @@ namespace AsmResolver.DotNet.Signatures.Types
         public abstract ITypeDefOrRef? GetUnderlyingTypeDefOrRef();
 
         /// <summary>
+        /// Obtains the reduced type of the type signature.
+        /// </summary>
+        /// <returns>The reduced type.</returns>
+        /// <remarks>
+        /// As per ECMA-335 I.8.7, the reduced type ignores the semantic differences between enumerations and the signed
+        /// and unsigned integer types; treating these types the same if they have the same number of bits.
+        /// </remarks>
+        public virtual TypeSignature GetReducedType() => this;
+
+        /// <summary>
+        /// Obtains the verification type of the type signature.
+        /// </summary>
+        /// <returns>The verification type.</returns>
+        /// <remarks>
+        /// As per ECMA-335 I.8.7, the verification type ignores the semantic differences between enumerations,
+        /// characters, booleans, the signed and unsigned integer types, and managed pointers to any of these; treating
+        /// these types the same if they have the same number of bits or point to types with the same number of bits.
+        /// </remarks>
+        public virtual TypeSignature GetVerificationType() => this;
+
+        /// <summary>
+        /// Obtains the intermediate type of the type signature.
+        /// </summary>
+        /// <returns>The intermediate type.</returns>
+        /// <remarks>
+        /// As per ECMA-335 I.8.7, intermediate types are a subset of the built-in value types can be represented on the
+        /// evaluation stack.
+        /// </remarks>
+        public virtual TypeSignature GetIntermediateType() => GetVerificationType();
+
+        /// <summary>
+        /// Obtains the direct base class of the type signature.
+        /// </summary>
+        /// <returns>The type representing the immediate base class.</returns>
+        /// <remarks>
+        /// The direct base class is computed according to the rules defined in ECMA-335 I.8.7, where interfaces
+        /// will extend <see cref="System.Object"/>, and generic base types will be instantiated with the derived
+        /// classes type arguments (if any).
+        /// </remarks>
+        public virtual TypeSignature? GetDirectBaseClass() => null;
+
+        /// <summary>
         /// Substitutes any generic type parameter in the type signature with the parameters provided by
         /// the generic context.
         /// </summary>
@@ -337,6 +379,7 @@ namespace AsmResolver.DotNet.Signatures.Types
 
         /// <inheritdoc />
         IImportable IImportable.ImportWith(ReferenceImporter importer) => ImportWith(importer);
+
 
         /// <summary>
         /// Visit the current type signature using the provided visitor.

--- a/src/AsmResolver.DotNet/Signatures/Types/TypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/TypeSignature.cs
@@ -437,9 +437,18 @@ namespace AsmResolver.DotNet.Signatures.Types
             // Achieve the transitivity rule by moving up the type hierarchy iteratively.
             while (current is not null)
             {
+                // Is the current type compatible?
                 if (current.IsDirectlyCompatibleWith(other, comparer))
                     return true;
 
+                // Are any of the interfaces compatible instead?
+                foreach (var @interface in current.GetDirectlyImplementedInterfaces())
+                {
+                    if (@interface.IsCompatibleWith(other, comparer))
+                        return true;
+                }
+
+                // If neither, move up type hierarchy.
                 current = current.GetDirectBaseClass()?.StripModifiers();
             }
 

--- a/src/AsmResolver.DotNet/Signatures/Types/TypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/TypeSignature.cs
@@ -399,14 +399,15 @@ namespace AsmResolver.DotNet.Signatures.Types
         /// Determines whether the current type is directly compatible with the provided type.
         /// </summary>
         /// <param name="other">The other type.</param>
+        /// <param name="comparer">The comparer to use for comparing type signatures.</param>
         /// <returns><c>true</c> if the types are directly compatible, <c>false</c> otherwise.</returns>
         /// <remarks>
         /// Type compatibility is determined according to the rules in ECMA-335 I.8.7.1., excluding the transitivity
         /// rule.
         /// </remarks>
-        protected virtual bool IsDirectlyCompatibleWith(TypeSignature other)
+        protected virtual bool IsDirectlyCompatibleWith(TypeSignature other, SignatureComparer comparer)
         {
-            return SignatureComparer.Default.Equals(this, other);
+            return comparer.Equals(this, other);
         }
 
         /// <summary>
@@ -417,7 +418,18 @@ namespace AsmResolver.DotNet.Signatures.Types
         /// <remarks>
         /// Type compatibility is determined according to the rules in ECMA-335 I.8.7.1.
         /// </remarks>
-        public bool IsCompatibleWith(TypeSignature other)
+        public bool IsCompatibleWith(TypeSignature other) => IsCompatibleWith(other, SignatureComparer.Default);
+
+        /// <summary>
+        /// Determines whether the current type is compatible with the provided type.
+        /// </summary>
+        /// <param name="other">The other type.</param>
+        /// <param name="comparer">The comparer to use for comparing type signatures.</param>
+        /// <returns><c>true</c> if the type is compatible with <paramref name="other" />, <c>false</c> otherwise.</returns>
+        /// <remarks>
+        /// Type compatibility is determined according to the rules in ECMA-335 I.8.7.1.
+        /// </remarks>
+        public bool IsCompatibleWith(TypeSignature other, SignatureComparer comparer)
         {
             var current = StripModifiers();
             other = other.StripModifiers();
@@ -425,7 +437,7 @@ namespace AsmResolver.DotNet.Signatures.Types
             // Achieve the transitivity rule by moving up the type hierarchy iteratively.
             while (current is not null)
             {
-                if (current.IsDirectlyCompatibleWith(other))
+                if (current.IsDirectlyCompatibleWith(other, comparer))
                     return true;
 
                 current = current.GetDirectBaseClass()?.StripModifiers();
@@ -442,19 +454,30 @@ namespace AsmResolver.DotNet.Signatures.Types
         /// <remarks>
         /// Type compatibility is determined according to the rules in ECMA-335 I.8.7.3.
         /// </remarks>
-        public bool IsAssignableTo(TypeSignature other)
+        public bool IsAssignableTo(TypeSignature other) => IsAssignableTo(other, SignatureComparer.Default);
+
+        /// <summary>
+        /// Determines whether the current type is assignable to the provided type.
+        /// </summary>
+        /// <param name="other">The other type.</param>
+        /// <param name="comparer">The comparer to use for comparing type signatures.</param>
+        /// <returns><c>true</c> if the type is assignable to <paramref name="other" />, <c>false</c> otherwise.</returns>
+        /// <remarks>
+        /// Type compatibility is determined according to the rules in ECMA-335 I.8.7.3.
+        /// </remarks>
+        public bool IsAssignableTo(TypeSignature other, SignatureComparer comparer)
         {
             var intermediateType1 = GetIntermediateType();
             var intermediateType2 = other.GetIntermediateType();
 
-            if (SignatureComparer.Default.Equals(intermediateType1, intermediateType2)
+            if (comparer.Equals(intermediateType1, intermediateType2)
                 || intermediateType1.ElementType == ElementType.I && intermediateType2.ElementType == ElementType.I4
                 || intermediateType1.ElementType == ElementType.I4 && intermediateType2.ElementType == ElementType.I)
             {
                 return true;
             }
 
-            return IsCompatibleWith(other);
+            return IsCompatibleWith(other, comparer);
         }
 
         /// <summary>

--- a/src/AsmResolver.PE.File/Headers/OptionalHeader.cs
+++ b/src/AsmResolver.PE.File/Headers/OptionalHeader.cs
@@ -399,6 +399,16 @@ namespace AsmResolver.PE.File.Headers
         /// <returns>The data directory entry.</returns>
         public DataDirectory GetDataDirectory(DataDirectoryIndex index) => DataDirectories[(int) index];
 
+        /// <summary>
+        /// Sets a data directory by its index.
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <param name="directory">The new data directory entry.</param>
+        public void SetDataDirectory(DataDirectoryIndex index, DataDirectory directory)
+        {
+            DataDirectories[(int) index] = directory;
+        }
+
         /// <inheritdoc />
         public override uint GetPhysicalSize()
         {

--- a/test/AsmResolver.DotNet.Tests/Signatures/TypeSignatureTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Signatures/TypeSignatureTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Types;
@@ -144,6 +145,16 @@ namespace AsmResolver.DotNet.Tests.Signatures
         {
             var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld);
             Assert.Equal(expected, module.CorLibTypeFactory.FromElementType(type)!.GetReducedType().ElementType);
+        }
+
+        [Theory]
+        [InlineData(typeof(Int32Enum), ElementType.I4)]
+        [InlineData(typeof(Int64Enum), ElementType.I8)]
+        public void GetReducedTypeOfEnum(Type type, ElementType expected)
+        {
+            var module = ModuleDefinition.FromFile(type.Assembly.Location);
+            var signature = module.LookupMember<TypeDefinition>(type.MetadataToken).ToTypeSignature();
+            Assert.Equal(expected, signature.GetReducedType().ElementType);
         }
 
         [Fact]

--- a/test/AsmResolver.DotNet.Tests/Signatures/TypeSignatureTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Signatures/TypeSignatureTest.cs
@@ -420,6 +420,30 @@ namespace AsmResolver.DotNet.Tests.Signatures
         }
 
         [Theory]
+        [InlineData(new[] { ElementType.I4, ElementType.I4 }, new[] { ElementType.I4, ElementType.I4, ElementType.String }, true)]
+        [InlineData(new[] { ElementType.I4, ElementType.I8 }, new[] { ElementType.I4, ElementType.I4, ElementType.String }, false)]
+        [InlineData(new[] { ElementType.I4, ElementType.I4 }, new[] { ElementType.I4, ElementType.I8, ElementType.String }, false)]
+        [InlineData(new[] { ElementType.I4, ElementType.I4 }, new[] { ElementType.I4, ElementType.I4, ElementType.Boolean }, false)]
+        public void IsCompatibleWithGenericInterface(ElementType[] typeArguments1, ElementType[] typeArguments2, bool expected)
+        {
+            var module = ModuleDefinition.FromFile(typeof(GenericInterfaceImplementation<,>).Assembly.Location);
+
+            var type1 = module.LookupMember<TypeDefinition>(typeof(GenericInterfaceImplementation<,>).MetadataToken)
+                .ToTypeSignature(false)
+                .MakeGenericInstanceType(
+                    typeArguments1.Select(x => (TypeSignature) module.CorLibTypeFactory.FromElementType(x)!).ToArray()
+                );
+
+            var type2 = module.LookupMember<TypeDefinition>(typeof(IGenericInterface<,,>).MetadataToken)
+                .ToTypeSignature(false)
+                .MakeGenericInstanceType(
+                    typeArguments2.Select(x => (TypeSignature) module.CorLibTypeFactory.FromElementType(x)!).ToArray()
+                );
+
+            Assert.Equal(expected, type1.IsCompatibleWith(type2));
+        }
+
+        [Theory]
         [InlineData(ElementType.I1, ElementType.I1, true)]
         [InlineData(ElementType.U1, ElementType.I1, true)]
         [InlineData(ElementType.I1, ElementType.U1, true)]

--- a/test/AsmResolver.DotNet.Tests/Signatures/TypeSignatureTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Signatures/TypeSignatureTest.cs
@@ -1,5 +1,8 @@
+using System.Linq;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Types;
+using AsmResolver.DotNet.TestCases.Generics;
+using AsmResolver.DotNet.TestCases.Types;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 using Xunit;
 
@@ -121,6 +124,193 @@ namespace AsmResolver.DotNet.Tests.Signatures
                     .ToTypeSignature()
                     .MakeModifierType(_dummyType, false)
                     .FullName);
+        }
+
+        [Theory]
+        [InlineData(ElementType.I, ElementType.I)]
+        [InlineData(ElementType.I1, ElementType.I1)]
+        [InlineData(ElementType.I2, ElementType.I2)]
+        [InlineData(ElementType.I4, ElementType.I4)]
+        [InlineData(ElementType.I8, ElementType.I8)]
+        [InlineData(ElementType.U, ElementType.I)]
+        [InlineData(ElementType.U1, ElementType.I1)]
+        [InlineData(ElementType.U2, ElementType.I2)]
+        [InlineData(ElementType.U4, ElementType.I4)]
+        [InlineData(ElementType.U8, ElementType.I8)]
+        [InlineData(ElementType.String, ElementType.String)]
+        [InlineData(ElementType.Boolean, ElementType.Boolean)]
+        [InlineData(ElementType.Char, ElementType.Char)]
+        public void GetReducedTypeOfPrimitive(ElementType type, ElementType expected)
+        {
+            var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld);
+            Assert.Equal(expected, module.CorLibTypeFactory.FromElementType(type)!.GetReducedType().ElementType);
+        }
+
+        [Fact]
+        public void GetReducedTypeOfNonPrimitive()
+        {
+            var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld);
+            var type = module.TopLevelTypes.First(t => t.Name == "Program").ToTypeSignature(false);
+            Assert.Equal(type, type.GetReducedType());
+        }
+
+        [Theory]
+        [InlineData(ElementType.I, ElementType.I)]
+        [InlineData(ElementType.I1, ElementType.I1)]
+        [InlineData(ElementType.I2, ElementType.I2)]
+        [InlineData(ElementType.I4, ElementType.I4)]
+        [InlineData(ElementType.I8, ElementType.I8)]
+        [InlineData(ElementType.U, ElementType.I)]
+        [InlineData(ElementType.U1, ElementType.I1)]
+        [InlineData(ElementType.U2, ElementType.I2)]
+        [InlineData(ElementType.U4, ElementType.I4)]
+        [InlineData(ElementType.U8, ElementType.I8)]
+        [InlineData(ElementType.String, ElementType.String)]
+        [InlineData(ElementType.Boolean, ElementType.I1)]
+        [InlineData(ElementType.Char, ElementType.I2)]
+        public void GetVerificationTypeOfPrimitive(ElementType type, ElementType expected)
+        {
+            var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld);
+            Assert.Equal(expected, module.CorLibTypeFactory.FromElementType(type)!.GetVerificationType().ElementType);
+        }
+
+        [Theory]
+        [InlineData(ElementType.I, ElementType.I)]
+        [InlineData(ElementType.I1, ElementType.I1)]
+        [InlineData(ElementType.I2, ElementType.I2)]
+        [InlineData(ElementType.I4, ElementType.I4)]
+        [InlineData(ElementType.I8, ElementType.I8)]
+        [InlineData(ElementType.U, ElementType.I)]
+        [InlineData(ElementType.U1, ElementType.I1)]
+        [InlineData(ElementType.U2, ElementType.I2)]
+        [InlineData(ElementType.U4, ElementType.I4)]
+        [InlineData(ElementType.U8, ElementType.I8)]
+        [InlineData(ElementType.String, ElementType.String)]
+        [InlineData(ElementType.Boolean, ElementType.I1)]
+        [InlineData(ElementType.Char, ElementType.I2)]
+        public void GetVerificationTypeOfManagedPrimitivePointer(ElementType type, ElementType expected)
+        {
+            var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld);
+            var pointerType = module.CorLibTypeFactory.FromElementType(type)!.MakeByReferenceType();
+            var actualType = Assert.IsAssignableFrom<ByReferenceTypeSignature>(pointerType.GetVerificationType());
+            Assert.Equal(expected, actualType.BaseType.ElementType);
+        }
+
+        [Fact]
+        public void GetVerificationTypeOfNonPrimitive()
+        {
+            var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld);
+            var type = module.TopLevelTypes.First(t => t.Name == "Program").ToTypeSignature(false);
+            Assert.Equal(type, type.GetVerificationType());
+        }
+
+        [Theory]
+        [InlineData(ElementType.I, ElementType.I)]
+        [InlineData(ElementType.I1, ElementType.I4)]
+        [InlineData(ElementType.I2, ElementType.I4)]
+        [InlineData(ElementType.I4, ElementType.I4)]
+        [InlineData(ElementType.I8, ElementType.I8)]
+        [InlineData(ElementType.U, ElementType.I)]
+        [InlineData(ElementType.U1, ElementType.I4)]
+        [InlineData(ElementType.U2, ElementType.I4)]
+        [InlineData(ElementType.U4, ElementType.I4)]
+        [InlineData(ElementType.U8, ElementType.I8)]
+        [InlineData(ElementType.String, ElementType.String)]
+        [InlineData(ElementType.Boolean, ElementType.I4)]
+        [InlineData(ElementType.Char, ElementType.I4)]
+        [InlineData(ElementType.R4, ElementType.R8)] // Technically incorrect, as it should be F.
+        [InlineData(ElementType.R8, ElementType.R8)]
+        public void GetIntermediateTypeOfPrimitive(ElementType type, ElementType expected)
+        {
+            var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld);
+            Assert.Equal(expected, module.CorLibTypeFactory.FromElementType(type)!.GetIntermediateType().ElementType);
+        }
+
+        [Fact]
+        public void GetIntermediateTypeOfNonPrimitive()
+        {
+            var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld);
+            var type = module.TopLevelTypes.First(t => t.Name == "Program").ToTypeSignature(false);
+            Assert.Equal(type, type.GetIntermediateType());
+        }
+
+        [Fact]
+        public void GetDirectBaseClassOfArrayType()
+        {
+            var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld);
+            var signature = module.CorLibTypeFactory.Object.MakeArrayType(3);
+            Assert.Equal("System.Array", signature.GetDirectBaseClass()!.FullName);
+        }
+
+        [Fact]
+        public void GetDirectBaseClassOfSzArrayType()
+        {
+            var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld);
+            var signature = module.CorLibTypeFactory.Object.MakeSzArrayType();
+            Assert.Equal("System.Array", signature.GetDirectBaseClass()!.FullName);
+        }
+
+        [Fact]
+        public void GetDirectBaseClassOfInterfaceType()
+        {
+            var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld);
+            var interfaceDefinition = new TypeDefinition("Namespace", "IName", TypeAttributes.Interface);
+            module.TopLevelTypes.Add(interfaceDefinition);
+
+            var interfaceSignature = interfaceDefinition.ToTypeSignature(false);
+
+            Assert.Equal("System.Object", interfaceSignature.GetDirectBaseClass()!.FullName);
+        }
+
+        [Fact]
+        public void GetDirectBaseClassOfNormalType()
+        {
+            var module = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld);
+            var type = module.TopLevelTypes.First(t => t.Name == "Program").ToTypeSignature();
+            Assert.Equal("System.Object", type.GetDirectBaseClass()!.FullName);
+        }
+
+        [Fact]
+        public void GetDirectBaseClassOfNormalTypeWithBaseType()
+        {
+            var module = ModuleDefinition.FromFile(typeof(DerivedClass).Assembly.Location);
+            var type = module.LookupMember<TypeDefinition>(typeof(DerivedClass).MetadataToken);
+            Assert.Equal(type.BaseType!.FullName, type.ToTypeSignature().GetDirectBaseClass()!.FullName);
+        }
+
+        [Fact]
+        public void GetDirectBaseClassOfGenericTypeInstance()
+        {
+            var module = ModuleDefinition.FromFile(typeof(GenericType<,,>).Assembly.Location);
+            var genericInstanceType = module.LookupMember<TypeDefinition>(typeof(GenericType<,,>).MetadataToken)
+                .MakeGenericInstanceType(
+                    module.CorLibTypeFactory.Int32,
+                    module.CorLibTypeFactory.String,
+                    module.CorLibTypeFactory.Object);
+
+            Assert.Equal("System.Object", genericInstanceType.GetDirectBaseClass()!.FullName);
+        }
+
+        [Fact]
+        public void GetDirectBaseClassOfGenericTypeInstanceWithGenericBaseClass()
+        {
+            var module = ModuleDefinition.FromFile(typeof(GenericDerivedType<,>).Assembly.Location);
+            var genericInstanceType = module.LookupMember<TypeDefinition>(typeof(GenericDerivedType<,>).MetadataToken)
+                .MakeGenericInstanceType(
+                    module.CorLibTypeFactory.Int32,
+                    module.CorLibTypeFactory.Object);
+
+            var baseClass = Assert.IsAssignableFrom<GenericInstanceTypeSignature>(
+                genericInstanceType.GetDirectBaseClass());
+
+            Assert.Equal(typeof(GenericType<,,>).Namespace, baseClass.GenericType.Namespace);
+            Assert.Equal(typeof(GenericType<,,>).Name, baseClass.GenericType.Name);
+            Assert.Equal(new[]
+            {
+                "System.Int32",
+                "System.Object",
+                "System.String"
+            }, baseClass.TypeArguments.Select(t => t.FullName));
         }
     }
 }

--- a/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Generics/GenericDerivedType.cs
+++ b/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Generics/GenericDerivedType.cs
@@ -1,0 +1,6 @@
+namespace AsmResolver.DotNet.TestCases.Generics
+{
+    public class GenericDerivedType<U1, U2> : GenericType<U1, U2, string>
+    {
+    }
+}

--- a/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Generics/GenericInterfaceImplementation.cs
+++ b/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Generics/GenericInterfaceImplementation.cs
@@ -1,0 +1,6 @@
+namespace AsmResolver.DotNet.TestCases.Generics
+{
+    public class GenericInterfaceImplementation<T1, T2> : IGenericInterface<T1, T2, string>
+    {
+    }
+}

--- a/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Generics/IGenericInterface.cs
+++ b/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Generics/IGenericInterface.cs
@@ -1,0 +1,7 @@
+namespace AsmResolver.DotNet.TestCases.Generics
+{
+    public interface IGenericInterface<T1, T2, T3>
+    {
+
+    }
+}

--- a/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Types/Int32Enum.cs
+++ b/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Types/Int32Enum.cs
@@ -1,0 +1,9 @@
+namespace AsmResolver.DotNet.TestCases.Types
+{
+    public enum Int32Enum : int
+    {
+        Member1 = 1,
+        Member2 = 2,
+        Member3 = 3,
+    }
+}

--- a/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Types/Int64Enum.cs
+++ b/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Types/Int64Enum.cs
@@ -1,0 +1,9 @@
+namespace AsmResolver.DotNet.TestCases.Types
+{
+    public enum Int64Enum : long
+    {
+        Member1 = 1,
+        Member2 = 2,
+        Member3 = 3,
+    }
+}


### PR DESCRIPTION
Implements the type compatibility and assignability rules as defined in ECMA-335 I.8.7

Introduces:
- `TypeSignature::GetUnderlyingType()`
- `TypeSignature::GetReducedType()`
- `TypeSignature::GetVerificationType()`
- `TypeSignature::GetIntermediateType()`
- `TypeSignature::GetDirectBaseClass()`
- `TypeSignature::GetDirectlyImplementedInterfaces()`
- `TypeSignature::StripModifiers()`
- `TypeSignature::IsCompatibleWith(TypeSignature)`
- `TypeSignature::IsAssignableTo(TypeSignature)`
- `ArrayBaseTypeSignature` base class for `ArrayTypeSignature` and `SzArrayTypeSignature`.