### PR TITLE
Strongly Typed Entry Point in .NET Data Directory

### DIFF
--- a/src/AsmResolver.DotNet/Serialized/SerializedModuleDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedModuleDefinition.cs
@@ -296,8 +296,8 @@ namespace AsmResolver.DotNet.Serialized
                 return null;
             }
 
-            if (DotNetDirectory.EntryPoint != 0)
-                return LookupMember(DotNetDirectory.EntryPoint) as IManagedEntryPoint;
+            if (DotNetDirectory.EntryPoint.IsManaged)
+                return LookupMember(DotNetDirectory.EntryPoint.MetadataToken) as IManagedEntryPoint;
 
             return null;
         }

--- a/src/AsmResolver.PE.File/Headers/OptionalHeader.cs
+++ b/src/AsmResolver.PE.File/Headers/OptionalHeader.cs
@@ -399,6 +399,16 @@ namespace AsmResolver.PE.File.Headers
         /// <returns>The data directory entry.</returns>
         public DataDirectory GetDataDirectory(DataDirectoryIndex index) => DataDirectories[(int) index];
 
+        /// <summary>
+        /// Sets a data directory by its index.
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <param name="directory">The new data directory entry.</param>
+        public void SetDataDirectory(DataDirectoryIndex index, DataDirectory directory)
+        {
+            DataDirectories[(int) index] = directory;
+        }
+
         /// <inheritdoc />
         public override uint GetPhysicalSize()
         {

--- a/src/AsmResolver.PE/DotNet/DotNetDirectory.cs
+++ b/src/AsmResolver.PE/DotNet/DotNetDirectory.cs
@@ -62,7 +62,7 @@ namespace AsmResolver.PE.DotNet
         }
 
         /// <inheritdoc />
-        public uint EntryPoint
+        public DotNetEntryPoint EntryPoint
         {
             get;
             set;
@@ -127,7 +127,7 @@ namespace AsmResolver.PE.DotNet
             writer.WriteUInt16(MinorRuntimeVersion);
             CreateDataDirectoryHeader(Metadata).Write(writer);
             writer.WriteUInt32((uint) Flags);
-            writer.WriteUInt32(EntryPoint);
+            writer.WriteUInt32(EntryPoint.GetRawValue());
             CreateDataDirectoryHeader(DotNetResources).Write(writer);
             CreateDataDirectoryHeader(StrongName).Write(writer);
             CreateDataDirectoryHeader(CodeManagerTable).Write(writer);

--- a/src/AsmResolver.PE/DotNet/DotNetEntryPoint.cs
+++ b/src/AsmResolver.PE/DotNet/DotNetEntryPoint.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using AsmResolver.PE.DotNet.Metadata.Tables;
+
+namespace AsmResolver.PE.DotNet
+{
+    /// <summary>
+    /// Represents a reference to an entry point in the .NET Data Directory. This is either a metadata token to a
+    /// method or file defined in the .NET metadata tables, or a virtual address to native code located in a PE section.
+    /// </summary>
+    public readonly struct DotNetEntryPoint
+    {
+        /// <summary>
+        /// Constructs a new managed entry point reference.
+        /// </summary>
+        /// <param name="token">
+        /// The metadata token of the managed entry point. This must be either a method or a file token.
+        /// </param>
+        public DotNetEntryPoint(MetadataToken token)
+        {
+            if (token != MetadataToken.Zero && token.Table is not TableIndex.Method or TableIndex.File)
+                throw new ArgumentException("Managed entry points can only be metadata tokens referencing a method or a file.");
+
+            MetadataToken = token;
+            NativeCode = null;
+        }
+
+        /// <summary>
+        /// Constructs a new native entry point reference.
+        /// </summary>
+        /// <param name="nativeCode">A reference to the native code implementing the entry point.</param>
+        public DotNetEntryPoint(ISegmentReference nativeCode)
+        {
+            MetadataToken = MetadataToken.Zero;
+            NativeCode = nativeCode;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether an entry point is present or not.
+        /// </summary>
+        public bool IsPresent => IsManaged || IsNative;
+
+        /// <summary>
+        /// Gets a value indicating the entry point is present in the form of a metadata token.
+        /// </summary>
+        public bool IsManaged => MetadataToken != MetadataToken.Zero;
+
+        /// <summary>
+        /// Gets a value indicating the entry point is present in the form of a reference to native code.
+        /// </summary>
+        [MemberNotNullWhen(true, nameof(NativeCode))]
+        public bool IsNative => NativeCode is not null;
+
+        /// <summary>
+        /// When the entry point is managed, gets the metadata token of the method or file implementing the managed
+        /// entry point.
+        /// </summary>
+        public MetadataToken MetadataToken
+        {
+            get;
+        }
+
+        /// <summary>
+        /// When the entry point is native, gets the reference to the beginning of the native code implementing the
+        /// native entry point.
+        /// </summary>
+        public ISegmentReference? NativeCode
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Gets the raw reference value as it would be written in the .NET data directory.
+        /// </summary>
+        public uint GetRawValue() => IsNative ? NativeCode.Rva : MetadataToken.ToUInt32();
+
+        /// <summary>
+        /// Constructs a new managed entry point reference.
+        /// </summary>
+        /// <param name="token">
+        /// The metadata token of the managed entry point. This must be either a method or a file token.
+        /// </param>
+        public static implicit operator DotNetEntryPoint(MetadataToken token) => new(token);
+
+        /// <summary>
+        /// Constructs a new native entry point reference.
+        /// </summary>
+        /// <param name="nativeCode">A reference to the native code implementing the entry point.</param>
+        public static implicit operator DotNetEntryPoint(SegmentReference nativeCode) => new(nativeCode);
+
+        /// <summary>
+        /// Constructs a new managed or native entry point reference.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns>The constructed entry point reference.</returns>
+        /// <remarks>
+        /// This method is added for backwards source compatibility, and should only be used when absolutely necessary.
+        /// When the input value resembles a valid metadata token, that is, it is of the form <c>0x06XXXXXX</c> or
+        /// <c>0x26XXXXXX</c>, a managed entry point will be constructed. In any other case, the passed in integer will
+        /// be interpreted as a relative virtual address pointing to native code instead.
+        /// </remarks>
+        [Obsolete("Construct entry points via a MetadataToken or an ISegmentReference instead.")]
+        public static implicit operator DotNetEntryPoint(uint value)
+        {
+            var token = new MetadataToken(value);
+            return token.Table is TableIndex.Method or TableIndex.File
+                ? new DotNetEntryPoint(token)
+                : new DotNetEntryPoint(new VirtualAddress(value));
+        }
+
+        /// <summary>
+        /// Gets the raw reference value of a .NET entry point reference as it would be written in the .NET data directory.
+        /// </summary>
+        /// <param name="value">The entry point reference.</param>
+        /// <returns>The raw reference value.</returns>
+        public static implicit operator uint(DotNetEntryPoint value) => value.GetRawValue();
+    }
+}

--- a/src/AsmResolver.PE/DotNet/IDotNetDirectory.cs
+++ b/src/AsmResolver.PE/DotNet/IDotNetDirectory.cs
@@ -55,7 +55,7 @@ namespace AsmResolver.PE.DotNet
         /// Gets or sets the metadata token or entry point virtual address, depending on whether
         /// <see cref="DotNetDirectoryFlags.NativeEntryPoint"/> is set in <see cref="Flags" />.
         /// </summary>
-        uint EntryPoint
+        DotNetEntryPoint EntryPoint
         {
             get;
             set;

--- a/src/AsmResolver.PE/DotNet/SerializedDotNetDirectory.cs
+++ b/src/AsmResolver.PE/DotNet/SerializedDotNetDirectory.cs
@@ -1,6 +1,7 @@
 using System;
 using AsmResolver.IO;
 using AsmResolver.PE.DotNet.Metadata;
+using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Resources;
 using AsmResolver.PE.DotNet.VTableFixups;
 using AsmResolver.PE.File.Headers;
@@ -39,7 +40,11 @@ namespace AsmResolver.PE.DotNet
             MinorRuntimeVersion = reader.ReadUInt16();
             _metadataDirectory = DataDirectory.FromReader(ref reader);
             Flags = (DotNetDirectoryFlags) reader.ReadUInt32();
-            EntryPoint = reader.ReadUInt32();
+
+            EntryPoint = (Flags & DotNetDirectoryFlags.NativeEntryPoint) != 0
+                ? new DotNetEntryPoint(context.File.GetReferenceToRva(reader.ReadUInt32()))
+                : new DotNetEntryPoint(new MetadataToken(reader.ReadUInt32()));
+
             _resourcesDirectory = DataDirectory.FromReader(ref reader);
             _strongNameDirectory = DataDirectory.FromReader(ref reader);
             _codeManagerDirectory = DataDirectory.FromReader(ref reader);


### PR DESCRIPTION
Introduces `DotNetEntryPoint` DU struct that is either a `MetadataToken` or `ISegmentReference`. This should take away the need to manually set the RVA of an unmanaged entry point after calculating all offsets, making it easier to create new .NET modules that use this feature

Note: this is technically a breaking ABI change, but is mitigated with source-level implicit operators.