### PR TITLE
Repackage AppHost files

### DIFF
--- a/docs/dotnet/bundles.rst
+++ b/docs/dotnet/bundles.rst
@@ -3,7 +3,7 @@ AppHost / SingleFileHost Bundles
 
 Since the release of .NET Core 3.1, it is possible to deploy .NET assemblies as a single binary. These files are executables that do not contain a traditional .NET metadata header, and run natively on the underlying operating system via a platform-specific application host bootstrapper.
 
-AsmResolver supports extracting the embedded files from these types of binaries. Additionally, given an application host template provided by the .NET SDK, AsmResolver also supports constructing new bundles as well. All relevant code is found in the following namespace:
+AsmResolver supports extracting the embedded files from these types of binaries. Additionally, given the original file or an application host template provided by the .NET SDK, AsmResolver also supports constructing new bundles as well. All relevant code is found in the following namespace:
 
 .. code-block:: csharp
 
@@ -96,14 +96,14 @@ Constructing new bundled executable files requires a template file that AsmResol
 - ``<DOTNET-INSTALLATION-PATH>/sdk/<version>/AppHostTemplate``
 - ``<DOTNET-INSTALLATION-PATH>/packs/Microsoft.NETCore.App.Host.<runtime-identifier>/<version>/runtimes/<runtime-identifier>/native``
 
-Using this template file, it is then possible to write a new bundled executable file using ``WriteUsingTemplate``:
+Using this template file, it is then possible to write a new bundled executable file using ``WriteUsingTemplate`` and the ``BundlerParameters::FromTemplate`` method:
 
 .. code-block:: csharp
 
     BundleManifest manifest = ...
     manifest.WriteUsingTemplate(
         @"C:\Path\To\Output\File.exe",
-        new BundlerParameters(
+        BundlerParameters.FromTemplate(
             appHostTemplatePath: @"C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Host.win-x64\6.0.0\runtimes\win-x64\native\apphost.exe",
             appBinaryPath: @"HelloWorld.dll"));
 
@@ -117,12 +117,47 @@ For bundle executable files targeting Windows, it may be required to copy over s
     BundleManifest manifest = ...
     manifest.WriteUsingTemplate(
         @"C:\Path\To\Output\File.exe",
-        new BundlerParameters(
+        BundlerParameters.FromTemplate(
             appHostTemplatePath: @"C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Host.win-x64\6.0.0\runtimes\win-x64\native\apphost.exe",
             appBinaryPath: @"HelloWorld.dll",
             imagePathToCopyHeadersFrom: @"C:\Path\To\Original\HelloWorld.exe"));
 
-``BundleManifest`` also defines other ```WriteUsingTemplate`` overloads taking ``byte[]``, ``IDataSource`` or ``IPEImage`` instances instead of paths.
+
+If you do not have access to a template file (e.g., if the SDK is not installed) but have another existing PE file that was packaged in a similar fashion, it is then possible to use this file as a template instead by extracting the bundler parameters using the ``BudnlerParameters::FromExistingFile`` method. This is in particularly useful when trying to patch existing AppHost bundles. Below is a full example for patching a bundled Hello World application to let it print ``Hello, Mars!`` instead:
+
+.. code-block:: csharp
+
+    string inputPath = @"C:\Path\To\Bundled\HelloWorld.exe";
+    string outputPath = Path.ChangeExtension(inputPath, ".patched.exe");
+
+    // Read manifest and locate main embedded file.
+    var manifest = BundleManifest.FromFile(inputPath);
+    var mainFile = manifest.Files.First(f => f.RelativePath == "HelloWorld.dll");
+
+    // Read the file as a module, and patch the "Hello, World!" string with "Hello, Mars!".
+    var module = ModuleDefinition.FromBytes(mainFile.GetData());
+    module.ManagedEntryPointMethod!.CilMethodBody!
+        .Instructions.First(i => i.OpCode.Code == CilCode.Ldstr)
+        .Operand = "Hello, Mars!";
+
+    // Replace the contents of the embedded HelloWorld.dll with the new version:
+    using var moduleStream = new MemoryStream();
+    module.Write(moduleStream);
+    mainFile.Contents = new DataSegment(moduleStream.ToArray());
+    mainFile.IsCompressed = false;
+
+    // Repackage bundle using existing bundle as template.
+    manifest.WriteUsingTemplate(outputPath, BundlerParameters.FromExistingFile(
+        inputPath,
+        mainFile.RelativePath));
+
+
+.. warning::
+
+    The ``BundlerParameters.FromExistingFile`` method applies heuristics on the input file to determine the parameters for patching the input file. As heuristics are not perfect, this is not guaranteed to always work.
+
+
+``BundleManifest`` and ``BundlerParameters`` also define overloads of the ``WriteUsingTemplate`` and ``FromTemplate`` / ``FromExistingFile`` respectively, taking ``byte[]``, ``IDataSource`` or ``IPEImage`` instances instead of file paths.
 
 
 Managing Files

--- a/docs/dotnet/bundles.rst
+++ b/docs/dotnet/bundles.rst
@@ -123,14 +123,14 @@ For bundle executable files targeting Windows, it may be required to copy over s
             imagePathToCopyHeadersFrom: @"C:\Path\To\Original\HelloWorld.exe"));
 
 
-If you do not have access to a template file (e.g., if the SDK is not installed) but have another existing PE file that was packaged in a similar fashion, it is then possible to use this file as a template instead by extracting the bundler parameters using the ``BudnlerParameters::FromExistingBundle`` method. This is in particularly useful when trying to patch existing AppHost bundles. Below is a full example for patching a bundled Hello World application to let it print ``Hello, Mars!`` instead:
+If you do not have access to a template file (e.g., if the SDK is not installed) but have another existing PE file that was packaged in a similar fashion, it is then possible to use this file as a template instead by extracting the bundler parameters using the ``BundlerParameters::FromExistingBundle`` method. This is in particularly useful when trying to patch existing AppHost bundles:
 
 .. code-block:: csharp
 
     string inputPath = @"C:\Path\To\Bundled\HelloWorld.exe";
     string outputPath = Path.ChangeExtension(inputPath, ".patched.exe");
 
-    // Read manifest and locate main embedded file.
+    // Read manifest.
     var manifest = BundleManifest.FromFile(inputPath);
 
     /* ... Make changes to manifest and its files ... */ 

--- a/src/AsmResolver.DotNet/Bundles/BundlerParameters.cs
+++ b/src/AsmResolver.DotNet/Bundles/BundlerParameters.cs
@@ -1,6 +1,9 @@
+using System;
 using System.IO;
+using System.Text;
 using AsmResolver.IO;
 using AsmResolver.PE;
+using AsmResolver.PE.File;
 using AsmResolver.PE.File.Headers;
 using AsmResolver.PE.Win32Resources;
 
@@ -11,6 +14,8 @@ namespace AsmResolver.DotNet.Bundles
     /// </summary>
     public struct BundlerParameters
     {
+        private const string DefaultPathPlaceholder = "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2";
+
         /// <summary>
         /// Initializes new bundler parameters.
         /// </summary>
@@ -22,6 +27,7 @@ namespace AsmResolver.DotNet.Bundles
         /// <param name="appBinaryPath">
         /// The name of the file in the bundle that contains the entry point of the application.
         /// </param>
+        [Obsolete("Use BundlerParameters::FromTemplate instead.")]
         public BundlerParameters(string appHostTemplatePath, string appBinaryPath)
             : this(File.ReadAllBytes(appHostTemplatePath), appBinaryPath)
         {
@@ -34,6 +40,7 @@ namespace AsmResolver.DotNet.Bundles
         /// <param name="appBinaryPath">
         /// The name of the file in the bundle that contains the entry point of the application.
         /// </param>
+        [Obsolete("Use BundlerParameters::FromTemplate instead.")]
         public BundlerParameters(byte[] appHostTemplate, string appBinaryPath)
         {
             ApplicationHostTemplate = appHostTemplate;
@@ -41,6 +48,7 @@ namespace AsmResolver.DotNet.Bundles
             IsArm64Linux = false;
             Resources = null;
             SubSystem = SubSystem.WindowsCui;
+            PathPlaceholder = Encoding.UTF8.GetBytes(DefaultPathPlaceholder);
         }
 
         /// <summary>
@@ -58,6 +66,7 @@ namespace AsmResolver.DotNet.Bundles
         /// The path to copy the PE headers and Win32 resources from. This is typically the original native executable
         /// file that hosts the CLR, or the original AppHost file the bundle was extracted from.
         /// </param>
+        [Obsolete("Use BundlerParameters::FromTemplate instead.")]
         public BundlerParameters(string appHostTemplatePath, string appBinaryPath, string? imagePathToCopyHeadersFrom)
             : this(
                 File.ReadAllBytes(appHostTemplatePath),
@@ -80,6 +89,7 @@ namespace AsmResolver.DotNet.Bundles
         /// The binary to copy the PE headers and Win32 resources from. This is typically the original native executable
         /// file that hosts the CLR, or the original AppHost file the bundle was extracted from.
         /// </param>
+        [Obsolete("Use BundlerParameters::FromTemplate instead.")]
         public BundlerParameters(byte[] appHostTemplate, string appBinaryPath, byte[]? imageToCopyHeadersFrom)
             : this(
                 appHostTemplate,
@@ -102,6 +112,7 @@ namespace AsmResolver.DotNet.Bundles
         /// The binary to copy the PE headers and Win32 resources from. This is typically the original native executable
         /// file that hosts the CLR, or the original AppHost file the bundle was extracted from.
         /// </param>
+        [Obsolete("Use BundlerParameters::FromTemplate instead.")]
         public BundlerParameters(byte[] appHostTemplate, string appBinaryPath, IDataSource? imageToCopyHeadersFrom)
             : this(
                 appHostTemplate,
@@ -124,6 +135,7 @@ namespace AsmResolver.DotNet.Bundles
         /// The PE image to copy the headers and Win32 resources from. This is typically the original native executable
         /// file that hosts the CLR, or the original AppHost file the bundle was extracted from.
         /// </param>
+        [Obsolete("Use BundlerParameters::FromTemplate instead.")]
         public BundlerParameters(byte[] appHostTemplate, string appBinaryPath, IPEImage? imageToCopyHeadersFrom)
             : this(
                 appHostTemplate,
@@ -143,6 +155,7 @@ namespace AsmResolver.DotNet.Bundles
         /// </param>
         /// <param name="subSystem">The subsystem to use in the final Windows PE binary.</param>
         /// <param name="resources">The resources to copy into the final Windows PE binary.</param>
+        [Obsolete("Use BundlerParameters::FromTemplate instead.")]
         public BundlerParameters(
             byte[] appHostTemplate,
             string appBinaryPath,
@@ -154,6 +167,7 @@ namespace AsmResolver.DotNet.Bundles
             IsArm64Linux = false;
             SubSystem = subSystem;
             Resources = resources;
+            PathPlaceholder = Encoding.UTF8.GetBytes(DefaultPathPlaceholder);
         }
 
         /// <summary>
@@ -178,6 +192,16 @@ namespace AsmResolver.DotNet.Bundles
         /// Gets or sets the path to the binary within the bundle that contains the application's entry point.
         /// </summary>
         public string ApplicationBinaryPath
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the path placeholder in <see cref="ApplicationHostTemplate"/>  that will be replaced with the
+        /// contents of <see cref="ApplicationBinaryPath"/>.
+        /// </summary>
+        public byte[] PathPlaceholder
         {
             get;
             set;
@@ -216,6 +240,183 @@ namespace AsmResolver.DotNet.Bundles
         {
             get;
             set;
+        }
+
+        /// <summary>
+        /// Initializes new bundler parameters from an apphost template.
+        /// </summary>
+        /// <param name="appHostTemplatePath">
+        /// The path to the application host file template to use. By default this is stored in
+        /// <c>&lt;DOTNET-INSTALLATION-PATH&gt;/sdk/&lt;version&gt;/AppHostTemplate</c> or
+        /// <c>&lt;DOTNET-INSTALLATION-PATH&gt;/packs/Microsoft.NETCore.App.Host.&lt;runtime-identifier&gt;/&lt;version&gt;/runtimes/&lt;runtime-identifier&gt;/native</c>.
+        /// </param>
+        /// <param name="appBinaryPath">
+        /// The name of the file in the bundle that contains the entry point of the application.
+        /// </param>
+        public static BundlerParameters FromTemplate(string appHostTemplatePath, string appBinaryPath)
+        {
+            return FromTemplate(appHostTemplatePath, appBinaryPath, null);
+        }
+
+        /// <summary>
+        /// Initializes new bundler parameters from an apphost template.
+        /// </summary>
+        /// <param name="appHostTemplatePath">
+        /// The path to the application host file template to use. By default this is stored in
+        /// <c>&lt;DOTNET-INSTALLATION-PATH&gt;/sdk/&lt;version&gt;/AppHostTemplate</c> or
+        /// <c>&lt;DOTNET-INSTALLATION-PATH&gt;/packs/Microsoft.NETCore.App.Host.&lt;runtime-identifier&gt;/&lt;version&gt;/runtimes/&lt;runtime-identifier&gt;/native</c>.
+        /// </param>
+        /// <param name="appBinaryPath">
+        /// The name of the file in the bundle that contains the entry point of the application.
+        /// </param>
+        /// <param name="imagePathToCopyHeadersFrom">
+        /// The path to the binary to copy the PE headers and Win32 resources from. This is typically the original
+        /// native executable file that hosts the CLR, or the original AppHost file the bundle was extracted from.
+        /// </param>
+        public static BundlerParameters FromTemplate(string appHostTemplatePath, string appBinaryPath, string? imagePathToCopyHeadersFrom)
+        {
+            return FromTemplate(
+                File.ReadAllBytes(appHostTemplatePath),
+                appBinaryPath,
+                imagePathToCopyHeadersFrom is not null
+                    ? File.ReadAllBytes(imagePathToCopyHeadersFrom)
+                    : null);
+        }
+
+        /// <summary>
+        /// Initializes new bundler parameters from an apphost template.
+        /// </summary>
+        /// <param name="appHostTemplate">The application host template file to use.</param>
+        /// <param name="appBinaryPath">
+        /// The name of the file in the bundle that contains the entry point of the application.
+        /// </param>
+        public static BundlerParameters FromTemplate(byte[] appHostTemplate, string appBinaryPath)
+        {
+            return FromTemplate(appHostTemplate, appBinaryPath, default(PEImage?));
+        }
+
+        /// <summary>
+        /// Initializes new bundler parameters from an apphost template.
+        /// </summary>
+        /// <param name="appHostTemplate">The application host template file to use.</param>
+        /// <param name="appBinaryPath">
+        /// The name of the file in the bundle that contains the entry point of the application.
+        /// </param>
+        /// <param name="imageToCopyHeadersFrom">
+        /// The binary to copy the PE headers and Win32 resources from. This is typically the original native executable
+        /// file that hosts the CLR, or the original AppHost file the bundle was extracted from.
+        /// </param>
+        public static BundlerParameters FromTemplate(byte[] appHostTemplate, string appBinaryPath, byte[]? imageToCopyHeadersFrom)
+        {
+            var image = imageToCopyHeadersFrom is not null
+                ? PEImage.FromBytes(imageToCopyHeadersFrom)
+                : null;
+
+            return FromTemplate(appHostTemplate, appBinaryPath, image);
+        }
+
+        /// <summary>
+        /// Initializes new bundler parameters from an apphost template.
+        /// </summary>
+        /// <param name="appHostTemplate">The application host template file to use.</param>
+        /// <param name="appBinaryPath">
+        /// The name of the file in the bundle that contains the entry point of the application.
+        /// </param>
+        /// <param name="imageToCopyHeadersFrom">
+        /// The image to copy the PE headers and Win32 resources from. This is typically the original native executable
+        /// file that hosts the CLR, or the original AppHost file the bundle was extracted from.
+        /// </param>
+        public static BundlerParameters FromTemplate(byte[] appHostTemplate, string appBinaryPath, IPEImage? imageToCopyHeadersFrom)
+        {
+            return new BundlerParameters
+            {
+                ApplicationHostTemplate = appHostTemplate,
+                ApplicationBinaryPath = appBinaryPath,
+                PathPlaceholder = Encoding.UTF8.GetBytes(DefaultPathPlaceholder),
+                IsArm64Linux = false,
+                Resources = imageToCopyHeadersFrom?.Resources,
+                SubSystem = imageToCopyHeadersFrom?.SubSystem ?? SubSystem.WindowsCui,
+            };
+        }
+
+        /// <summary>
+        /// Extracts bundler parameters from an existing packaged bundled PE file.
+        /// </summary>
+        /// <param name="originalFile">The path to the original PE file.</param>
+        /// <param name="appBinaryPath">
+        /// The name of the file in the bundle that contains the entry point of the application.
+        /// </param>
+        /// <remarks>
+        /// This method uses heuristics to determine the right offsets within the existing apphost bundle file, and is
+        /// not guaranteed to always produce the right bundler parameters.
+        /// </remarks>
+        public static BundlerParameters FromExistingFile(string originalFile, string appBinaryPath)
+        {
+            return FromExistingFile(File.ReadAllBytes(originalFile), appBinaryPath, appBinaryPath);
+        }
+
+        /// <summary>
+        /// Extracts bundler parameters from an existing packaged bundled PE file.
+        /// </summary>
+        /// <param name="originalFile">The raw contents of the original PE file.</param>
+        /// <param name="appBinaryPath">
+        /// The name of the file in the bundle that contains the entry point of the application.
+        /// </param>
+        /// <remarks>
+        /// This method uses heuristics to determine the right offsets within the existing apphost bundle file, and is
+        /// not guaranteed to always produce the right bundler parameters.
+        /// </remarks>
+        public static BundlerParameters FromExistingFile(byte[] originalFile, string appBinaryPath)
+        {
+            return FromExistingFile(originalFile, appBinaryPath, appBinaryPath);
+        }
+
+        /// <summary>
+        /// Extracts bundler parameters from an existing packaged bundled PE file.
+        /// </summary>
+        /// <param name="originalFile">The raw contents of the original PE file.</param>
+        /// <param name="originalAppBinaryPath">
+        /// The original name of the file in the bundle that contains the entry point of the application.
+        /// </param>
+        /// <param name="newAppBinaryPath">
+        /// The new name of the file in the bundle that contains the entry point of the application.
+        /// </param>
+        /// <remarks>
+        /// This method uses heuristics to determine the right offsets within the existing apphost bundle file, and is
+        /// not guaranteed to always produce the right bundler parameters.
+        /// </remarks>
+        public static BundlerParameters FromExistingFile(byte[] originalFile, string originalAppBinaryPath, string newAppBinaryPath)
+        {
+            PEFile file;
+            try
+            {
+                file = PEFile.FromBytes(originalFile);
+            }
+            catch (Exception ex)
+            {
+                throw new NotSupportedException("Only valid PE files are currently supported for repackaging.", ex);
+            }
+
+            // Strip original bundle and reserialize PE file to use as template.
+            file.EofData = null;
+            using var stream = new MemoryStream();
+            file.Write(stream);
+
+            // Construct a template path to search for in the PE.
+            byte[] pathPlaceholder = new byte[32];
+            Encoding.UTF8.GetBytes(
+                originalAppBinaryPath, 0, originalAppBinaryPath.Length,
+                pathPlaceholder, 0);
+
+            return new BundlerParameters
+            {
+                ApplicationHostTemplate = stream.ToArray(),
+                ApplicationBinaryPath = newAppBinaryPath,
+                PathPlaceholder = pathPlaceholder,
+                IsArm64Linux = false,
+                Resources = PEImage.FromFile(file).Resources,
+                SubSystem = file.OptionalHeader.SubSystem,
+            };
         }
     }
 }

--- a/src/AsmResolver.DotNet/Bundles/BundlerParameters.cs
+++ b/src/AsmResolver.DotNet/Bundles/BundlerParameters.cs
@@ -366,7 +366,7 @@ namespace AsmResolver.DotNet.Bundles
         /// This method uses heuristics to determine the right offsets within the existing apphost bundle file, and is
         /// not guaranteed to always produce the right bundler parameters.
         /// </remarks>
-        public static BundlerParameters FromExistingFile(byte[] originalFile, string appBinaryPath)
+        public static BundlerParameters FromExistingBundle(byte[] originalFile, string appBinaryPath)
         {
             return FromExistingBundle(originalFile, appBinaryPath, appBinaryPath);
         }

--- a/src/AsmResolver.DotNet/Bundles/BundlerParameters.cs
+++ b/src/AsmResolver.DotNet/Bundles/BundlerParameters.cs
@@ -350,9 +350,9 @@ namespace AsmResolver.DotNet.Bundles
         /// This method uses heuristics to determine the right offsets within the existing apphost bundle file, and is
         /// not guaranteed to always produce the right bundler parameters.
         /// </remarks>
-        public static BundlerParameters FromExistingFile(string originalFile, string appBinaryPath)
+        public static BundlerParameters FromExistingBundle(string originalFile, string appBinaryPath)
         {
-            return FromExistingFile(File.ReadAllBytes(originalFile), appBinaryPath, appBinaryPath);
+            return FromExistingBundle(File.ReadAllBytes(originalFile), appBinaryPath, appBinaryPath);
         }
 
         /// <summary>
@@ -368,7 +368,7 @@ namespace AsmResolver.DotNet.Bundles
         /// </remarks>
         public static BundlerParameters FromExistingFile(byte[] originalFile, string appBinaryPath)
         {
-            return FromExistingFile(originalFile, appBinaryPath, appBinaryPath);
+            return FromExistingBundle(originalFile, appBinaryPath, appBinaryPath);
         }
 
         /// <summary>
@@ -385,7 +385,7 @@ namespace AsmResolver.DotNet.Bundles
         /// This method uses heuristics to determine the right offsets within the existing apphost bundle file, and is
         /// not guaranteed to always produce the right bundler parameters.
         /// </remarks>
-        public static BundlerParameters FromExistingFile(byte[] originalFile, string originalAppBinaryPath, string newAppBinaryPath)
+        public static BundlerParameters FromExistingBundle(byte[] originalFile, string originalAppBinaryPath, string newAppBinaryPath)
         {
             PEFile file;
             try

--- a/test/AsmResolver.DotNet.Tests/Bundles/BundleManifestTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Bundles/BundleManifestTest.cs
@@ -226,7 +226,7 @@ namespace AsmResolver.DotNet.Tests.Bundles
 
             // Repackage bundle using existing bundle as template.
             using var bundleStream = new MemoryStream();
-            manifest.WriteUsingTemplate(bundleStream, BundlerParameters.FromExistingFile(
+            manifest.WriteUsingTemplate(bundleStream, BundlerParameters.FromExistingBundle(
                 Properties.Resources.HelloWorld_SingleFile_V6,
                 mainFile.RelativePath));
 


### PR DESCRIPTION
Introduces:
- `BundlerParameters::FromTemplate`
- `BundlerParameters::FromExistingBundle`

Deprecates:
- All constructors of `BundlerParameters`

Closes #420 