### PR TITLE
Migrate to LazyVariable<TOwner, TValue> to avoid delegate closure allocation

### DIFF
--- a/src/AsmResolver.DotNet/AssemblyDefinition.cs
+++ b/src/AsmResolver.DotNet/AssemblyDefinition.cs
@@ -24,7 +24,7 @@ namespace AsmResolver.DotNet
     {
         private IList<ModuleDefinition>? _modules;
         private IList<SecurityDeclaration>? _securityDeclarations;
-        private readonly LazyVariable<byte[]?> _publicKey;
+        private readonly LazyVariable<AssemblyDefinition, byte[]?> _publicKey;
         private byte[]? _publicKeyToken;
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace AsmResolver.DotNet
         protected AssemblyDefinition(MetadataToken token)
             : base(token)
         {
-            _publicKey = new LazyVariable<byte[]?>(GetPublicKey);
+            _publicKey = new LazyVariable<AssemblyDefinition, byte[]?>(x => x.GetPublicKey());
         }
 
         /// <summary>
@@ -169,10 +169,10 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public byte[]? PublicKey
         {
-            get => _publicKey.Value;
+            get => _publicKey.GetValue(this);
             set
             {
-                _publicKey.Value = value;
+                _publicKey.SetValue(value);
                 _publicKeyToken = null;
             }
         }

--- a/src/AsmResolver.DotNet/AssemblyDescriptor.cs
+++ b/src/AsmResolver.DotNet/AssemblyDescriptor.cs
@@ -19,8 +19,8 @@ namespace AsmResolver.DotNet
     {
         private const int PublicKeyTokenLength = 8;
 
-        private readonly LazyVariable<Utf8String?> _name;
-        private readonly LazyVariable<Utf8String?> _culture;
+        private readonly LazyVariable<AssemblyDescriptor, Utf8String?> _name;
+        private readonly LazyVariable<AssemblyDescriptor, Utf8String?> _culture;
         private IList<CustomAttribute>? _customAttributes;
 
         /// <summary>
@@ -30,8 +30,8 @@ namespace AsmResolver.DotNet
         protected AssemblyDescriptor(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(GetName);
-            _culture = new LazyVariable<Utf8String?>(GetCulture);
+            _name = new LazyVariable<AssemblyDescriptor, Utf8String?>(x => x.GetName());
+            _culture = new LazyVariable<AssemblyDescriptor, Utf8String?>(x => x.GetCulture());
             Version = new Version(0, 0, 0, 0);
         }
 
@@ -43,8 +43,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Utf8String? Name
         {
-            get => _name.Value;
-            set => _name.Value = value;
+            get => _name.GetValue(this);
+            set => _name.SetValue(value);
         }
 
         string? INameProvider.Name => Name;
@@ -175,8 +175,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Utf8String? Culture
         {
-            get => _culture.Value;
-            set => _culture.Value = value;
+            get => _culture.GetValue(this);
+            set => _culture.SetValue(value);
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/AssemblyReference.cs
+++ b/src/AsmResolver.DotNet/AssemblyReference.cs
@@ -15,8 +15,8 @@ namespace AsmResolver.DotNet
         IOwnedCollectionElement<ModuleDefinition>,
         IImplementation
     {
-        private readonly LazyVariable<byte[]?> _publicKeyOrToken;
-        private readonly LazyVariable<byte[]?> _hashValue;
+        private readonly LazyVariable<AssemblyReference, byte[]?> _publicKeyOrToken;
+        private readonly LazyVariable<AssemblyReference, byte[]?> _hashValue;
         private byte[]? _publicKeyToken;
 
         /// <summary>
@@ -26,8 +26,8 @@ namespace AsmResolver.DotNet
         protected AssemblyReference(MetadataToken token)
             : base(token)
         {
-            _publicKeyOrToken = new LazyVariable<byte[]?>(GetPublicKeyOrToken);
-            _hashValue = new LazyVariable<byte[]?>(GetHashValue);
+            _publicKeyOrToken = new LazyVariable<AssemblyReference, byte[]?>(x => x.GetPublicKeyOrToken());
+            _hashValue = new LazyVariable<AssemblyReference, byte[]?>(x => x.GetHashValue());
         }
 
         /// <summary>
@@ -107,8 +107,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public byte[]? PublicKeyOrToken
         {
-            get => _publicKeyOrToken.Value;
-            set => _publicKeyOrToken.Value = value;
+            get => _publicKeyOrToken.GetValue(this);
+            set => _publicKeyOrToken.SetValue(value);
         }
 
         /// <summary>
@@ -116,8 +116,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public byte[]? HashValue
         {
-            get => _hashValue.Value;
-            set => _hashValue.Value = value;
+            get => _hashValue.GetValue(this);
+            set => _hashValue.SetValue(value);
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/Bundles/BundleFile.cs
+++ b/src/AsmResolver.DotNet/Bundles/BundleFile.cs
@@ -11,7 +11,7 @@ namespace AsmResolver.DotNet.Bundles
     /// </summary>
     public class BundleFile : IOwnedCollectionElement<BundleManifest>
     {
-        private readonly LazyVariable<ISegment> _contents;
+        private readonly LazyVariable<BundleFile, ISegment> _contents;
 
         /// <summary>
         /// Creates a new empty bundle file.
@@ -20,7 +20,7 @@ namespace AsmResolver.DotNet.Bundles
         public BundleFile(string relativePath)
         {
             RelativePath = relativePath;
-            _contents = new LazyVariable<ISegment>(GetContents);
+            _contents = new LazyVariable<BundleFile, ISegment>(x => x.GetContents());
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace AsmResolver.DotNet.Bundles
         {
             RelativePath = relativePath;
             Type = type;
-            _contents = new LazyVariable<ISegment>(contents);
+            _contents = new LazyVariable<BundleFile, ISegment>(contents);
         }
 
         /// <summary>
@@ -102,8 +102,8 @@ namespace AsmResolver.DotNet.Bundles
         /// </summary>
         public ISegment Contents
         {
-            get => _contents.Value;
-            set => _contents.Value = value;
+            get => _contents.GetValue(this);
+            set => _contents.SetValue(value);
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/ClassLayout.cs
+++ b/src/AsmResolver.DotNet/ClassLayout.cs
@@ -7,7 +7,7 @@ namespace AsmResolver.DotNet
     /// </summary>
     public class ClassLayout : MetadataMember
     {
-        private readonly LazyVariable<TypeDefinition?> _parent;
+        private readonly LazyVariable<ClassLayout, TypeDefinition?> _parent;
 
         /// <summary>
         /// Initializes the class layout with a metadata token.
@@ -16,7 +16,7 @@ namespace AsmResolver.DotNet
         protected ClassLayout(MetadataToken token)
             : base(token)
         {
-            _parent = new LazyVariable<TypeDefinition?>(GetParent);
+            _parent = new LazyVariable<ClassLayout, TypeDefinition?>(x => x.GetParent());
         }
 
         /// <summary>
@@ -58,8 +58,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public TypeDefinition? Parent
         {
-            get => _parent.Value;
-            internal set => _parent.Value = value;
+            get => _parent.GetValue(this);
+            internal set => _parent.SetValue(value);
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/Constant.cs
+++ b/src/AsmResolver.DotNet/Constant.cs
@@ -9,8 +9,8 @@ namespace AsmResolver.DotNet
     /// </summary>
     public class Constant : MetadataMember
     {
-        private readonly LazyVariable<IHasConstant?> _parent;
-        private readonly LazyVariable<DataBlobSignature?> _value;
+        private readonly LazyVariable<Constant, IHasConstant?> _parent;
+        private readonly LazyVariable<Constant, DataBlobSignature?> _value;
 
         /// <summary>
         /// Initializes the constant with a metadata token.
@@ -19,8 +19,8 @@ namespace AsmResolver.DotNet
         protected Constant(MetadataToken token)
             : base(token)
         {
-            _parent = new LazyVariable<IHasConstant?>(GetParent);
-            _value = new LazyVariable<DataBlobSignature?>(GetValue);
+            _parent = new LazyVariable<Constant, IHasConstant?>(x => x.GetParent());
+            _value = new LazyVariable<Constant, DataBlobSignature?>(x => x.GetValue());
         }
 
         /// <summary>
@@ -50,8 +50,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public IHasConstant? Parent
         {
-            get => _parent.Value;
-            internal set => _parent.Value = value;
+            get => _parent.GetValue(this);
+            internal set => _parent.SetValue(value);
         }
 
         /// <summary>
@@ -59,8 +59,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public DataBlobSignature? Value
         {
-            get => _value.Value;
-            set => _value.Value = value;
+            get => _value.GetValue(this);
+            set => _value.SetValue(value);
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/CustomAttribute.cs
+++ b/src/AsmResolver.DotNet/CustomAttribute.cs
@@ -9,9 +9,9 @@ namespace AsmResolver.DotNet
     /// </summary>
     public class CustomAttribute : MetadataMember, IOwnedCollectionElement<IHasCustomAttribute>
     {
-        private readonly LazyVariable<IHasCustomAttribute?> _parent;
-        private readonly LazyVariable<ICustomAttributeType?> _constructor;
-        private readonly LazyVariable<CustomAttributeSignature?> _signature;
+        private readonly LazyVariable<CustomAttribute, IHasCustomAttribute?> _parent;
+        private readonly LazyVariable<CustomAttribute, ICustomAttributeType?> _constructor;
+        private readonly LazyVariable<CustomAttribute, CustomAttributeSignature?> _signature;
 
         /// <summary>
         /// Initializes an empty custom attribute.
@@ -20,9 +20,9 @@ namespace AsmResolver.DotNet
         protected CustomAttribute(MetadataToken token)
             : base(token)
         {
-            _parent = new LazyVariable<IHasCustomAttribute?>(GetParent);
-            _constructor = new LazyVariable<ICustomAttributeType?>(GetConstructor);
-            _signature = new LazyVariable<CustomAttributeSignature?>(GetSignature);
+            _parent = new LazyVariable<CustomAttribute, IHasCustomAttribute?>(x => x.GetParent());
+            _constructor = new LazyVariable<CustomAttribute, ICustomAttributeType?>(x => x.GetConstructor());
+            _signature = new LazyVariable<CustomAttribute, CustomAttributeSignature?>(x => x.GetSignature());
         }
 
         /// <summary>
@@ -53,8 +53,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public IHasCustomAttribute? Parent
         {
-            get => _parent.Value;
-            private set => _parent.Value = value;
+            get => _parent.GetValue(this);
+            private set => _parent.SetValue(value);
         }
 
         IHasCustomAttribute? IOwnedCollectionElement<IHasCustomAttribute>.Owner
@@ -68,8 +68,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public ICustomAttributeType? Constructor
         {
-            get => _constructor.Value;
-            set => _constructor.Value = value;
+            get => _constructor.GetValue(this);
+            set => _constructor.SetValue(value);
         }
 
         /// <summary>
@@ -77,8 +77,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public CustomAttributeSignature? Signature
         {
-            get => _signature.Value;
-            set => _signature.Value = value;
+            get => _signature.GetValue(this);
+            set => _signature.SetValue(value);
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/EventDefinition.cs
+++ b/src/AsmResolver.DotNet/EventDefinition.cs
@@ -18,9 +18,9 @@ namespace AsmResolver.DotNet
         IHasCustomAttribute,
         IOwnedCollectionElement<TypeDefinition>
     {
-        private readonly LazyVariable<Utf8String?> _name;
-        private readonly LazyVariable<TypeDefinition?> _declaringType;
-        private readonly LazyVariable<ITypeDefOrRef?> _eventType;
+        private readonly LazyVariable<EventDefinition, Utf8String?> _name;
+        private readonly LazyVariable<EventDefinition, TypeDefinition?> _declaringType;
+        private readonly LazyVariable<EventDefinition, ITypeDefOrRef?> _eventType;
         private IList<MethodSemantics>? _semantics;
         private IList<CustomAttribute>? _customAttributes;
 
@@ -31,9 +31,9 @@ namespace AsmResolver.DotNet
         protected EventDefinition(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(() => GetName());
-            _eventType = new LazyVariable<ITypeDefOrRef?>(GetEventType);
-            _declaringType = new LazyVariable<TypeDefinition?>(GetDeclaringType);
+            _name = new LazyVariable<EventDefinition, Utf8String?>(x => x.GetName());
+            _eventType = new LazyVariable<EventDefinition, ITypeDefOrRef?>(x => x.GetEventType());
+            _declaringType = new LazyVariable<EventDefinition, TypeDefinition?>(x => x.GetDeclaringType());
         }
 
         /// <summary>
@@ -87,8 +87,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Utf8String? Name
         {
-            get => _name.Value;
-            set => _name.Value = value;
+            get => _name.GetValue(this);
+            set => _name.SetValue(value);
         }
 
         string? INameProvider.Name => Name;
@@ -101,8 +101,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public ITypeDefOrRef? EventType
         {
-            get => _eventType.Value;
-            set => _eventType.Value = value;
+            get => _eventType.GetValue(this);
+            set => _eventType.SetValue(value);
         }
 
         /// <inheritdoc />
@@ -113,8 +113,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public TypeDefinition? DeclaringType
         {
-            get => _declaringType.Value;
-            private set => _declaringType.Value = value;
+            get => _declaringType.GetValue(this);
+            private set => _declaringType.SetValue(value);
         }
 
         ITypeDescriptor? IMemberDescriptor.DeclaringType => DeclaringType;

--- a/src/AsmResolver.DotNet/ExportedType.cs
+++ b/src/AsmResolver.DotNet/ExportedType.cs
@@ -16,9 +16,9 @@ namespace AsmResolver.DotNet
         ITypeDescriptor,
         IOwnedCollectionElement<ModuleDefinition>
     {
-        private readonly LazyVariable<Utf8String?> _name;
-        private readonly LazyVariable<Utf8String?> _namespace;
-        private readonly LazyVariable<IImplementation?> _implementation;
+        private readonly LazyVariable<ExportedType, Utf8String?> _name;
+        private readonly LazyVariable<ExportedType, Utf8String?> _namespace;
+        private readonly LazyVariable<ExportedType, IImplementation?> _implementation;
         private IList<CustomAttribute>? _customAttributes;
 
         /// <summary>
@@ -28,9 +28,9 @@ namespace AsmResolver.DotNet
         protected ExportedType(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(GetName);
-            _namespace = new LazyVariable<Utf8String?>(GetNamespace);
-            _implementation = new LazyVariable<IImplementation?>(GetImplementation);
+            _name = new LazyVariable<ExportedType, Utf8String?>(x => x.GetName());
+            _namespace = new LazyVariable<ExportedType, Utf8String?>(x => x.GetNamespace());
+            _implementation = new LazyVariable<ExportedType, IImplementation?>(x => x.GetImplementation());
         }
 
         /// <summary>
@@ -73,8 +73,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Utf8String? Name
         {
-            get => _name.Value;
-            set => _name.Value = value;
+            get => _name.GetValue(this);
+            set => _name.SetValue(value);
         }
 
         string? INameProvider.Name => Name;
@@ -87,8 +87,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Utf8String? Namespace
         {
-            get => _namespace.Value;
-            set => _namespace.Value = value;
+            get => _namespace.GetValue(this);
+            set => _namespace.SetValue(value);
         }
 
         string? ITypeDescriptor.Namespace => Namespace;
@@ -114,8 +114,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public IImplementation? Implementation
         {
-            get => _implementation.Value;
-            set => _implementation.Value = value;
+            get => _implementation.GetValue(this);
+            set => _implementation.SetValue(value);
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/FieldDefinition.cs
+++ b/src/AsmResolver.DotNet/FieldDefinition.cs
@@ -23,14 +23,14 @@ namespace AsmResolver.DotNet
         IHasFieldMarshal,
         IOwnedCollectionElement<TypeDefinition>
     {
-        private readonly LazyVariable<Utf8String?> _name;
-        private readonly LazyVariable<FieldSignature?> _signature;
-        private readonly LazyVariable<TypeDefinition?> _declaringType;
-        private readonly LazyVariable<Constant?> _constant;
-        private readonly LazyVariable<MarshalDescriptor?> _marshalDescriptor;
-        private readonly LazyVariable<ImplementationMap?> _implementationMap;
-        private readonly LazyVariable<ISegment?> _fieldRva;
-        private readonly LazyVariable<int?> _fieldOffset;
+        private readonly LazyVariable<FieldDefinition, Utf8String?> _name;
+        private readonly LazyVariable<FieldDefinition, FieldSignature?> _signature;
+        private readonly LazyVariable<FieldDefinition, TypeDefinition?> _declaringType;
+        private readonly LazyVariable<FieldDefinition, Constant?> _constant;
+        private readonly LazyVariable<FieldDefinition, MarshalDescriptor?> _marshalDescriptor;
+        private readonly LazyVariable<FieldDefinition, ImplementationMap?> _implementationMap;
+        private readonly LazyVariable<FieldDefinition, ISegment?> _fieldRva;
+        private readonly LazyVariable<FieldDefinition, int?> _fieldOffset;
 
         private IList<CustomAttribute>? _customAttributes;
 
@@ -41,14 +41,14 @@ namespace AsmResolver.DotNet
         protected FieldDefinition(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(GetName);
-            _signature = new LazyVariable<FieldSignature?>(GetSignature);
-            _declaringType = new LazyVariable<TypeDefinition?>(GetDeclaringType);
-            _constant = new LazyVariable<Constant?>(GetConstant);
-            _marshalDescriptor = new LazyVariable<MarshalDescriptor?>(GetMarshalDescriptor);
-            _implementationMap = new LazyVariable<ImplementationMap?>(GetImplementationMap);
-            _fieldRva = new LazyVariable<ISegment?>(GetFieldRva);
-            _fieldOffset = new LazyVariable<int?>(GetFieldOffset);
+            _name = new LazyVariable<FieldDefinition, Utf8String?>(x => x.GetName());
+            _signature = new LazyVariable<FieldDefinition, FieldSignature?>(x => x.GetSignature());
+            _declaringType = new LazyVariable<FieldDefinition, TypeDefinition?>(x => x.GetDeclaringType());
+            _constant = new LazyVariable<FieldDefinition, Constant?>(x => x.GetConstant());
+            _marshalDescriptor = new LazyVariable<FieldDefinition, MarshalDescriptor?>(x => x.GetMarshalDescriptor());
+            _implementationMap = new LazyVariable<FieldDefinition, ImplementationMap?>(x => x.GetImplementationMap());
+            _fieldRva = new LazyVariable<FieldDefinition, ISegment?>(x => x.GetFieldRva());
+            _fieldOffset = new LazyVariable<FieldDefinition, int?>(x => x.GetFieldOffset());
         }
 
         /// <summary>
@@ -89,8 +89,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Utf8String? Name
         {
-            get => _name.Value;
-            set => _name.Value = value;
+            get => _name.GetValue(this);
+            set => _name.SetValue(value);
         }
 
         string? INameProvider.Name => Name;
@@ -100,8 +100,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public FieldSignature? Signature
         {
-            get => _signature.Value;
-            set => _signature.Value = value;
+            get => _signature.GetValue(this);
+            set => _signature.SetValue(value);
         }
 
         /// <inheritdoc />
@@ -308,8 +308,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public TypeDefinition? DeclaringType
         {
-            get => _declaringType.Value;
-            private set => _declaringType.Value = value;
+            get => _declaringType.GetValue(this);
+            private set => _declaringType.SetValue(value);
         }
 
         TypeDefinition? IOwnedCollectionElement<TypeDefinition>.Owner
@@ -334,29 +334,29 @@ namespace AsmResolver.DotNet
         /// <inheritdoc />
         public Constant? Constant
         {
-            get => _constant.Value;
-            set => _constant.Value = value;
+            get => _constant.GetValue(this);
+            set => _constant.SetValue(value);
         }
 
         /// <inheritdoc />
         public MarshalDescriptor? MarshalDescriptor
         {
-            get => _marshalDescriptor.Value;
-            set => _marshalDescriptor.Value = value;
+            get => _marshalDescriptor.GetValue(this);
+            set => _marshalDescriptor.SetValue(value);
         }
 
         /// <inheritdoc />
         public ImplementationMap? ImplementationMap
         {
-            get => _implementationMap.Value;
+            get => _implementationMap.GetValue(this);
             set
             {
-                if (value?.MemberForwarded is {})
+                if (value?.MemberForwarded is not null)
                     throw new ArgumentException("Cannot add an implementation map that was already added to another member.");
-                if (_implementationMap.Value is {})
-                    _implementationMap.Value.MemberForwarded = null;
-                _implementationMap.Value = value;
-                if (value is {})
+                if (_implementationMap.GetValue(this) is { } map)
+                    map.MemberForwarded = null;
+                _implementationMap.SetValue(value);
+                if (value is not null)
                     value.MemberForwarded = this;
             }
         }
@@ -371,8 +371,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public ISegment? FieldRva
         {
-            get => _fieldRva.Value;
-            set => _fieldRva.Value = value;
+            get => _fieldRva.GetValue(this);
+            set => _fieldRva.SetValue(value);
         }
 
         /// <summary>
@@ -380,8 +380,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public int? FieldOffset
         {
-            get => _fieldOffset.Value;
-            set => _fieldOffset.Value = value;
+            get => _fieldOffset.GetValue(this);
+            set => _fieldOffset.SetValue(value);
         }
 
         FieldDefinition IFieldDescriptor.Resolve() => this;

--- a/src/AsmResolver.DotNet/FileReference.cs
+++ b/src/AsmResolver.DotNet/FileReference.cs
@@ -15,8 +15,8 @@ namespace AsmResolver.DotNet
         IManagedEntryPoint,
         IOwnedCollectionElement<ModuleDefinition>
     {
-        private readonly LazyVariable<Utf8String?> _name;
-        private readonly LazyVariable<byte[]?> _hashValue;
+        private readonly LazyVariable<FileReference, Utf8String?> _name;
+        private readonly LazyVariable<FileReference, byte[]?> _hashValue;
         private IList<CustomAttribute>? _customAttributes;
 
         /// <summary>
@@ -26,8 +26,8 @@ namespace AsmResolver.DotNet
         protected FileReference(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(GetName);
-            _hashValue = new LazyVariable<byte[]?>(GetHashValue);
+            _name = new LazyVariable<FileReference, Utf8String?>(x => x.GetName());
+            _hashValue = new LazyVariable<FileReference, byte[]?>(x => x.GetHashValue());
         }
 
         /// <summary>
@@ -78,8 +78,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Utf8String? Name
         {
-            get => _name.Value;
-            set => _name.Value = value;
+            get => _name.GetValue(this);
+            set => _name.SetValue(value);
         }
 
         string? INameProvider.Name => Name;
@@ -105,8 +105,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public byte[]? HashValue
         {
-            get => _hashValue.Value;
-            set => _hashValue.Value = value;
+            get => _hashValue.GetValue(this);
+            set => _hashValue.SetValue(value);
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/GenericParameter.cs
+++ b/src/AsmResolver.DotNet/GenericParameter.cs
@@ -16,8 +16,8 @@ namespace AsmResolver.DotNet
         IModuleProvider,
         IOwnedCollectionElement<IHasGenericParameters>
     {
-        private readonly LazyVariable<Utf8String?> _name;
-        private readonly LazyVariable<IHasGenericParameters?> _owner;
+        private readonly LazyVariable<GenericParameter, Utf8String?> _name;
+        private readonly LazyVariable<GenericParameter, IHasGenericParameters?> _owner;
         private IList<GenericParameterConstraint>? _constraints;
         private IList<CustomAttribute>? _customAttributes;
 
@@ -28,8 +28,8 @@ namespace AsmResolver.DotNet
         protected GenericParameter(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(GetName);
-            _owner = new LazyVariable<IHasGenericParameters?>(GetOwner);
+            _name = new LazyVariable<GenericParameter, Utf8String?>(x => x.GetName());
+            _owner = new LazyVariable<GenericParameter, IHasGenericParameters?>(x => x.GetOwner());
         }
 
         /// <summary>
@@ -59,8 +59,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public IHasGenericParameters? Owner
         {
-            get => _owner.Value;
-            private set => _owner.Value = value;
+            get => _owner.GetValue(this);
+            private set => _owner.SetValue(value);
         }
 
         IHasGenericParameters? IOwnedCollectionElement<IHasGenericParameters>.Owner
@@ -77,8 +77,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Utf8String? Name
         {
-            get => _name.Value;
-            set => _name.Value = value;
+            get => _name.GetValue(this);
+            set => _name.SetValue(value);
         }
 
         string? INameProvider.Name => Name;

--- a/src/AsmResolver.DotNet/GenericParameterConstraint.cs
+++ b/src/AsmResolver.DotNet/GenericParameterConstraint.cs
@@ -14,8 +14,8 @@ namespace AsmResolver.DotNet
         IModuleProvider,
         IOwnedCollectionElement<GenericParameter>
     {
-        private readonly LazyVariable<GenericParameter?> _owner;
-        private readonly LazyVariable<ITypeDefOrRef?> _constraint;
+        private readonly LazyVariable<GenericParameterConstraint, GenericParameter?> _owner;
+        private readonly LazyVariable<GenericParameterConstraint, ITypeDefOrRef?> _constraint;
         private IList<CustomAttribute>? _customAttributes;
 
         /// <summary>
@@ -25,8 +25,8 @@ namespace AsmResolver.DotNet
         protected GenericParameterConstraint(MetadataToken token)
             : base(token)
         {
-            _owner = new LazyVariable<GenericParameter?>(GetOwner);
-            _constraint = new LazyVariable<ITypeDefOrRef?>(GetConstraint);
+            _owner = new LazyVariable<GenericParameterConstraint, GenericParameter?>(x => x.GetOwner());
+            _constraint = new LazyVariable<GenericParameterConstraint, ITypeDefOrRef?>(x => x.GetConstraint());
         }
 
         /// <summary>
@@ -44,8 +44,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public GenericParameter? Owner
         {
-            get => _owner.Value;
-            private set => _owner.Value = value;
+            get => _owner.GetValue(this);
+            private set => _owner.SetValue(value);
         }
 
         /// <inheritdoc />
@@ -60,8 +60,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public ITypeDefOrRef? Constraint
         {
-            get => _constraint.Value;
-            set => _constraint.Value = value;
+            get => _constraint.GetValue(this);
+            set => _constraint.SetValue(value);
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/ImplementationMap.cs
+++ b/src/AsmResolver.DotNet/ImplementationMap.cs
@@ -9,9 +9,9 @@ namespace AsmResolver.DotNet
     /// </summary>
     public class ImplementationMap : MetadataMember, IFullNameProvider
     {
-        private readonly LazyVariable<Utf8String?> _name;
-        private readonly LazyVariable<ModuleReference?> _scope;
-        private readonly LazyVariable<IMemberForwarded?> _memberForwarded;
+        private readonly LazyVariable<ImplementationMap, Utf8String?> _name;
+        private readonly LazyVariable<ImplementationMap, ModuleReference?> _scope;
+        private readonly LazyVariable<ImplementationMap, IMemberForwarded?> _memberForwarded;
 
         /// <summary>
         /// Initializes the <see cref="ImplementationMap"/> with a metadata token.
@@ -20,9 +20,9 @@ namespace AsmResolver.DotNet
         protected ImplementationMap(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(GetName);
-            _scope = new LazyVariable<ModuleReference?>(GetScope);
-            _memberForwarded = new LazyVariable<IMemberForwarded?>(GetMemberForwarded);
+            _name = new LazyVariable<ImplementationMap, Utf8String?>(x => x.GetName());
+            _scope = new LazyVariable<ImplementationMap, ModuleReference?>(x => x.GetScope());
+            _memberForwarded = new LazyVariable<ImplementationMap, IMemberForwarded?>(x => x.GetMemberForwarded());
         }
 
         /// <summary>
@@ -53,8 +53,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public IMemberForwarded? MemberForwarded
         {
-            get => _memberForwarded.Value;
-            internal set => _memberForwarded.Value = value;
+            get => _memberForwarded.GetValue(this);
+            internal set => _memberForwarded.SetValue(value);
         }
 
         /// <summary>
@@ -65,8 +65,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Utf8String? Name
         {
-            get => _name.Value;
-            set => _name.Value = value;
+            get => _name.GetValue(this);
+            set => _name.SetValue(value);
         }
 
         string? INameProvider.Name => Name;
@@ -81,8 +81,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public ModuleReference? Scope
         {
-            get => _scope.Value;
-            set => _scope.Value = value;
+            get => _scope.GetValue(this);
+            set => _scope.SetValue(value);
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/InterfaceImplementation.cs
+++ b/src/AsmResolver.DotNet/InterfaceImplementation.cs
@@ -14,8 +14,8 @@ namespace AsmResolver.DotNet
         IOwnedCollectionElement<TypeDefinition>,
         IHasCustomAttribute
     {
-        private readonly LazyVariable<TypeDefinition?> _class;
-        private readonly LazyVariable<ITypeDefOrRef?> _interface;
+        private readonly LazyVariable<InterfaceImplementation, TypeDefinition?> _class;
+        private readonly LazyVariable<InterfaceImplementation, ITypeDefOrRef?> _interface;
         private IList<CustomAttribute>? _customAttributes;
 
         /// <summary>
@@ -25,8 +25,8 @@ namespace AsmResolver.DotNet
         protected InterfaceImplementation(MetadataToken token)
             : base(token)
         {
-            _class = new LazyVariable<TypeDefinition?>(GetClass);
-            _interface = new LazyVariable<ITypeDefOrRef?>(GetInterface);
+            _class = new LazyVariable<InterfaceImplementation, TypeDefinition?>(x => x.GetClass());
+            _interface = new LazyVariable<InterfaceImplementation, ITypeDefOrRef?>(x => x.GetInterface());
         }
 
         /// <summary>
@@ -44,8 +44,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public TypeDefinition? Class
         {
-            get => _class.Value;
-            private set => _class.Value = value;
+            get => _class.GetValue(this);
+            private set => _class.SetValue(value);
         }
 
         /// <inheritdoc />
@@ -60,8 +60,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public ITypeDefOrRef? Interface
         {
-            get => _interface.Value;
-            set => _interface.Value = value;
+            get => _interface.GetValue(this);
+            set => _interface.SetValue(value);
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/ManifestResource.cs
+++ b/src/AsmResolver.DotNet/ManifestResource.cs
@@ -18,9 +18,9 @@ namespace AsmResolver.DotNet
         IHasCustomAttribute,
         IOwnedCollectionElement<ModuleDefinition>
     {
-        private readonly LazyVariable<Utf8String?> _name;
-        private readonly LazyVariable<IImplementation?> _implementation;
-        private readonly LazyVariable<ISegment?> _embeddedData;
+        private readonly LazyVariable<ManifestResource, Utf8String?> _name;
+        private readonly LazyVariable<ManifestResource, IImplementation?> _implementation;
+        private readonly LazyVariable<ManifestResource, ISegment?> _embeddedData;
         private IList<CustomAttribute>? _customAttributes;
 
         /// <summary>
@@ -30,9 +30,9 @@ namespace AsmResolver.DotNet
         protected ManifestResource(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(GetName);
-            _implementation = new LazyVariable<IImplementation?>(GetImplementation);
-            _embeddedData = new LazyVariable<ISegment?>(GetEmbeddedDataSegment);
+            _name = new LazyVariable<ManifestResource, Utf8String?>(x => x.GetName());
+            _implementation = new LazyVariable<ManifestResource, IImplementation?>(x => x.GetImplementation());
+            _embeddedData = new LazyVariable<ManifestResource, ISegment?>(x => x.GetEmbeddedDataSegment());
         }
 
         /// <summary>
@@ -110,8 +110,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Utf8String? Name
         {
-            get => _name.Value;
-            set => _name.Value = value;
+            get => _name.GetValue(this);
+            set => _name.SetValue(value);
         }
 
         string? INameProvider.Name => Name;
@@ -121,8 +121,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public IImplementation? Implementation
         {
-            get => _implementation.Value;
-            set => _implementation.Value = value;
+            get => _implementation.GetValue(this);
+            set => _implementation.SetValue(value);
         }
 
         /// <summary>
@@ -135,8 +135,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public ISegment? EmbeddedDataSegment
         {
-            get => _embeddedData.Value;
-            set => _embeddedData.Value = value;
+            get => _embeddedData.GetValue(this);
+            set => _embeddedData.SetValue(value);
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/MemberReference.cs
+++ b/src/AsmResolver.DotNet/MemberReference.cs
@@ -13,9 +13,9 @@ namespace AsmResolver.DotNet
     /// </summary>
     public class MemberReference : MetadataMember, ICustomAttributeType, IFieldDescriptor
     {
-        private readonly LazyVariable<IMemberRefParent?> _parent;
-        private readonly LazyVariable<Utf8String?> _name;
-        private readonly LazyVariable<CallingConventionSignature?> _signature;
+        private readonly LazyVariable<MemberReference, IMemberRefParent?> _parent;
+        private readonly LazyVariable<MemberReference, Utf8String?> _name;
+        private readonly LazyVariable<MemberReference, CallingConventionSignature?> _signature;
         private IList<CustomAttribute>? _customAttributes;
 
         /// <summary>
@@ -25,9 +25,9 @@ namespace AsmResolver.DotNet
         protected MemberReference(MetadataToken token)
             : base(token)
         {
-            _parent = new LazyVariable<IMemberRefParent?>(GetParent);
-            _name = new LazyVariable<Utf8String?>(GetName);
-            _signature = new LazyVariable<CallingConventionSignature?>(GetSignature);
+            _parent = new LazyVariable<MemberReference, IMemberRefParent?>(x => x.GetParent());
+            _name = new LazyVariable<MemberReference, Utf8String?>(x => x.GetName());
+            _signature = new LazyVariable<MemberReference, CallingConventionSignature?>(x => x.GetSignature());
         }
 
         /// <summary>
@@ -50,8 +50,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public IMemberRefParent? Parent
         {
-            get => _parent.Value;
-            set => _parent.Value = value;
+            get => _parent.GetValue(this);
+            set => _parent.SetValue(value);
         }
 
         /// <summary>
@@ -62,8 +62,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Utf8String? Name
         {
-            get => _name.Value;
-            set => _name.Value = value;
+            get => _name.GetValue(this);
+            set => _name.SetValue(value);
         }
 
         /// <inheritdoc />
@@ -77,8 +77,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public CallingConventionSignature? Signature
         {
-            get => _signature.Value;
-            set => _signature.Value = value;
+            get => _signature.GetValue(this);
+            set => _signature.SetValue(value);
         }
 
         MethodSignature? IMethodDescriptor.Signature => Signature as MethodSignature;

--- a/src/AsmResolver.DotNet/MethodDefinition.cs
+++ b/src/AsmResolver.DotNet/MethodDefinition.cs
@@ -27,13 +27,13 @@ namespace AsmResolver.DotNet
         IHasSecurityDeclaration,
         IManagedEntryPoint
     {
-        private readonly LazyVariable<Utf8String?> _name;
-        private readonly LazyVariable<TypeDefinition?> _declaringType;
-        private readonly LazyVariable<MethodSignature?> _signature;
-        private readonly LazyVariable<MethodBody?> _methodBody;
-        private readonly LazyVariable<ImplementationMap?> _implementationMap;
-        private readonly LazyVariable<MethodSemantics?> _semantics;
-        private readonly LazyVariable<UnmanagedExportInfo?> _exportInfo;
+        private readonly LazyVariable<MethodDefinition, Utf8String?> _name;
+        private readonly LazyVariable<MethodDefinition, TypeDefinition?> _declaringType;
+        private readonly LazyVariable<MethodDefinition, MethodSignature?> _signature;
+        private readonly LazyVariable<MethodDefinition, MethodBody?> _methodBody;
+        private readonly LazyVariable<MethodDefinition, ImplementationMap?> _implementationMap;
+        private readonly LazyVariable<MethodDefinition, MethodSemantics?> _semantics;
+        private readonly LazyVariable<MethodDefinition, UnmanagedExportInfo?> _exportInfo;
         private IList<ParameterDefinition>? _parameterDefinitions;
         private ParameterCollection? _parameters;
         private IList<CustomAttribute>? _customAttributes;
@@ -47,13 +47,13 @@ namespace AsmResolver.DotNet
         protected MethodDefinition(MetadataToken token)
             : base(token)
         {
-            _name  =new LazyVariable<Utf8String?>(GetName);
-            _declaringType = new LazyVariable<TypeDefinition?>(GetDeclaringType);
-            _signature = new LazyVariable<MethodSignature?>(GetSignature);
-            _methodBody = new LazyVariable<MethodBody?>(GetBody);
-            _implementationMap = new LazyVariable<ImplementationMap?>(GetImplementationMap);
-            _semantics = new LazyVariable<MethodSemantics?>(GetSemantics);
-            _exportInfo = new LazyVariable<UnmanagedExportInfo?>(GetExportInfo);
+            _name = new LazyVariable<MethodDefinition, Utf8String?>(x => GetName());
+            _declaringType = new LazyVariable<MethodDefinition, TypeDefinition?>(x => GetDeclaringType());
+            _signature = new LazyVariable<MethodDefinition, MethodSignature?>(x => x.GetSignature());
+            _methodBody = new LazyVariable<MethodDefinition, MethodBody?>(x => x.GetBody());
+            _implementationMap = new LazyVariable<MethodDefinition, ImplementationMap?>(x => x.GetImplementationMap());
+            _semantics = new LazyVariable<MethodDefinition, MethodSemantics?>(x => x.GetSemantics());
+            _exportInfo = new LazyVariable<MethodDefinition, UnmanagedExportInfo?>(x => x.GetExportInfo());
         }
 
         /// <summary>
@@ -83,8 +83,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Utf8String? Name
         {
-            get => _name.Value;
-            set => _name.Value = value;
+            get => _name.GetValue(this);
+            set => _name.SetValue(value);
         }
 
         string? INameProvider.Name => Name;
@@ -95,8 +95,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public MethodSignature? Signature
         {
-            get => _signature.Value;
-            set => _signature.Value = value;
+            get => _signature.GetValue(this);
+            set => _signature.SetValue(value);
         }
 
         /// <inheritdoc />
@@ -483,8 +483,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public TypeDefinition? DeclaringType
         {
-            get => _declaringType.Value;
-            set => _declaringType.Value = value;
+            get => _declaringType.GetValue(this);
+            set => _declaringType.SetValue(value);
         }
 
         ITypeDescriptor? IMemberDescriptor.DeclaringType => DeclaringType;
@@ -546,8 +546,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public MethodBody? MethodBody
         {
-            get => _methodBody.Value;
-            set => _methodBody.Value = value;
+            get => _methodBody.GetValue(this);
+            set => _methodBody.SetValue(value);
         }
 
         /// <summary>
@@ -594,15 +594,15 @@ namespace AsmResolver.DotNet
         /// <inheritdoc />
         public ImplementationMap? ImplementationMap
         {
-            get => _implementationMap.Value;
+            get => _implementationMap.GetValue(this);
             set
             {
-                if (value?.MemberForwarded is {})
+                if (value?.MemberForwarded is not null)
                     throw new ArgumentException("Cannot add an implementation map that was already added to another member.");
-                if (_implementationMap.Value is {})
-                    _implementationMap.Value.MemberForwarded = null;
-                _implementationMap.Value = value;
-                if (value is {})
+                if (_implementationMap.GetValue(this) is { } map)
+                    map.MemberForwarded = null;
+                _implementationMap.SetValue(value);
+                if (value is not null)
                     value.MemberForwarded = this;
             }
         }
@@ -645,8 +645,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public MethodSemantics? Semantics
         {
-            get => _semantics.Value;
-            set => _semantics.Value = value;
+            get => _semantics.GetValue(this);
+            set => _semantics.SetValue(value);
         }
 
         /// <summary>
@@ -685,8 +685,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public UnmanagedExportInfo? ExportInfo
         {
-            get => _exportInfo.Value;
-            set => _exportInfo.Value = value;
+            get => _exportInfo.GetValue(this);
+            set => _exportInfo.SetValue(value);
         }
 
         MethodDefinition IMethodDescriptor.Resolve() => this;

--- a/src/AsmResolver.DotNet/MethodSemantics.cs
+++ b/src/AsmResolver.DotNet/MethodSemantics.cs
@@ -10,8 +10,8 @@ namespace AsmResolver.DotNet
     /// </summary>
     public class MethodSemantics : MetadataMember, IOwnedCollectionElement<IHasSemantics>
     {
-        private readonly LazyVariable<MethodDefinition?> _method;
-        private readonly LazyVariable<IHasSemantics?> _association;
+        private readonly LazyVariable<MethodSemantics, MethodDefinition?> _method;
+        private readonly LazyVariable<MethodSemantics, IHasSemantics?> _association;
 
         /// <summary>
         /// Initializes an empty method semantics object.
@@ -20,8 +20,8 @@ namespace AsmResolver.DotNet
         protected MethodSemantics(MetadataToken token)
             : base(token)
         {
-            _method = new LazyVariable<MethodDefinition?>(GetMethod);
-            _association = new LazyVariable<IHasSemantics?>(GetAssociation);
+            _method = new LazyVariable<MethodSemantics, MethodDefinition?>(x => x.GetMethod());
+            _association = new LazyVariable<MethodSemantics, IHasSemantics?>(x => x.GetAssociation());
         }
 
         /// <summary>
@@ -50,8 +50,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public MethodDefinition? Method
         {
-            get => _method.Value;
-            private set => _method.Value = value;
+            get => _method.GetValue(this);
+            private set => _method.SetValue(value);
         }
 
         /// <summary>
@@ -59,8 +59,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public IHasSemantics? Association
         {
-            get => _association.Value;
-            private set => _association.Value = value;
+            get => _association.GetValue(this);
+            private set => _association.SetValue(value);
         }
 
         IHasSemantics? IOwnedCollectionElement<IHasSemantics>.Owner

--- a/src/AsmResolver.DotNet/MethodSpecification.cs
+++ b/src/AsmResolver.DotNet/MethodSpecification.cs
@@ -11,8 +11,8 @@ namespace AsmResolver.DotNet
     /// </summary>
     public class MethodSpecification : MetadataMember, IMethodDescriptor, IHasCustomAttribute
     {
-        private readonly LazyVariable<IMethodDefOrRef?> _method;
-        private readonly LazyVariable<GenericInstanceMethodSignature?> _signature;
+        private readonly LazyVariable<MethodSpecification, IMethodDefOrRef?> _method;
+        private readonly LazyVariable<MethodSpecification, GenericInstanceMethodSignature?> _signature;
         private IList<CustomAttribute>? _customAttributes;
 
         /// <summary>
@@ -22,8 +22,8 @@ namespace AsmResolver.DotNet
         protected MethodSpecification(MetadataToken token)
             : base(token)
         {
-            _method = new LazyVariable<IMethodDefOrRef?>(GetMethod);
-            _signature = new LazyVariable<GenericInstanceMethodSignature?>(GetSignature);
+            _method = new LazyVariable<MethodSpecification, IMethodDefOrRef?>(x => x.GetMethod());
+            _signature = new LazyVariable<MethodSpecification, GenericInstanceMethodSignature?>(x => x.GetSignature());
         }
 
         /// <summary>
@@ -43,8 +43,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public IMethodDefOrRef? Method
         {
-            get => _method.Value;
-            set => _method.Value = value;
+            get => _method.GetValue(this);
+            set => _method.SetValue(value);
         }
 
         MethodSignature? IMethodDescriptor.Signature => Method?.Signature;
@@ -54,8 +54,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public GenericInstanceMethodSignature? Signature
         {
-            get => _signature.Value;
-            set => _signature.Value = value;
+            get => _signature.GetValue(this);
+            set => _signature.SetValue(value);
         }
 
 

--- a/src/AsmResolver.DotNet/ModuleDefinition.cs
+++ b/src/AsmResolver.DotNet/ModuleDefinition.cs
@@ -35,24 +35,24 @@ namespace AsmResolver.DotNet
     {
         private static MethodInfo? GetHINSTANCEMethod;
 
-        private readonly LazyVariable<Utf8String?> _name;
-        private readonly LazyVariable<Guid> _mvid;
-        private readonly LazyVariable<Guid> _encId;
-        private readonly LazyVariable<Guid> _encBaseId;
+        private readonly LazyVariable<ModuleDefinition, Utf8String?> _name;
+        private readonly LazyVariable<ModuleDefinition, Guid> _mvid;
+        private readonly LazyVariable<ModuleDefinition, Guid> _encId;
+        private readonly LazyVariable<ModuleDefinition, Guid> _encBaseId;
 
         private IList<TypeDefinition>? _topLevelTypes;
         private IList<AssemblyReference>? _assemblyReferences;
         private IList<CustomAttribute>? _customAttributes;
 
-        private readonly LazyVariable<IManagedEntryPoint?> _managedEntryPoint;
+        private readonly LazyVariable<ModuleDefinition, IManagedEntryPoint?> _managedEntryPoint;
         private IList<ModuleReference>? _moduleReferences;
         private IList<FileReference>? _fileReferences;
         private IList<ManifestResource>? _resources;
         private IList<ExportedType>? _exportedTypes;
         private TokenAllocator? _tokenAllocator;
 
-        private readonly LazyVariable<string> _runtimeVersion;
-        private readonly LazyVariable<IResourceDirectory?> _nativeResources;
+        private readonly LazyVariable<ModuleDefinition, string> _runtimeVersion;
+        private readonly LazyVariable<ModuleDefinition, IResourceDirectory?> _nativeResources;
         private IList<DebugDataEntry>? _debugData;
         private ReferenceImporter? _defaultImporter;
 
@@ -267,13 +267,13 @@ namespace AsmResolver.DotNet
         protected ModuleDefinition(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(GetName);
-            _mvid = new LazyVariable<Guid>(GetMvid);
-            _encId = new LazyVariable<Guid>(GetEncId);
-            _encBaseId = new LazyVariable<Guid>(GetEncBaseId);
-            _managedEntryPoint = new LazyVariable<IManagedEntryPoint?>(GetManagedEntryPoint);
-            _runtimeVersion = new LazyVariable<string>(GetRuntimeVersion);
-            _nativeResources = new LazyVariable<IResourceDirectory?>(GetNativeResources);
+            _name = new LazyVariable<ModuleDefinition, Utf8String?>(x => x.GetName());
+            _mvid = new LazyVariable<ModuleDefinition, Guid>(x => x.GetMvid());
+            _encId = new LazyVariable<ModuleDefinition, Guid>(x => x.GetEncId());
+            _encBaseId = new LazyVariable<ModuleDefinition, Guid>(x => x.GetEncBaseId());
+            _managedEntryPoint = new LazyVariable<ModuleDefinition, IManagedEntryPoint?>(x => x.GetManagedEntryPoint());
+            _runtimeVersion = new LazyVariable<ModuleDefinition, string>(x => x.GetRuntimeVersion());
+            _nativeResources = new LazyVariable<ModuleDefinition, IResourceDirectory?>(x => x.GetNativeResources());
             Attributes = DotNetDirectoryFlags.ILOnly;
         }
 
@@ -384,8 +384,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Utf8String? Name
         {
-            get => _name.Value;
-            set => _name.Value = value;
+            get => _name.GetValue(this);
+            set => _name.SetValue(value);
         }
 
         string? INameProvider.Name => Name;
@@ -416,8 +416,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Guid Mvid
         {
-            get => _mvid.Value;
-            set => _mvid.Value = value;
+            get => _mvid.GetValue(this);
+            set => _mvid.SetValue(value);
         }
 
         /// <summary>
@@ -428,8 +428,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Guid EncId
         {
-            get => _encId.Value;
-            set => _encId.Value = value;
+            get => _encId.GetValue(this);
+            set => _encId.SetValue(value);
         }
 
         /// <summary>
@@ -440,8 +440,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Guid EncBaseId
         {
-            get => _encBaseId.Value;
-            set => _encBaseId.Value = value;
+            get => _encBaseId.GetValue(this);
+            set => _encBaseId.SetValue(value);
         }
 
         /// <summary>
@@ -635,8 +635,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public string RuntimeVersion
         {
-            get => _runtimeVersion.Value;
-            set => _runtimeVersion.Value = value;
+            get => _runtimeVersion.GetValue(this);
+            set => _runtimeVersion.SetValue(value);
         }
 
         /// <summary>
@@ -645,8 +645,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public IResourceDirectory? NativeResourceDirectory
         {
-            get => _nativeResources.Value;
-            set => _nativeResources.Value = value;
+            get => _nativeResources.GetValue(this);
+            set => _nativeResources.SetValue(value);
         }
 
         /// <summary>
@@ -772,8 +772,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public IManagedEntryPoint? ManagedEntryPoint
         {
-            get => _managedEntryPoint.Value;
-            set => _managedEntryPoint.Value = value;
+            get => _managedEntryPoint.GetValue(this);
+            set => _managedEntryPoint.SetValue(value);
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/ModuleReference.cs
+++ b/src/AsmResolver.DotNet/ModuleReference.cs
@@ -15,7 +15,7 @@ namespace AsmResolver.DotNet
         IHasCustomAttribute,
         IOwnedCollectionElement<ModuleDefinition>
     {
-        private readonly LazyVariable<Utf8String?> _name;
+        private readonly LazyVariable<ModuleReference, Utf8String?> _name;
         private IList<CustomAttribute>? _customAttributes;
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace AsmResolver.DotNet
         protected ModuleReference(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(GetName);
+            _name = new LazyVariable<ModuleReference, Utf8String?>(x => x.GetName());
         }
 
         /// <summary>
@@ -46,8 +46,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Utf8String? Name
         {
-            get => _name.Value;
-            set => _name.Value = value;
+            get => _name.GetValue(this);
+            set => _name.SetValue(value);
         }
 
         string? INameProvider.Name => Name;

--- a/src/AsmResolver.DotNet/ParameterDefinition.cs
+++ b/src/AsmResolver.DotNet/ParameterDefinition.cs
@@ -22,10 +22,10 @@ namespace AsmResolver.DotNet
         IHasFieldMarshal,
         IOwnedCollectionElement<MethodDefinition>
     {
-        private readonly LazyVariable<Utf8String?> _name;
-        private readonly LazyVariable<MethodDefinition?> _method;
-        private readonly LazyVariable<Constant?> _constant;
-        private readonly LazyVariable<MarshalDescriptor?> _marshalDescriptor;
+        private readonly LazyVariable<ParameterDefinition, Utf8String?> _name;
+        private readonly LazyVariable<ParameterDefinition, MethodDefinition?> _method;
+        private readonly LazyVariable<ParameterDefinition, Constant?> _constant;
+        private readonly LazyVariable<ParameterDefinition, MarshalDescriptor?> _marshalDescriptor;
         private IList<CustomAttribute>? _customAttributes;
 
         /// <summary>
@@ -35,10 +35,10 @@ namespace AsmResolver.DotNet
         protected ParameterDefinition(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(GetName);
-            _method = new LazyVariable<MethodDefinition?>(GetMethod);
-            _constant = new LazyVariable<Constant?>(GetConstant);
-            _marshalDescriptor = new LazyVariable<MarshalDescriptor?>(GetMarshalDescriptor);
+            _name = new LazyVariable<ParameterDefinition, Utf8String?>(x => x.GetName());
+            _method = new LazyVariable<ParameterDefinition, MethodDefinition?>(x => x.GetMethod());
+            _constant = new LazyVariable<ParameterDefinition, Constant?>(x => x.GetConstant());
+            _marshalDescriptor = new LazyVariable<ParameterDefinition, MarshalDescriptor?>(x => x.GetMarshalDescriptor());
         }
 
         /// <summary>
@@ -73,8 +73,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Utf8String? Name
         {
-            get => _name.Value;
-            set => _name.Value = value;
+            get => _name.GetValue(this);
+            set => _name.SetValue(value);
         }
 
         string? INameProvider.Name => Name;
@@ -162,8 +162,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public MethodDefinition? Method
         {
-            get => _method.Value;
-            private set => _method.Value = value;
+            get => _method.GetValue(this);
+            private set => _method.SetValue(value);
         }
 
         MethodDefinition? IOwnedCollectionElement<MethodDefinition>.Owner
@@ -194,8 +194,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Constant? Constant
         {
-            get => _constant.Value;
-            set => _constant.Value = value;
+            get => _constant.GetValue(this);
+            set => _constant.SetValue(value);
         }
 
         /// <inheritdoc />
@@ -206,8 +206,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public MarshalDescriptor? MarshalDescriptor
         {
-            get => _marshalDescriptor.Value;
-            set => _marshalDescriptor.Value = value;
+            get => _marshalDescriptor.GetValue(this);
+            set => _marshalDescriptor.SetValue(value);
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/PropertyDefinition.cs
+++ b/src/AsmResolver.DotNet/PropertyDefinition.cs
@@ -20,10 +20,10 @@ namespace AsmResolver.DotNet
         IHasConstant,
         IOwnedCollectionElement<TypeDefinition>
     {
-        private readonly LazyVariable<Utf8String?> _name;
-        private readonly LazyVariable<TypeDefinition?> _declaringType;
-        private readonly LazyVariable<PropertySignature?> _signature;
-        private readonly LazyVariable<Constant?> _constant;
+        private readonly LazyVariable<PropertyDefinition, Utf8String?> _name;
+        private readonly LazyVariable<PropertyDefinition, TypeDefinition?> _declaringType;
+        private readonly LazyVariable<PropertyDefinition, PropertySignature?> _signature;
+        private readonly LazyVariable<PropertyDefinition, Constant?> _constant;
         private IList<MethodSemantics>? _semantics;
         private IList<CustomAttribute>? _customAttributes;
 
@@ -34,10 +34,10 @@ namespace AsmResolver.DotNet
         protected PropertyDefinition(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(GetName);
-            _signature = new LazyVariable<PropertySignature?>(GetSignature);
-            _declaringType = new LazyVariable<TypeDefinition?>(GetDeclaringType);
-            _constant = new LazyVariable<Constant?>(GetConstant);
+            _name = new LazyVariable<PropertyDefinition, Utf8String?>(x => x.GetName());
+            _signature = new LazyVariable<PropertyDefinition, PropertySignature?>(x => x.GetSignature());
+            _declaringType = new LazyVariable<PropertyDefinition, TypeDefinition?>(x => x.GetDeclaringType());
+            _constant = new LazyVariable<PropertyDefinition, Constant?>(x => x.GetConstant());
         }
 
         /// <summary>
@@ -102,8 +102,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Utf8String? Name
         {
-            get => _name.Value;
-            set => _name.Value = value;
+            get => _name.GetValue(this);
+            set => _name.SetValue(value);
         }
 
         string? INameProvider.Name => Name;
@@ -117,8 +117,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public PropertySignature? Signature
         {
-            get => _signature.Value;
-            set => _signature.Value = value;
+            get => _signature.GetValue(this);
+            set => _signature.SetValue(value);
         }
 
         /// <inheritdoc />
@@ -129,8 +129,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public TypeDefinition? DeclaringType
         {
-            get => _declaringType.Value;
-            private set => _declaringType.Value = value;
+            get => _declaringType.GetValue(this);
+            private set => _declaringType.SetValue(value);
         }
 
         ITypeDescriptor? IMemberDescriptor.DeclaringType => DeclaringType;
@@ -166,8 +166,8 @@ namespace AsmResolver.DotNet
         /// <inheritdoc />
         public Constant? Constant
         {
-            get => _constant.Value;
-            set => _constant.Value = value;
+            get => _constant.GetValue(this);
+            set => _constant.SetValue(value);
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/Resources/ResourceSetEntry.cs
+++ b/src/AsmResolver.DotNet/Resources/ResourceSetEntry.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.DotNet.Resources
     /// </summary>
     public class ResourceSetEntry
     {
-        private readonly LazyVariable<object?> _data;
+        private readonly LazyVariable<ResourceSetEntry, object?> _data;
 
         /// <summary>
         /// Creates a new empty resource set entry.
@@ -19,7 +19,7 @@ namespace AsmResolver.DotNet.Resources
         {
             Name = name;
             Type = IntrinsicResourceType.Get(typeCode);
-            _data = new LazyVariable<object?>(GetData);
+            _data = new LazyVariable<ResourceSetEntry, object?>(x => x.GetData());
         }
 
         /// <summary>
@@ -31,7 +31,7 @@ namespace AsmResolver.DotNet.Resources
         {
             Name = name;
             Type = type;
-            _data = new LazyVariable<object?>(GetData);
+            _data = new LazyVariable<ResourceSetEntry, object?>(x => x.GetData());
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace AsmResolver.DotNet.Resources
         {
             Name = name;
             Type = IntrinsicResourceType.Get(typeCode);
-            _data = new LazyVariable<object?>(data);
+            _data = new LazyVariable<ResourceSetEntry, object?>(data);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace AsmResolver.DotNet.Resources
         {
             Name = name;
             Type = type;
-            _data = new LazyVariable<object?>(data);
+            _data = new LazyVariable<ResourceSetEntry, object?>(data);
         }
 
         /// <summary>
@@ -81,8 +81,8 @@ namespace AsmResolver.DotNet.Resources
         /// </summary>
         public object? Data
         {
-            get => _data.Value;
-            set => _data.Value = value;
+            get => _data.GetValue(this);
+            set => _data.SetValue(value);
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/SecurityDeclaration.cs
+++ b/src/AsmResolver.DotNet/SecurityDeclaration.cs
@@ -12,8 +12,8 @@ namespace AsmResolver.DotNet
         MetadataMember,
         IOwnedCollectionElement<IHasSecurityDeclaration>
     {
-        private readonly LazyVariable<IHasSecurityDeclaration?> _parent;
-        private readonly LazyVariable<PermissionSetSignature?> _permissionSet;
+        private readonly LazyVariable<SecurityDeclaration, IHasSecurityDeclaration?> _parent;
+        private readonly LazyVariable<SecurityDeclaration, PermissionSetSignature?> _permissionSet;
 
         /// <summary>
         /// Initializes the <see cref="SecurityDeclaration"/> with a metadata token.
@@ -22,8 +22,8 @@ namespace AsmResolver.DotNet
         protected SecurityDeclaration(MetadataToken token)
             : base(token)
         {
-            _parent = new LazyVariable<IHasSecurityDeclaration?>(GetParent);
-            _permissionSet = new LazyVariable<PermissionSetSignature?>(GetPermissionSet);
+            _parent = new LazyVariable<SecurityDeclaration, IHasSecurityDeclaration?>(x => x.GetParent());
+            _permissionSet = new LazyVariable<SecurityDeclaration, PermissionSetSignature?>(x => x.GetPermissionSet());
         }
 
         /// <summary>
@@ -52,8 +52,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public IHasSecurityDeclaration? Parent
         {
-            get => _parent.Value;
-            private set => _parent.Value = value;
+            get => _parent.GetValue(this);
+            private set => _parent.SetValue(value);
         }
 
         /// <inheritdoc />
@@ -68,8 +68,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public PermissionSetSignature? PermissionSet
         {
-            get => _permissionSet.Value;
-            set => _permissionSet.Value = value;
+            get => _permissionSet.GetValue(this);
+            set => _permissionSet.SetValue(value);
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/StandAloneSignature.cs
+++ b/src/AsmResolver.DotNet/StandAloneSignature.cs
@@ -15,7 +15,7 @@ namespace AsmResolver.DotNet
     /// </remarks>
     public class StandAloneSignature : MetadataMember, IHasCustomAttribute
     {
-        private readonly LazyVariable<BlobSignature?> _signature;
+        private readonly LazyVariable<StandAloneSignature, BlobSignature?> _signature;
         private IList<CustomAttribute>? _customAttributes;
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace AsmResolver.DotNet
         protected StandAloneSignature(MetadataToken token)
             : base(token)
         {
-            _signature = new LazyVariable<BlobSignature?>(GetSignature);
+            _signature = new LazyVariable<StandAloneSignature, BlobSignature?>(x => x.GetSignature());
         }
 
         /// <summary>
@@ -43,8 +43,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public BlobSignature? Signature
         {
-            get => _signature.Value;
-            set => _signature.Value = value;
+            get => _signature.GetValue(this);
+            set => _signature.SetValue(value);
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/TypeDefinition.cs
+++ b/src/AsmResolver.DotNet/TypeDefinition.cs
@@ -27,11 +27,11 @@ namespace AsmResolver.DotNet
     {
         internal static readonly Utf8String ModuleTypeName = "<Module>";
 
-        private readonly LazyVariable<Utf8String?> _namespace;
-        private readonly LazyVariable<Utf8String?> _name;
-        private readonly LazyVariable<ITypeDefOrRef?> _baseType;
-        private readonly LazyVariable<TypeDefinition?> _declaringType;
-        private readonly LazyVariable<ClassLayout?> _classLayout;
+        private readonly LazyVariable<TypeDefinition, Utf8String?> _namespace;
+        private readonly LazyVariable<TypeDefinition, Utf8String?> _name;
+        private readonly LazyVariable<TypeDefinition, ITypeDefOrRef?> _baseType;
+        private readonly LazyVariable<TypeDefinition, TypeDefinition?> _declaringType;
+        private readonly LazyVariable<TypeDefinition, ClassLayout?> _classLayout;
         private IList<TypeDefinition>? _nestedTypes;
         private ModuleDefinition? _module;
         private IList<FieldDefinition>? _fields;
@@ -51,11 +51,11 @@ namespace AsmResolver.DotNet
         protected TypeDefinition(MetadataToken token)
             : base(token)
         {
-            _namespace = new LazyVariable<Utf8String?>(GetNamespace);
-            _name = new LazyVariable<Utf8String?>(GetName);
-            _baseType = new LazyVariable<ITypeDefOrRef?>(GetBaseType);
-            _declaringType = new LazyVariable<TypeDefinition?>(GetDeclaringType);
-            _classLayout = new LazyVariable<ClassLayout?>(GetClassLayout);
+            _namespace = new LazyVariable<TypeDefinition, Utf8String?>(x => x.GetNamespace());
+            _name = new LazyVariable<TypeDefinition, Utf8String?>(x => x.GetName());
+            _baseType = new LazyVariable<TypeDefinition, ITypeDefOrRef?>(x => x.GetBaseType());
+            _declaringType = new LazyVariable<TypeDefinition, TypeDefinition?>(x => x.GetDeclaringType());
+            _classLayout = new LazyVariable<TypeDefinition, ClassLayout?>(x => x.GetClassLayout());
         }
 
         /// <summary>
@@ -93,8 +93,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Utf8String? Namespace
         {
-            get => _namespace.Value;
-            set => _namespace.Value = value;
+            get => _namespace.GetValue(this);
+            set => _namespace.SetValue(value);
         }
 
         string? ITypeDescriptor.Namespace => Namespace;
@@ -107,8 +107,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Utf8String? Name
         {
-            get => _name.Value;
-            set => _name.Value = value;
+            get => _name.GetValue(this);
+            set => _name.SetValue(value);
         }
 
         string? INameProvider.Name => Name;
@@ -415,8 +415,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public ITypeDefOrRef? BaseType
         {
-            get => _baseType.Value;
-            set => _baseType.Value = value;
+            get => _baseType.GetValue(this);
+            set => _baseType.SetValue(value);
         }
 
         /// <summary>
@@ -435,8 +435,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public TypeDefinition? DeclaringType
         {
-            get => _declaringType.Value;
-            private set => _declaringType.Value = value;
+            get => _declaringType.GetValue(this);
+            private set => _declaringType.SetValue(value);
         }
 
         ITypeDefOrRef? ITypeDefOrRef.DeclaringType => DeclaringType;
@@ -642,8 +642,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public ClassLayout? ClassLayout
         {
-            get => _classLayout.Value;
-            set => _classLayout.Value = value;
+            get => _classLayout.GetValue(this);
+            set => _classLayout.SetValue(value);
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/TypeReference.cs
+++ b/src/AsmResolver.DotNet/TypeReference.cs
@@ -14,9 +14,9 @@ namespace AsmResolver.DotNet
         ITypeDefOrRef,
         IResolutionScope
     {
-        private readonly LazyVariable<Utf8String?> _name;
-        private readonly LazyVariable<Utf8String?> _namespace;
-        private readonly LazyVariable<IResolutionScope?> _scope;
+        private readonly LazyVariable<TypeReference, Utf8String?> _name;
+        private readonly LazyVariable<TypeReference, Utf8String?> _namespace;
+        private readonly LazyVariable<TypeReference, IResolutionScope?> _scope;
         private IList<CustomAttribute>? _customAttributes;
 
         /// <summary>
@@ -26,9 +26,9 @@ namespace AsmResolver.DotNet
         protected TypeReference(MetadataToken token)
             : base(token)
         {
-            _name = new LazyVariable<Utf8String?>(GetName);
-            _namespace = new LazyVariable<Utf8String?>(GetNamespace);
-            _scope = new LazyVariable<IResolutionScope?>(GetScope);
+            _name = new LazyVariable<TypeReference, Utf8String?>(x => x.GetName());
+            _namespace = new LazyVariable<TypeReference, Utf8String?>(x => x.GetNamespace());
+            _scope = new LazyVariable<TypeReference, IResolutionScope?>(x => x.GetScope());
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace AsmResolver.DotNet
         public TypeReference(IResolutionScope? scope, Utf8String? ns, Utf8String? name)
             : this(new MetadataToken(TableIndex.TypeRef, 0))
         {
-            _scope.Value = scope;
+            _scope.SetValue(scope);
             Namespace = ns;
             Name = name;
         }
@@ -55,7 +55,7 @@ namespace AsmResolver.DotNet
         public TypeReference(ModuleDefinition? module, IResolutionScope? scope, Utf8String? ns, Utf8String? name)
             : this(new MetadataToken(TableIndex.TypeRef, 0))
         {
-            _scope.Value = scope;
+            _scope.SetValue(scope);
             Module = module;
             Namespace = ns;
             Name = name;
@@ -69,8 +69,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Utf8String? Name
         {
-            get => _name.Value;
-            set => _name.Value = value;
+            get => _name.GetValue(this);
+            set => _name.SetValue(value);
         }
 
         string? INameProvider.Name => Name;
@@ -83,8 +83,8 @@ namespace AsmResolver.DotNet
         /// </remarks>
         public Utf8String? Namespace
         {
-            get => _namespace.Value;
-            set => _namespace.Value = value;
+            get => _namespace.GetValue(this);
+            set => _namespace.SetValue(value);
         }
 
         string? ITypeDescriptor.Namespace => Namespace;
@@ -95,8 +95,8 @@ namespace AsmResolver.DotNet
         /// <inheritdoc />
         public IResolutionScope? Scope
         {
-            get => _scope.Value;
-            set => _scope.Value = value;
+            get => _scope.GetValue(this);
+            set => _scope.SetValue(value);
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/TypeSpecification.cs
+++ b/src/AsmResolver.DotNet/TypeSpecification.cs
@@ -14,7 +14,7 @@ namespace AsmResolver.DotNet
         MetadataMember,
         ITypeDefOrRef
     {
-        private readonly LazyVariable<TypeSignature?> _signature;
+        private readonly LazyVariable<TypeSpecification, TypeSignature?> _signature;
         private IList<CustomAttribute>? _customAttributes;
 
         /// <summary>
@@ -24,7 +24,7 @@ namespace AsmResolver.DotNet
         protected TypeSpecification(MetadataToken token)
             : base(token)
         {
-            _signature = new LazyVariable<TypeSignature?>(GetSignature);
+            _signature = new LazyVariable<TypeSpecification, TypeSignature?>(x => x.GetSignature());
         }
 
         /// <summary>
@@ -42,8 +42,8 @@ namespace AsmResolver.DotNet
         /// </summary>
         public TypeSignature? Signature
         {
-            get => _signature.Value;
-            set => _signature.Value = value;
+            get => _signature.GetValue(this);
+            set => _signature.SetValue(value);
         }
 
         /// <summary>

--- a/src/AsmResolver.PE.File/PEFile.cs
+++ b/src/AsmResolver.PE.File/PEFile.cs
@@ -20,8 +20,8 @@ namespace AsmResolver.PE.File
         /// </summary>
         public const uint ValidPESignature = 0x4550; // "PE\0\0"
 
-        private readonly LazyVariable<ISegment?> _extraSectionData;
-        private readonly LazyVariable<ISegment?> _eofData;
+        private readonly LazyVariable<PEFile, ISegment?> _extraSectionData;
+        private readonly LazyVariable<PEFile, ISegment?> _eofData;
         private IList<PESection>? _sections;
 
         /// <summary>
@@ -43,8 +43,8 @@ namespace AsmResolver.PE.File
             DosHeader = dosHeader ?? throw new ArgumentNullException(nameof(dosHeader));
             FileHeader = fileHeader ?? throw new ArgumentNullException(nameof(fileHeader));
             OptionalHeader = optionalHeader ?? throw new ArgumentNullException(nameof(optionalHeader));
-            _extraSectionData = new LazyVariable<ISegment?>(GetExtraSectionData);
-            _eofData = new LazyVariable<ISegment?>(GetEofData);
+            _extraSectionData = new LazyVariable<PEFile, ISegment?>(x =>x.GetExtraSectionData());
+            _eofData = new LazyVariable<PEFile, ISegment?>(x =>x.GetEofData());
             MappingMode = PEMappingMode.Unmapped;
         }
 
@@ -97,15 +97,15 @@ namespace AsmResolver.PE.File
         /// <inheritdoc />
         public ISegment? ExtraSectionData
         {
-            get => _extraSectionData.Value;
-            set => _extraSectionData.Value = value;
+            get => _extraSectionData.GetValue(this);
+            set => _extraSectionData.SetValue(value);
         }
 
         /// <inheritdoc />
         public ISegment? EofData
         {
-            get => _eofData.Value;
-            set => _eofData.Value = value;
+            get => _eofData.GetValue(this);
+            set => _eofData.SetValue(value);
         }
 
         /// <summary>

--- a/src/AsmResolver.PE/Debug/DebugDataEntry.cs
+++ b/src/AsmResolver.PE/Debug/DebugDataEntry.cs
@@ -21,14 +21,14 @@ namespace AsmResolver.PE.Debug
                 + sizeof(uint) // PointerToRawData
             ;
 
-        private readonly LazyVariable<IDebugDataSegment?> _contents;
+        private readonly LazyVariable<DebugDataEntry, IDebugDataSegment?> _contents;
 
         /// <summary>
         /// Initializes an empty <see cref="DebugDataEntry"/> instance.
         /// </summary>
         protected DebugDataEntry()
         {
-            _contents = new LazyVariable<IDebugDataSegment?>(GetContents);
+            _contents = new LazyVariable<DebugDataEntry, IDebugDataSegment?>(x => x.GetContents());
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace AsmResolver.PE.Debug
         /// <param name="contents">The contents.</param>
         public DebugDataEntry(IDebugDataSegment contents)
         {
-            _contents = new LazyVariable<IDebugDataSegment?>(contents);
+            _contents = new LazyVariable<DebugDataEntry, IDebugDataSegment?>(contents);
         }
 
         /// <summary>
@@ -81,8 +81,8 @@ namespace AsmResolver.PE.Debug
         /// </summary>
         public IDebugDataSegment? Contents
         {
-            get => _contents.Value;
-            set => _contents.Value = value;
+            get => _contents.GetValue(this);
+            set => _contents.SetValue(value);
         }
 
         /// <summary>

--- a/src/AsmResolver.PE/DotNet/DotNetDirectory.cs
+++ b/src/AsmResolver.PE/DotNet/DotNetDirectory.cs
@@ -11,26 +11,26 @@ namespace AsmResolver.PE.DotNet
     /// </summary>
     public class DotNetDirectory : SegmentBase, IDotNetDirectory
     {
-        private readonly LazyVariable<IMetadata?> _metadata;
-        private readonly LazyVariable<DotNetResourcesDirectory?> _resources;
-        private readonly LazyVariable<IReadableSegment?> _strongName;
-        private readonly LazyVariable<IReadableSegment?> _codeManagerTable;
-        private readonly LazyVariable<IReadableSegment?> _exportAddressTable;
-        private readonly LazyVariable<VTableFixupsDirectory?> _vtableFixups;
-        private readonly LazyVariable<IReadableSegment?> _managedNativeHeader;
+        private readonly LazyVariable<DotNetDirectory, IMetadata?> _metadata;
+        private readonly LazyVariable<DotNetDirectory, DotNetResourcesDirectory?> _resources;
+        private readonly LazyVariable<DotNetDirectory, IReadableSegment?> _strongName;
+        private readonly LazyVariable<DotNetDirectory, IReadableSegment?> _codeManagerTable;
+        private readonly LazyVariable<DotNetDirectory, IReadableSegment?> _exportAddressTable;
+        private readonly LazyVariable<DotNetDirectory, VTableFixupsDirectory?> _vtableFixups;
+        private readonly LazyVariable<DotNetDirectory, IReadableSegment?> _managedNativeHeader;
 
         /// <summary>
         /// Creates a new .NET data directory.
         /// </summary>
         public DotNetDirectory()
         {
-            _metadata = new LazyVariable<IMetadata?>(GetMetadata);
-            _resources = new LazyVariable<DotNetResourcesDirectory?>(GetResources);
-            _strongName = new LazyVariable<IReadableSegment?>(GetStrongName);
-            _codeManagerTable = new LazyVariable<IReadableSegment?>(GetCodeManagerTable);
-            _exportAddressTable = new LazyVariable<IReadableSegment?>(GetExportAddressTable);
-            _vtableFixups = new LazyVariable<VTableFixupsDirectory?>(GetVTableFixups);
-            _managedNativeHeader = new LazyVariable<IReadableSegment?>(GetManagedNativeHeader);
+            _metadata = new LazyVariable<DotNetDirectory, IMetadata?>(x => x.GetMetadata());
+            _resources = new LazyVariable<DotNetDirectory, DotNetResourcesDirectory?>(x => x.GetResources());
+            _strongName = new LazyVariable<DotNetDirectory, IReadableSegment?>(x => x.GetStrongName());
+            _codeManagerTable = new LazyVariable<DotNetDirectory, IReadableSegment?>(x => x.GetCodeManagerTable());
+            _exportAddressTable = new LazyVariable<DotNetDirectory, IReadableSegment?>(x => x.GetExportAddressTable());
+            _vtableFixups = new LazyVariable<DotNetDirectory, VTableFixupsDirectory?>(x => x.GetVTableFixups());
+            _managedNativeHeader = new LazyVariable<DotNetDirectory, IReadableSegment?>(x => x.GetManagedNativeHeader());
         }
 
         /// <inheritdoc />
@@ -50,8 +50,8 @@ namespace AsmResolver.PE.DotNet
         /// <inheritdoc />
         public IMetadata? Metadata
         {
-            get => _metadata.Value;
-            set => _metadata.Value = value;
+            get => _metadata.GetValue(this);
+            set => _metadata.SetValue(value);
         }
 
         /// <inheritdoc />
@@ -71,43 +71,43 @@ namespace AsmResolver.PE.DotNet
         /// <inheritdoc />
         public DotNetResourcesDirectory? DotNetResources
         {
-            get => _resources.Value;
-            set => _resources.Value = value;
+            get => _resources.GetValue(this);
+            set => _resources.SetValue(value);
         }
 
         /// <inheritdoc />
         public IReadableSegment? StrongName
         {
-            get => _strongName.Value;
-            set => _strongName.Value = value;
+            get => _strongName.GetValue(this);
+            set => _strongName.SetValue(value);
         }
 
         /// <inheritdoc />
         public IReadableSegment? CodeManagerTable
         {
-            get => _codeManagerTable.Value;
-            set => _codeManagerTable.Value = value;
+            get => _codeManagerTable.GetValue(this);
+            set => _codeManagerTable.SetValue(value);
         }
 
         /// <inheritdoc />
         public VTableFixupsDirectory? VTableFixups
         {
-            get => _vtableFixups.Value;
-            set => _vtableFixups.Value = value;
+            get => _vtableFixups.GetValue(this);
+            set => _vtableFixups.SetValue(value);
         }
 
         /// <inheritdoc />
         public IReadableSegment? ExportAddressTable
         {
-            get => _exportAddressTable.Value;
-            set => _exportAddressTable.Value = value;
+            get => _exportAddressTable.GetValue(this);
+            set => _exportAddressTable.SetValue(value);
         }
 
         /// <inheritdoc />
         public IReadableSegment? ManagedNativeHeader
         {
-            get => _managedNativeHeader.Value;
-            set => _managedNativeHeader.Value = value;
+            get => _managedNativeHeader.GetValue(this);
+            set => _managedNativeHeader.SetValue(value);
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/TablesStream.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/TablesStream.cs
@@ -33,16 +33,16 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables
         public const string UncompressedStreamName = "#Schema";
 
         private readonly Dictionary<CodedIndex, IndexEncoder> _indexEncoders;
-        private readonly LazyVariable<IList<IMetadataTable?>> _tables;
-        private readonly LazyVariable<IList<TableLayout>> _layouts;
+        private readonly LazyVariable<TablesStream, IList<IMetadataTable?>> _tables;
+        private readonly LazyVariable<TablesStream, IList<TableLayout>> _layouts;
 
         /// <summary>
         /// Creates a new, empty tables stream.
         /// </summary>
         public TablesStream()
         {
-            _layouts = new LazyVariable<IList<TableLayout>>(GetTableLayouts);
-            _tables = new LazyVariable<IList<IMetadataTable?>>(GetTables);
+            _layouts = new LazyVariable<TablesStream, IList<TableLayout>>(x => x.GetTableLayouts());
+            _tables = new LazyVariable<TablesStream, IList<IMetadataTable?>>(x => x.GetTables());
             _indexEncoders = CreateIndexEncoders();
         }
 
@@ -223,12 +223,12 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables
         /// This collection always contains all tables, in the same order as <see cref="TableIndex"/> defines, regardless
         /// of whether a table actually has elements or not.
         /// </remarks>
-        protected IList<IMetadataTable?> Tables => _tables.Value;
+        protected IList<IMetadataTable?> Tables => _tables.GetValue(this);
 
         /// <summary>
         /// Gets the layout of all tables in the stream.
         /// </summary>
-        protected IList<TableLayout> TableLayouts => _layouts.Value;
+        protected IList<TableLayout> TableLayouts => _layouts.GetValue(this);
 
         /// <inheritdoc />
         public virtual BinaryStreamReader CreateReader() => throw new NotSupportedException();

--- a/src/AsmResolver.PE/Exports/ExportDirectory.cs
+++ b/src/AsmResolver.PE/Exports/ExportDirectory.cs
@@ -10,7 +10,7 @@ namespace AsmResolver.PE.Exports
     /// </summary>
     public class ExportDirectory : IExportDirectory
     {
-        private readonly LazyVariable<string?> _name;
+        private readonly LazyVariable<ExportDirectory, string?> _name;
         private IList<ExportedSymbol>? _exports;
 
         /// <summary>
@@ -18,7 +18,7 @@ namespace AsmResolver.PE.Exports
         /// </summary>
         protected ExportDirectory()
         {
-            _name = new LazyVariable<string?>(GetName);
+            _name = new LazyVariable<ExportDirectory, string?>(x => x.GetName());
         }
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace AsmResolver.PE.Exports
         /// <param name="name">The name of the library exporting the symbols.</param>
         public ExportDirectory(string name)
         {
-            _name = new LazyVariable<string?>(name ?? throw new ArgumentNullException(nameof(name)));
+            _name = new LazyVariable<ExportDirectory, string?>(name ?? throw new ArgumentNullException(nameof(name)));
         }
 
         /// <inheritdoc />
@@ -61,8 +61,8 @@ namespace AsmResolver.PE.Exports
         /// <inheritdoc />
         public string? Name
         {
-            get => _name.Value;
-            set => _name.Value = value;
+            get => _name.GetValue(this);
+            set => _name.SetValue(value);
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/PEImage.cs
+++ b/src/AsmResolver.PE/PEImage.cs
@@ -21,13 +21,13 @@ namespace AsmResolver.PE
     public class PEImage : IPEImage
     {
         private IList<IImportedModule>? _imports;
-        private readonly LazyVariable<IExportDirectory?> _exports;
-        private readonly LazyVariable<IResourceDirectory?> _resources;
-        private readonly LazyVariable<IExceptionDirectory?> _exceptions;
+        private readonly LazyVariable<PEImage, IExportDirectory?> _exports;
+        private readonly LazyVariable<PEImage, IResourceDirectory?> _resources;
+        private readonly LazyVariable<PEImage, IExceptionDirectory?> _exceptions;
         private IList<BaseRelocation>? _relocations;
-        private readonly LazyVariable<IDotNetDirectory?> _dotNetDirectory;
+        private readonly LazyVariable<PEImage, IDotNetDirectory?> _dotNetDirectory;
         private IList<DebugDataEntry>? _debugData;
-        private readonly LazyVariable<ITlsDirectory?> _tlsDirectory;
+        private readonly LazyVariable<PEImage, ITlsDirectory?> _tlsDirectory;
 
         /// <summary>
         /// Opens a PE image from a specific file on the disk.
@@ -169,11 +169,11 @@ namespace AsmResolver.PE
         /// </summary>
         public PEImage()
         {
-            _exports = new LazyVariable<IExportDirectory?>(GetExports);
-            _resources = new LazyVariable<IResourceDirectory?>(GetResources);
-            _exceptions = new LazyVariable<IExceptionDirectory?>(GetExceptions);
-            _dotNetDirectory = new LazyVariable<IDotNetDirectory?>(GetDotNetDirectory);
-            _tlsDirectory = new LazyVariable<ITlsDirectory?>(GetTlsDirectory);
+            _exports = new LazyVariable<PEImage, IExportDirectory?>(x => x.GetExports());
+            _resources = new LazyVariable<PEImage, IResourceDirectory?>(x => x.GetResources());
+            _exceptions = new LazyVariable<PEImage, IExceptionDirectory?>(x => x.GetExceptions());
+            _dotNetDirectory = new LazyVariable<PEImage, IDotNetDirectory?>(x => x.GetDotNetDirectory());
+            _tlsDirectory = new LazyVariable<PEImage, ITlsDirectory?>(x => x.GetTlsDirectory());
         }
 
         /// <inheritdoc />
@@ -247,22 +247,22 @@ namespace AsmResolver.PE
         /// <inheritdoc />
         public IExportDirectory? Exports
         {
-            get => _exports.Value;
-            set => _exports.Value = value;
+            get => _exports.GetValue(this);
+            set => _exports.SetValue(value);
         }
 
         /// <inheritdoc />
         public IResourceDirectory? Resources
         {
-            get => _resources.Value;
-            set => _resources.Value = value;
+            get => _resources.GetValue(this);
+            set => _resources.SetValue(value);
         }
 
         /// <inheritdoc />
         public IExceptionDirectory? Exceptions
         {
-            get => _exceptions.Value;
-            set => _exceptions.Value = value;
+            get => _exceptions.GetValue(this);
+            set => _exceptions.SetValue(value);
         }
 
         /// <inheritdoc />
@@ -279,8 +279,8 @@ namespace AsmResolver.PE
         /// <inheritdoc />
         public IDotNetDirectory? DotNetDirectory
         {
-            get => _dotNetDirectory.Value;
-            set => _dotNetDirectory.Value = value;
+            get => _dotNetDirectory.GetValue(this);
+            set => _dotNetDirectory.SetValue(value);
         }
 
         /// <inheritdoc />
@@ -297,8 +297,8 @@ namespace AsmResolver.PE
         /// <inheritdoc />
         public ITlsDirectory? TlsDirectory
         {
-            get => _tlsDirectory.Value;
-            set => _tlsDirectory.Value = value;
+            get => _tlsDirectory.GetValue(this);
+            set => _tlsDirectory.SetValue(value);
         }
 
         /// <summary>

--- a/src/AsmResolver.PE/Tls/TlsDirectory.cs
+++ b/src/AsmResolver.PE/Tls/TlsDirectory.cs
@@ -10,7 +10,7 @@ namespace AsmResolver.PE.Tls
     /// </summary>
     public class TlsDirectory : SegmentBase, ITlsDirectory
     {
-        private readonly LazyVariable<IReadableSegment?> _templateData;
+        private readonly LazyVariable<TlsDirectory, IReadableSegment?> _templateData;
         private TlsCallbackCollection? _callbackFunctions;
         private ulong _imageBase = 0x00400000;
         private bool _is32Bit = true;
@@ -20,15 +20,15 @@ namespace AsmResolver.PE.Tls
         /// </summary>
         public TlsDirectory()
         {
-            _templateData = new LazyVariable<IReadableSegment?>(GetTemplateData);
+            _templateData = new LazyVariable<TlsDirectory, IReadableSegment?>(x => x.GetTemplateData());
             Index = SegmentReference.Null;
         }
 
         /// <inheritdoc />
         public IReadableSegment? TemplateData
         {
-            get => _templateData.Value;
-            set => _templateData.Value = value;
+            get => _templateData.GetValue(this);
+            set => _templateData.SetValue(value);
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.PE/Win32Resources/ResourceData.cs
+++ b/src/AsmResolver.PE/Win32Resources/ResourceData.cs
@@ -9,14 +9,14 @@ namespace AsmResolver.PE.Win32Resources
     /// </summary>
     public class ResourceData : IResourceData
     {
-        private readonly LazyVariable<ISegment?> _contents;
+        private readonly LazyVariable<ResourceData, ISegment?> _contents;
 
         /// <summary>
         /// Initializes a new resource data entry.
         /// </summary>
         protected ResourceData()
         {
-            _contents = new LazyVariable<ISegment?>(GetContents);
+            _contents = new LazyVariable<ResourceData, ISegment?>(x => x.GetContents());
         }
 
         /// <summary>
@@ -79,8 +79,8 @@ namespace AsmResolver.PE.Win32Resources
         /// <inheritdoc />
         public ISegment? Contents
         {
-            get => _contents.Value;
-            set => _contents.Value = value;
+            get => _contents.GetValue(this);
+            set => _contents.SetValue(value);
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.Symbols.Pdb/Leaves/ArrayTypeRecord.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/ArrayTypeRecord.cs
@@ -5,9 +5,9 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public class ArrayTypeRecord : CodeViewTypeRecord
 {
-    private readonly LazyVariable<CodeViewTypeRecord?> _elementType;
-    private readonly LazyVariable<CodeViewTypeRecord?> _indexType;
-    private readonly LazyVariable<Utf8String> _name;
+    private readonly LazyVariable<ArrayTypeRecord, CodeViewTypeRecord?> _elementType;
+    private readonly LazyVariable<ArrayTypeRecord, CodeViewTypeRecord?> _indexType;
+    private readonly LazyVariable<ArrayTypeRecord, Utf8String> _name;
 
     /// <summary>
     /// Initializes a new empty array type.
@@ -16,9 +16,9 @@ public class ArrayTypeRecord : CodeViewTypeRecord
     protected ArrayTypeRecord(uint typeIndex)
         : base(typeIndex)
     {
-        _elementType = new LazyVariable<CodeViewTypeRecord?>(GetElementType);
-        _indexType = new LazyVariable<CodeViewTypeRecord?>(GetIndexType);
-        _name = new LazyVariable<Utf8String>(GetName);
+        _elementType = new LazyVariable<ArrayTypeRecord, CodeViewTypeRecord?>(x => x.GetElementType());
+        _indexType = new LazyVariable<ArrayTypeRecord, CodeViewTypeRecord?>(x => x.GetIndexType());
+        _name = new LazyVariable<ArrayTypeRecord, Utf8String>(x => x.GetName());
     }
 
     /// <summary>
@@ -30,10 +30,10 @@ public class ArrayTypeRecord : CodeViewTypeRecord
     public ArrayTypeRecord(CodeViewTypeRecord elementType, CodeViewTypeRecord indexType, ulong length)
         : base(0)
     {
-        _elementType = new LazyVariable<CodeViewTypeRecord?>(elementType);
-        _indexType = new LazyVariable<CodeViewTypeRecord?>(indexType);
+        _elementType = new LazyVariable<ArrayTypeRecord, CodeViewTypeRecord?>(elementType);
+        _indexType = new LazyVariable<ArrayTypeRecord, CodeViewTypeRecord?>(indexType);
+        _name = new LazyVariable<ArrayTypeRecord, Utf8String>(Utf8String.Empty);
         Length = length;
-        _name = new LazyVariable<Utf8String>(Utf8String.Empty);
     }
 
     /// <summary>
@@ -46,10 +46,10 @@ public class ArrayTypeRecord : CodeViewTypeRecord
     public ArrayTypeRecord(CodeViewTypeRecord elementType, CodeViewTypeRecord indexType, ulong length, Utf8String name)
         : base(0)
     {
-        _elementType = new LazyVariable<CodeViewTypeRecord?>(elementType);
-        _indexType = new LazyVariable<CodeViewTypeRecord?>(indexType);
+        _elementType = new LazyVariable<ArrayTypeRecord, CodeViewTypeRecord?>(elementType);
+        _indexType = new LazyVariable<ArrayTypeRecord, CodeViewTypeRecord?>(indexType);
+        _name = new LazyVariable<ArrayTypeRecord, Utf8String>(name);
         Length = length;
-        _name = new LazyVariable<Utf8String>(Name);
     }
 
     /// <inheritdoc />
@@ -60,8 +60,8 @@ public class ArrayTypeRecord : CodeViewTypeRecord
     /// </summary>
     public CodeViewTypeRecord? ElementType
     {
-        get => _elementType.Value;
-        set => _elementType.Value = value;
+        get => _elementType.GetValue(this);
+        set => _elementType.SetValue(value);
     }
 
     /// <summary>
@@ -69,8 +69,8 @@ public class ArrayTypeRecord : CodeViewTypeRecord
     /// </summary>
     public CodeViewTypeRecord? IndexType
     {
-        get => _indexType.Value;
-        set => _indexType.Value = value;
+        get => _indexType.GetValue(this);
+        set => _indexType.SetValue(value);
     }
 
     /// <summary>
@@ -87,8 +87,8 @@ public class ArrayTypeRecord : CodeViewTypeRecord
     /// </summary>
     public Utf8String Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/BaseClassField.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/BaseClassField.cs
@@ -5,7 +5,7 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public class BaseClassField : CodeViewField
 {
-    private readonly LazyVariable<CodeViewTypeRecord?> _type;
+    private readonly LazyVariable<BaseClassField, CodeViewTypeRecord?> _type;
 
     /// <summary>
     /// Initializes an empty base class.
@@ -14,7 +14,7 @@ public class BaseClassField : CodeViewField
     protected BaseClassField(uint typeIndex)
         : base(typeIndex)
     {
-        _type = new LazyVariable<CodeViewTypeRecord?>(GetBaseType);
+        _type = new LazyVariable<BaseClassField, CodeViewTypeRecord?>(x => x.GetBaseType());
     }
 
     /// <summary>
@@ -24,7 +24,7 @@ public class BaseClassField : CodeViewField
     public BaseClassField(CodeViewTypeRecord type)
         : base(0)
     {
-        _type = new LazyVariable<CodeViewTypeRecord?>(type);
+        _type = new LazyVariable<BaseClassField, CodeViewTypeRecord?>(type);
     }
 
     /// <inheritdoc />
@@ -35,8 +35,8 @@ public class BaseClassField : CodeViewField
     /// </summary>
     public CodeViewTypeRecord? Type
     {
-        get => _type.Value;
-        set => _type.Value = value;
+        get => _type.GetValue(this);
+        set => _type.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/BitFieldTypeRecord.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/BitFieldTypeRecord.cs
@@ -5,7 +5,7 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public class BitFieldTypeRecord : CodeViewTypeRecord
 {
-    private readonly LazyVariable<CodeViewTypeRecord?> _type;
+    private readonly LazyVariable<BitFieldTypeRecord, CodeViewTypeRecord?> _type;
 
     /// <summary>
     /// Initializes an empty bit field record.
@@ -14,7 +14,7 @@ public class BitFieldTypeRecord : CodeViewTypeRecord
     protected BitFieldTypeRecord(uint typeIndex)
         : base(typeIndex)
     {
-        _type = new LazyVariable<CodeViewTypeRecord?>(GetBaseType);
+        _type = new LazyVariable<BitFieldTypeRecord, CodeViewTypeRecord?>(x => x.GetBaseType());
     }
 
     /// <summary>
@@ -26,7 +26,7 @@ public class BitFieldTypeRecord : CodeViewTypeRecord
     public BitFieldTypeRecord(CodeViewTypeRecord type, byte position, byte length)
         : base(0)
     {
-        _type = new LazyVariable<CodeViewTypeRecord?>(type);
+        _type = new LazyVariable<BitFieldTypeRecord, CodeViewTypeRecord?>(type);
         Position = position;
         Length = length;
     }
@@ -39,8 +39,8 @@ public class BitFieldTypeRecord : CodeViewTypeRecord
     /// </summary>
     public CodeViewTypeRecord? Type
     {
-        get => _type.Value;
-        set => _type.Value = value;
+        get => _type.GetValue(this);
+        set => _type.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/ClassTypeRecord.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/ClassTypeRecord.cs
@@ -7,8 +7,8 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public class ClassTypeRecord : CodeViewDerivedTypeRecord
 {
-    private readonly LazyVariable<Utf8String> _uniqueName;
-    private readonly LazyVariable<VTableShapeLeaf?> _vtableShape;
+    private readonly LazyVariable<ClassTypeRecord, Utf8String> _uniqueName;
+    private readonly LazyVariable<ClassTypeRecord, VTableShapeLeaf?> _vtableShape;
 
     /// <summary>
     /// Initializes an empty class type.
@@ -25,8 +25,8 @@ public class ClassTypeRecord : CodeViewDerivedTypeRecord
             throw new ArgumentOutOfRangeException(nameof(kind));
 
         LeafKind = kind;
-        _uniqueName = new LazyVariable<Utf8String>(GetUniqueName);
-        _vtableShape = new LazyVariable<VTableShapeLeaf?>(GetVTableShape);
+        _uniqueName = new LazyVariable<ClassTypeRecord, Utf8String>(x => x.GetUniqueName());
+        _vtableShape = new LazyVariable<ClassTypeRecord, VTableShapeLeaf?>(x => x.GetVTableShape());
     }
 
     /// <summary>
@@ -50,8 +50,8 @@ public class ClassTypeRecord : CodeViewDerivedTypeRecord
 
         LeafKind = kind;
         Name = name;
-        _uniqueName = new LazyVariable<Utf8String>(uniqueName);
-        _vtableShape = new LazyVariable<VTableShapeLeaf?>(default(VTableShapeLeaf));
+        _uniqueName = new LazyVariable<ClassTypeRecord, Utf8String>(uniqueName);
+        _vtableShape = new LazyVariable<ClassTypeRecord, VTableShapeLeaf?>(default(VTableShapeLeaf));
         Size = size;
         StructureAttributes = attributes;
         BaseType = baseType;
@@ -77,8 +77,8 @@ public class ClassTypeRecord : CodeViewDerivedTypeRecord
     /// </summary>
     public Utf8String UniqueName
     {
-        get => _uniqueName.Value;
-        set => _uniqueName.Value = value;
+        get => _uniqueName.GetValue(this);
+        set => _uniqueName.SetValue(value);
     }
 
     /// <summary>
@@ -86,8 +86,8 @@ public class ClassTypeRecord : CodeViewDerivedTypeRecord
     /// </summary>
     public VTableShapeLeaf? VTableShape
     {
-        get => _vtableShape.Value;
-        set => _vtableShape.Value = value;
+        get => _vtableShape.GetValue(this);
+        set => _vtableShape.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/CodeViewCompositeTypeRecord.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/CodeViewCompositeTypeRecord.cs
@@ -5,8 +5,8 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public abstract class CodeViewCompositeTypeRecord : CodeViewTypeRecord
 {
-    private readonly LazyVariable<Utf8String> _name;
-    private readonly LazyVariable<FieldListLeaf?> _fields;
+    private readonly LazyVariable<CodeViewCompositeTypeRecord, Utf8String> _name;
+    private readonly LazyVariable<CodeViewCompositeTypeRecord, FieldListLeaf?> _fields;
 
     /// <summary>
     /// Initializes a new empty composite type.
@@ -15,8 +15,8 @@ public abstract class CodeViewCompositeTypeRecord : CodeViewTypeRecord
     protected CodeViewCompositeTypeRecord(uint typeIndex)
         : base(typeIndex)
     {
-        _name = new LazyVariable<Utf8String>(GetName);
-        _fields = new LazyVariable<FieldListLeaf?>(GetFields);
+        _name = new LazyVariable<CodeViewCompositeTypeRecord, Utf8String>(x => x.GetName());
+        _fields = new LazyVariable<CodeViewCompositeTypeRecord, FieldListLeaf?>(x => x.GetFields());
     }
 
     /// <summary>
@@ -33,8 +33,8 @@ public abstract class CodeViewCompositeTypeRecord : CodeViewTypeRecord
     /// </summary>
     public Utf8String Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <summary>
@@ -42,8 +42,8 @@ public abstract class CodeViewCompositeTypeRecord : CodeViewTypeRecord
     /// </summary>
     public FieldListLeaf? Fields
     {
-        get => _fields.Value;
-        set => _fields.Value = value;
+        get => _fields.GetValue(this);
+        set => _fields.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/CodeViewDataField.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/CodeViewDataField.cs
@@ -5,7 +5,7 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public abstract class CodeViewDataField : CodeViewNamedField
 {
-    private readonly LazyVariable<CodeViewTypeRecord> _dataType;
+    private readonly LazyVariable<CodeViewDataField, CodeViewTypeRecord> _dataType;
 
     /// <summary>
     /// Initializes an empty instance data member.
@@ -14,7 +14,7 @@ public abstract class CodeViewDataField : CodeViewNamedField
     protected CodeViewDataField(uint typeIndex)
         : base(typeIndex)
     {
-        _dataType = new LazyVariable<CodeViewTypeRecord>(GetDataType);
+        _dataType = new LazyVariable<CodeViewDataField, CodeViewTypeRecord>(x => x.GetDataType());
     }
 
     /// <summary>
@@ -25,7 +25,7 @@ public abstract class CodeViewDataField : CodeViewNamedField
     protected CodeViewDataField(CodeViewTypeRecord dataType, Utf8String name)
         : base(0)
     {
-        _dataType = new LazyVariable<CodeViewTypeRecord>(dataType);
+        _dataType = new LazyVariable<CodeViewDataField, CodeViewTypeRecord>(dataType);
         Name = name;
     }
 
@@ -34,8 +34,8 @@ public abstract class CodeViewDataField : CodeViewNamedField
     /// </summary>
     public CodeViewTypeRecord DataType
     {
-        get => _dataType.Value;
-        set => _dataType.Value = value;
+        get => _dataType.GetValue(this);
+        set => _dataType.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/CodeViewDerivedTypeRecord.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/CodeViewDerivedTypeRecord.cs
@@ -5,13 +5,13 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public abstract class CodeViewDerivedTypeRecord : CodeViewCompositeTypeRecord
 {
-    private readonly LazyVariable<CodeViewTypeRecord?> _baseType;
+    private readonly LazyVariable<CodeViewDerivedTypeRecord, CodeViewTypeRecord?> _baseType;
 
     /// <inheritdoc />
     protected CodeViewDerivedTypeRecord(uint typeIndex)
         : base(typeIndex)
     {
-        _baseType = new LazyVariable<CodeViewTypeRecord?>(GetBaseType);
+        _baseType = new LazyVariable<CodeViewDerivedTypeRecord, CodeViewTypeRecord?>(x => x.GetBaseType());
     }
 
     /// <summary>
@@ -19,8 +19,8 @@ public abstract class CodeViewDerivedTypeRecord : CodeViewCompositeTypeRecord
     /// </summary>
     public CodeViewTypeRecord? BaseType
     {
-        get => _baseType.Value;
-        set => _baseType.Value = value;
+        get => _baseType.GetValue(this);
+        set => _baseType.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/CodeViewNamedField.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/CodeViewNamedField.cs
@@ -5,7 +5,7 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public abstract class CodeViewNamedField : CodeViewField
 {
-    private readonly LazyVariable<Utf8String> _name;
+    private readonly LazyVariable<CodeViewNamedField, Utf8String> _name;
 
     /// <summary>
     /// Initializes an empty CodeView field leaf.
@@ -14,7 +14,7 @@ public abstract class CodeViewNamedField : CodeViewField
     protected CodeViewNamedField(uint typeIndex)
         : base(typeIndex)
     {
-        _name = new LazyVariable<Utf8String>(GetName);
+        _name = new LazyVariable<CodeViewNamedField, Utf8String>(x => x.GetName());
     }
 
     /// <summary>
@@ -22,8 +22,8 @@ public abstract class CodeViewNamedField : CodeViewField
     /// </summary>
     public Utf8String Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/EnumerateField.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/EnumerateField.cs
@@ -5,7 +5,7 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public class EnumerateField : CodeViewNamedField
 {
-    private readonly LazyVariable<object> _value;
+    private readonly LazyVariable<EnumerateField, object> _value;
 
     /// <summary>
     /// Initializes an empty enumerate field leaf.
@@ -14,7 +14,7 @@ public class EnumerateField : CodeViewNamedField
     protected EnumerateField(uint typeIndex)
         : base(typeIndex)
     {
-        _value = new LazyVariable<object>(GetValue);
+        _value = new LazyVariable<EnumerateField, object>(x => x.GetValue());
     }
 
     /// <summary>
@@ -27,7 +27,7 @@ public class EnumerateField : CodeViewNamedField
         : base(0)
     {
         Name = name;
-        _value = new LazyVariable<object>(value);
+        _value = new LazyVariable<EnumerateField, object>(value);
         Attributes = attributes;
     }
 
@@ -39,8 +39,8 @@ public class EnumerateField : CodeViewNamedField
     /// </summary>
     public object Value
     {
-        get => _value.Value;
-        set => _value.Value = value;
+        get => _value.GetValue(this);
+        set => _value.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/FunctionIdentifier.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/FunctionIdentifier.cs
@@ -5,8 +5,8 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public class FunctionIdentifier : CodeViewLeaf, IIpiLeaf
 {
-    private readonly LazyVariable<Utf8String?> _name;
-    private readonly LazyVariable<CodeViewTypeRecord?> _functionType;
+    private readonly LazyVariable<FunctionIdentifier, Utf8String?> _name;
+    private readonly LazyVariable<FunctionIdentifier, CodeViewTypeRecord?> _functionType;
 
     /// <summary>
     /// Initializes an empty function identifier leaf.
@@ -15,8 +15,8 @@ public class FunctionIdentifier : CodeViewLeaf, IIpiLeaf
     protected FunctionIdentifier(uint typeIndex)
         : base(typeIndex)
     {
-        _name = new LazyVariable<Utf8String?>(GetName);
-        _functionType = new LazyVariable<CodeViewTypeRecord?>(GetFunctionType);
+        _name = new LazyVariable<FunctionIdentifier, Utf8String?>(x => x.GetName());
+        _functionType = new LazyVariable<FunctionIdentifier, CodeViewTypeRecord?>(x => x.GetFunctionType());
     }
 
     /// <summary>
@@ -29,8 +29,8 @@ public class FunctionIdentifier : CodeViewLeaf, IIpiLeaf
         : base(0)
     {
         ScopeId = scopeId;
-        _name = new LazyVariable<Utf8String?>(name);
-        _functionType = new LazyVariable<CodeViewTypeRecord?>(functionType);
+        _name = new LazyVariable<FunctionIdentifier, Utf8String?>(name);
+        _functionType = new LazyVariable<FunctionIdentifier, CodeViewTypeRecord?>(functionType);
     }
 
     /// <inheritdoc />
@@ -50,8 +50,8 @@ public class FunctionIdentifier : CodeViewLeaf, IIpiLeaf
     /// </summary>
     public Utf8String? Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <summary>
@@ -59,8 +59,8 @@ public class FunctionIdentifier : CodeViewLeaf, IIpiLeaf
     /// </summary>
     public CodeViewTypeRecord? FunctionType
     {
-        get => _functionType.Value;
-        set => _functionType.Value = value;
+        get => _functionType.GetValue(this);
+        set => _functionType.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/MemberFunctionLeaf.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/MemberFunctionLeaf.cs
@@ -7,10 +7,10 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public class MemberFunctionLeaf : CodeViewLeaf, ITpiLeaf
 {
-    private readonly LazyVariable<CodeViewTypeRecord?> _returnType;
-    private readonly LazyVariable<CodeViewTypeRecord?> _declaringType;
-    private readonly LazyVariable<CodeViewTypeRecord?> _thisType;
-    private readonly LazyVariable<ArgumentListLeaf?> _argumentList;
+    private readonly LazyVariable<MemberFunctionLeaf, CodeViewTypeRecord?> _returnType;
+    private readonly LazyVariable<MemberFunctionLeaf, CodeViewTypeRecord?> _declaringType;
+    private readonly LazyVariable<MemberFunctionLeaf, CodeViewTypeRecord?> _thisType;
+    private readonly LazyVariable<MemberFunctionLeaf, ArgumentListLeaf?> _argumentList;
 
     /// <summary>
     /// Initializes an empty member function.
@@ -19,10 +19,10 @@ public class MemberFunctionLeaf : CodeViewLeaf, ITpiLeaf
     protected MemberFunctionLeaf(uint typeIndex)
         : base(typeIndex)
     {
-        _returnType = new LazyVariable<CodeViewTypeRecord?>(GetReturnType);
-        _declaringType = new LazyVariable<CodeViewTypeRecord?>(GetDeclaringType);
-        _thisType = new LazyVariable<CodeViewTypeRecord?>(GetThisType);
-        _argumentList = new LazyVariable<ArgumentListLeaf?>(GetArguments);
+        _returnType = new LazyVariable<MemberFunctionLeaf, CodeViewTypeRecord?>(x => x.GetReturnType());
+        _declaringType = new LazyVariable<MemberFunctionLeaf, CodeViewTypeRecord?>(x => x.GetDeclaringType());
+        _thisType = new LazyVariable<MemberFunctionLeaf, CodeViewTypeRecord?>(x => x.GetThisType());
+        _argumentList = new LazyVariable<MemberFunctionLeaf, ArgumentListLeaf?>(x => x.GetArguments());
     }
 
     /// <summary>
@@ -34,10 +34,10 @@ public class MemberFunctionLeaf : CodeViewLeaf, ITpiLeaf
     public MemberFunctionLeaf(CodeViewTypeRecord returnType, CodeViewTypeRecord declaringType, ArgumentListLeaf arguments)
         : base(0)
     {
-        _returnType = new LazyVariable<CodeViewTypeRecord?>(returnType);
-        _declaringType = new LazyVariable<CodeViewTypeRecord?>(declaringType);
-        _thisType = new LazyVariable<CodeViewTypeRecord?>(default(CodeViewTypeRecord));
-        _argumentList = new LazyVariable<ArgumentListLeaf?>(arguments);
+        _returnType = new LazyVariable<MemberFunctionLeaf, CodeViewTypeRecord?>(returnType);
+        _declaringType = new LazyVariable<MemberFunctionLeaf, CodeViewTypeRecord?>(declaringType);
+        _thisType = new LazyVariable<MemberFunctionLeaf, CodeViewTypeRecord?>(default(CodeViewTypeRecord));
+        _argumentList = new LazyVariable<MemberFunctionLeaf, ArgumentListLeaf?>(arguments);
         CallingConvention = CodeViewCallingConvention.NearC;
         Attributes = 0;
         ThisAdjuster = 0;
@@ -51,8 +51,8 @@ public class MemberFunctionLeaf : CodeViewLeaf, ITpiLeaf
     /// </summary>
     public CodeViewTypeRecord? ReturnType
     {
-        get => _returnType.Value;
-        set => _returnType.Value = value;
+        get => _returnType.GetValue(this);
+        set => _returnType.SetValue(value);
     }
 
     /// <summary>
@@ -60,8 +60,8 @@ public class MemberFunctionLeaf : CodeViewLeaf, ITpiLeaf
     /// </summary>
     public CodeViewTypeRecord? DeclaringType
     {
-        get => _declaringType.Value;
-        set => _declaringType.Value = value;
+        get => _declaringType.GetValue(this);
+        set => _declaringType.SetValue(value);
     }
 
     /// <summary>
@@ -69,8 +69,8 @@ public class MemberFunctionLeaf : CodeViewLeaf, ITpiLeaf
     /// </summary>
     public CodeViewTypeRecord? ThisType
     {
-        get => _thisType.Value;
-        set => _thisType.Value = value;
+        get => _thisType.GetValue(this);
+        set => _thisType.SetValue(value);
     }
 
     /// <summary>
@@ -96,8 +96,8 @@ public class MemberFunctionLeaf : CodeViewLeaf, ITpiLeaf
     /// </summary>
     public ArgumentListLeaf? Arguments
     {
-        get => _argumentList.Value;
-        set => _argumentList.Value = value;
+        get => _argumentList.GetValue(this);
+        set => _argumentList.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/MethodListEntry.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/MethodListEntry.cs
@@ -5,14 +5,14 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public class MethodListEntry
 {
-    private readonly LazyVariable<MemberFunctionLeaf?> _function;
+    private readonly LazyVariable<MethodListEntry, MemberFunctionLeaf?> _function;
 
     /// <summary>
     /// Initializes an empty method list entry.
     /// </summary>
     protected MethodListEntry()
     {
-        _function = new LazyVariable<MemberFunctionLeaf?>(GetFunction);
+        _function = new LazyVariable<MethodListEntry, MemberFunctionLeaf?>(x => x.GetFunction());
     }
 
     /// <summary>
@@ -23,7 +23,7 @@ public class MethodListEntry
     public MethodListEntry(CodeViewFieldAttributes attributes, MemberFunctionLeaf function)
     {
         Attributes = attributes;
-        _function = new LazyVariable<MemberFunctionLeaf?>(function);
+        _function = new LazyVariable<MethodListEntry, MemberFunctionLeaf?>(function);
         VTableOffset = 0;
     }
 
@@ -36,7 +36,7 @@ public class MethodListEntry
     public MethodListEntry(CodeViewFieldAttributes attributes, MemberFunctionLeaf function, uint vTableOffset)
     {
         Attributes = attributes;
-        _function = new LazyVariable<MemberFunctionLeaf?>(function);
+        _function = new LazyVariable<MethodListEntry, MemberFunctionLeaf?>(function);
         VTableOffset = vTableOffset;
     }
 
@@ -54,8 +54,8 @@ public class MethodListEntry
     /// </summary>
     public MemberFunctionLeaf? Function
     {
-        get => _function.Value;
-        set => _function.Value = value;
+        get => _function.GetValue(this);
+        set => _function.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/ModifierTypeRecord.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/ModifierTypeRecord.cs
@@ -5,7 +5,7 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public class ModifierTypeRecord : CodeViewTypeRecord
 {
-    private readonly LazyVariable<CodeViewTypeRecord> _baseType;
+    private readonly LazyVariable<ModifierTypeRecord, CodeViewTypeRecord> _baseType;
 
     /// <summary>
     /// Initializes a new empty modifier type.
@@ -14,7 +14,7 @@ public class ModifierTypeRecord : CodeViewTypeRecord
     protected ModifierTypeRecord(uint typeIndex)
         : base(typeIndex)
     {
-        _baseType = new LazyVariable<CodeViewTypeRecord>(GetBaseType);
+        _baseType = new LazyVariable<ModifierTypeRecord, CodeViewTypeRecord>(x => x.GetBaseType());
     }
 
     /// <summary>
@@ -25,7 +25,7 @@ public class ModifierTypeRecord : CodeViewTypeRecord
     public ModifierTypeRecord(CodeViewTypeRecord type, ModifierAttributes attributes)
         : base(0)
     {
-        _baseType = new LazyVariable<CodeViewTypeRecord>(type);
+        _baseType = new LazyVariable<ModifierTypeRecord, CodeViewTypeRecord>(type);
         Attributes = attributes;
     }
 
@@ -37,8 +37,8 @@ public class ModifierTypeRecord : CodeViewTypeRecord
     /// </summary>
     public CodeViewTypeRecord BaseType
     {
-        get => _baseType.Value;
-        set => _baseType.Value = value;
+        get => _baseType.GetValue(this);
+        set => _baseType.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/NestedTypeField.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/NestedTypeField.cs
@@ -5,7 +5,7 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public class NestedTypeField : CodeViewNamedField
 {
-    private readonly LazyVariable<CodeViewTypeRecord?> _type;
+    private readonly LazyVariable<NestedTypeField, CodeViewTypeRecord?> _type;
 
     /// <summary>
     /// Initializes an empty nested type.
@@ -14,7 +14,7 @@ public class NestedTypeField : CodeViewNamedField
     protected NestedTypeField(uint typeIndex)
         : base(typeIndex)
     {
-        _type = new LazyVariable<CodeViewTypeRecord?>(GetNestedType);
+        _type = new LazyVariable<NestedTypeField, CodeViewTypeRecord?>(x => x.GetNestedType());
     }
 
     /// <summary>
@@ -25,7 +25,7 @@ public class NestedTypeField : CodeViewNamedField
     public NestedTypeField(CodeViewTypeRecord type, Utf8String name)
         : base(0)
     {
-        _type = new LazyVariable<CodeViewTypeRecord?>(type);
+        _type = new LazyVariable<NestedTypeField, CodeViewTypeRecord?>(type);
         Name = name;
         Attributes = 0;
     }
@@ -39,7 +39,7 @@ public class NestedTypeField : CodeViewNamedField
     public NestedTypeField(CodeViewTypeRecord type, Utf8String name, CodeViewFieldAttributes attributes)
         : base(0)
     {
-        _type = new LazyVariable<CodeViewTypeRecord?>(type);
+        _type = new LazyVariable<NestedTypeField, CodeViewTypeRecord?>(type);
         Name = name;
         Attributes = attributes;
     }
@@ -54,8 +54,8 @@ public class NestedTypeField : CodeViewNamedField
     /// </summary>
     public CodeViewTypeRecord? Type
     {
-        get => _type.Value;
-        set => _type.Value = value;
+        get => _type.GetValue(this);
+        set => _type.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/NonOverloadedMethod.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/NonOverloadedMethod.cs
@@ -5,7 +5,7 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public class NonOverloadedMethod : CodeViewNamedField
 {
-    private readonly LazyVariable<MemberFunctionLeaf?> _function;
+    private readonly LazyVariable<NonOverloadedMethod, MemberFunctionLeaf?> _function;
 
     /// <summary>
     /// Initializes an empty non-overloaded method.
@@ -14,7 +14,7 @@ public class NonOverloadedMethod : CodeViewNamedField
     protected NonOverloadedMethod(uint typeIndex)
         : base(typeIndex)
     {
-        _function = new LazyVariable<MemberFunctionLeaf?>(GetFunction);
+        _function = new LazyVariable<NonOverloadedMethod, MemberFunctionLeaf?>(x => x.GetFunction());
     }
 
     /// <summary>
@@ -26,7 +26,7 @@ public class NonOverloadedMethod : CodeViewNamedField
     public NonOverloadedMethod(Utf8String name, CodeViewFieldAttributes attributes, MemberFunctionLeaf function)
         : base(0)
     {
-        _function = new LazyVariable<MemberFunctionLeaf?>(function);
+        _function = new LazyVariable<NonOverloadedMethod, MemberFunctionLeaf?>(function);
         Attributes = attributes;
         Name = name;
     }
@@ -41,7 +41,7 @@ public class NonOverloadedMethod : CodeViewNamedField
     public NonOverloadedMethod(Utf8String name, CodeViewFieldAttributes attributes, uint vTableOffset, MemberFunctionLeaf function)
         : base(0)
     {
-        _function = new LazyVariable<MemberFunctionLeaf?>(function);
+        _function = new LazyVariable<NonOverloadedMethod, MemberFunctionLeaf?>(function);
         Attributes = attributes;
         Name = name;
         VTableOffset = vTableOffset;
@@ -55,8 +55,8 @@ public class NonOverloadedMethod : CodeViewNamedField
     /// </summary>
     public MemberFunctionLeaf? Function
     {
-        get => _function.Value;
-        set => _function.Value = value;
+        get => _function.GetValue(this);
+        set => _function.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/OverloadedMethod.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/OverloadedMethod.cs
@@ -5,7 +5,7 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public class OverloadedMethod : CodeViewNamedField
 {
-    private readonly LazyVariable<MethodListLeaf?> _methods;
+    private readonly LazyVariable<OverloadedMethod, MethodListLeaf?> _methods;
 
     /// <summary>
     /// Initializes an empty overloaded method.
@@ -14,7 +14,7 @@ public class OverloadedMethod : CodeViewNamedField
     protected OverloadedMethod(uint typeIndex)
         : base(typeIndex)
     {
-        _methods = new LazyVariable<MethodListLeaf?>(GetMethods);
+        _methods = new LazyVariable<OverloadedMethod, MethodListLeaf?>(x => x.GetMethods());
     }
 
     /// <summary>
@@ -23,7 +23,7 @@ public class OverloadedMethod : CodeViewNamedField
     public OverloadedMethod()
         : base(0)
     {
-        _methods = new LazyVariable<MethodListLeaf?>(new MethodListLeaf());
+        _methods = new LazyVariable<OverloadedMethod, MethodListLeaf?>(new MethodListLeaf());
     }
 
     /// <summary>
@@ -32,7 +32,7 @@ public class OverloadedMethod : CodeViewNamedField
     public OverloadedMethod(MethodListLeaf methods)
         : base(0)
     {
-        _methods = new LazyVariable<MethodListLeaf?>(methods);
+        _methods = new LazyVariable<OverloadedMethod, MethodListLeaf?>(methods);
     }
 
     /// <summary>
@@ -41,7 +41,7 @@ public class OverloadedMethod : CodeViewNamedField
     public OverloadedMethod(params MethodListEntry[] methods)
         : base(0)
     {
-        _methods = new LazyVariable<MethodListLeaf?>(new MethodListLeaf(methods));
+        _methods = new LazyVariable<OverloadedMethod, MethodListLeaf?>(new MethodListLeaf(methods));
     }
 
     /// <inheritdoc />
@@ -52,8 +52,8 @@ public class OverloadedMethod : CodeViewNamedField
     /// </summary>
     public MethodListLeaf? Methods
     {
-        get => _methods.Value;
-        set => _methods.Value = value;
+        get => _methods.GetValue(this);
+        set => _methods.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/PointerTypeRecord.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/PointerTypeRecord.cs
@@ -5,7 +5,7 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public class PointerTypeRecord : CodeViewTypeRecord
 {
-    private readonly LazyVariable<CodeViewTypeRecord> _baseType;
+    private readonly LazyVariable<PointerTypeRecord, CodeViewTypeRecord> _baseType;
 
     /// <summary>
     /// Initializes a new empty pointer type.
@@ -14,7 +14,7 @@ public class PointerTypeRecord : CodeViewTypeRecord
     protected PointerTypeRecord(uint typeIndex)
         : base(typeIndex)
     {
-        _baseType = new LazyVariable<CodeViewTypeRecord>(GetBaseType);
+        _baseType = new LazyVariable<PointerTypeRecord, CodeViewTypeRecord>(x => x.GetBaseType());
     }
 
     /// <summary>
@@ -25,7 +25,7 @@ public class PointerTypeRecord : CodeViewTypeRecord
     public PointerTypeRecord(CodeViewTypeRecord type, PointerAttributes attributes)
         : base(0)
     {
-        _baseType = new LazyVariable<CodeViewTypeRecord>(type);
+        _baseType = new LazyVariable<PointerTypeRecord, CodeViewTypeRecord>(type);
         Attributes = attributes;
     }
 
@@ -38,7 +38,7 @@ public class PointerTypeRecord : CodeViewTypeRecord
     public PointerTypeRecord(CodeViewTypeRecord type, PointerAttributes attributes, byte size)
         : base(0)
     {
-        _baseType = new LazyVariable<CodeViewTypeRecord>(type);
+        _baseType = new LazyVariable<PointerTypeRecord, CodeViewTypeRecord>(type);
         Attributes = attributes;
         Size = size;
     }
@@ -51,8 +51,8 @@ public class PointerTypeRecord : CodeViewTypeRecord
     /// </summary>
     public CodeViewTypeRecord BaseType
     {
-        get => _baseType.Value;
-        set => _baseType.Value = value;
+        get => _baseType.GetValue(this);
+        set => _baseType.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/ProcedureTypeRecord.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/ProcedureTypeRecord.cs
@@ -7,8 +7,8 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public class ProcedureTypeRecord : CodeViewTypeRecord
 {
-    private readonly LazyVariable<CodeViewTypeRecord?> _returnType;
-    private readonly LazyVariable<ArgumentListLeaf?> _argumentList;
+    private readonly LazyVariable<ProcedureTypeRecord, CodeViewTypeRecord?> _returnType;
+    private readonly LazyVariable<ProcedureTypeRecord, ArgumentListLeaf?> _argumentList;
 
     /// <summary>
     /// Initializes an empty procedure type.
@@ -17,8 +17,8 @@ public class ProcedureTypeRecord : CodeViewTypeRecord
     protected ProcedureTypeRecord(uint typeIndex)
         : base(typeIndex)
     {
-        _returnType = new LazyVariable<CodeViewTypeRecord?>(GetReturnType);
-        _argumentList = new LazyVariable<ArgumentListLeaf?>(GetArguments);
+        _returnType = new LazyVariable<ProcedureTypeRecord, CodeViewTypeRecord?>(x => x.GetReturnType());
+        _argumentList = new LazyVariable<ProcedureTypeRecord, ArgumentListLeaf?>(x => x.GetArguments());
     }
 
     /// <summary>
@@ -31,8 +31,8 @@ public class ProcedureTypeRecord : CodeViewTypeRecord
         : base(0)
     {
         CallingConvention = callingConvention;
-        _returnType = new LazyVariable<CodeViewTypeRecord?>(returnType);
-        _argumentList = new LazyVariable<ArgumentListLeaf?>(arguments);
+        _returnType = new LazyVariable<ProcedureTypeRecord, CodeViewTypeRecord?>(returnType);
+        _argumentList = new LazyVariable<ProcedureTypeRecord, ArgumentListLeaf?>(arguments);
     }
 
     /// <inheritdoc />
@@ -43,8 +43,8 @@ public class ProcedureTypeRecord : CodeViewTypeRecord
     /// </summary>
     public CodeViewTypeRecord? ReturnType
     {
-        get => _returnType.Value;
-        set => _returnType.Value = value;
+        get => _returnType.GetValue(this);
+        set => _returnType.SetValue(value);
     }
 
     /// <summary>
@@ -70,8 +70,8 @@ public class ProcedureTypeRecord : CodeViewTypeRecord
     /// </summary>
     public ArgumentListLeaf? Arguments
     {
-        get => _argumentList.Value;
-        set => _argumentList.Value = value;
+        get => _argumentList.GetValue(this);
+        set => _argumentList.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/StringIdentifier.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/StringIdentifier.cs
@@ -5,8 +5,8 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public class StringIdentifier : CodeViewLeaf, IIpiLeaf
 {
-    private readonly LazyVariable<Utf8String> _value;
-    private readonly LazyVariable<SubStringListLeaf?> _subStrings;
+    private readonly LazyVariable<StringIdentifier, Utf8String> _value;
+    private readonly LazyVariable<StringIdentifier, SubStringListLeaf?> _subStrings;
 
     /// <summary>
     /// Initializes an empty String ID entry.
@@ -15,8 +15,8 @@ public class StringIdentifier : CodeViewLeaf, IIpiLeaf
     protected StringIdentifier(uint typeIndex)
         : base(typeIndex)
     {
-        _value = new LazyVariable<Utf8String>(GetValue);
-        _subStrings = new LazyVariable<SubStringListLeaf?>(GetSubStrings);
+        _value = new LazyVariable<StringIdentifier, Utf8String>(x =>x .GetValue());
+        _subStrings = new LazyVariable<StringIdentifier, SubStringListLeaf?>(x =>x .GetSubStrings());
     }
 
     /// <summary>
@@ -36,8 +36,8 @@ public class StringIdentifier : CodeViewLeaf, IIpiLeaf
     public StringIdentifier(Utf8String value, SubStringListLeaf? subStrings)
         : base(0)
     {
-        _value = new LazyVariable<Utf8String>(value);
-        _subStrings = new LazyVariable<SubStringListLeaf?>(subStrings);
+        _value = new LazyVariable<StringIdentifier, Utf8String>(value);
+        _subStrings = new LazyVariable<StringIdentifier, SubStringListLeaf?>(subStrings);
     }
 
     /// <inheritdoc />
@@ -48,8 +48,8 @@ public class StringIdentifier : CodeViewLeaf, IIpiLeaf
     /// </summary>
     public Utf8String Value
     {
-        get => _value.Value;
-        set => _value.Value = value;
+        get => _value.GetValue(this);
+        set => _value.SetValue(value);
     }
 
     /// <summary>
@@ -57,8 +57,8 @@ public class StringIdentifier : CodeViewLeaf, IIpiLeaf
     /// </summary>
     public SubStringListLeaf? SubStrings
     {
-        get => _subStrings.Value;
-        set => _subStrings.Value = value;
+        get => _subStrings.GetValue(this);
+        set => _subStrings.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/UnionTypeRecord.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/UnionTypeRecord.cs
@@ -5,7 +5,7 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public class UnionTypeRecord : CodeViewCompositeTypeRecord
 {
-    private readonly LazyVariable<Utf8String> _uniqueName;
+    private readonly LazyVariable<UnionTypeRecord, Utf8String> _uniqueName;
 
     /// <summary>
     /// Initializes an empty union type.
@@ -14,7 +14,7 @@ public class UnionTypeRecord : CodeViewCompositeTypeRecord
     protected UnionTypeRecord(uint typeIndex)
         : base(typeIndex)
     {
-        _uniqueName = new LazyVariable<Utf8String>(GetUniqueName);
+        _uniqueName = new LazyVariable<UnionTypeRecord, Utf8String>(x => x.GetUniqueName());
     }
 
     /// <summary>
@@ -24,7 +24,7 @@ public class UnionTypeRecord : CodeViewCompositeTypeRecord
     public UnionTypeRecord(ulong size)
         : base(0)
     {
-        _uniqueName = new LazyVariable<Utf8String>(Utf8String.Empty);
+        _uniqueName = new LazyVariable<UnionTypeRecord, Utf8String>(Utf8String.Empty);
         Size = size;
     }
 
@@ -45,8 +45,8 @@ public class UnionTypeRecord : CodeViewCompositeTypeRecord
     /// </summary>
     public Utf8String UniqueName
     {
-        get => _uniqueName.Value;
-        set => _uniqueName.Value = value;
+        get => _uniqueName.GetValue(this);
+        set => _uniqueName.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/VBaseClassField.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/VBaseClassField.cs
@@ -5,8 +5,8 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public class VBaseClassField : CodeViewField
 {
-    private readonly LazyVariable<CodeViewTypeRecord?> _baseType;
-    private readonly LazyVariable<CodeViewTypeRecord?> _basePointerType;
+    private readonly LazyVariable<VBaseClassField, CodeViewTypeRecord?> _baseType;
+    private readonly LazyVariable<VBaseClassField, CodeViewTypeRecord?> _basePointerType;
 
     /// <summary>
     /// Initializes a new empty virtual base class field.
@@ -15,8 +15,8 @@ public class VBaseClassField : CodeViewField
     protected VBaseClassField(uint typeIndex)
         : base(typeIndex)
     {
-        _baseType = new LazyVariable<CodeViewTypeRecord?>(GetBaseType);
-        _basePointerType = new LazyVariable<CodeViewTypeRecord?>(GetBasePointerType);
+        _baseType = new LazyVariable<VBaseClassField, CodeViewTypeRecord?>(x => x.GetBaseType());
+        _basePointerType = new LazyVariable<VBaseClassField, CodeViewTypeRecord?>(x => x.GetBasePointerType());
     }
 
     /// <summary>
@@ -35,8 +35,8 @@ public class VBaseClassField : CodeViewField
         bool isIndirect)
         : base(0)
     {
-        _baseType = new LazyVariable<CodeViewTypeRecord?>(baseType);
-        _basePointerType = new LazyVariable<CodeViewTypeRecord?>(pointerType);
+        _baseType = new LazyVariable<VBaseClassField, CodeViewTypeRecord?>(baseType);
+        _basePointerType = new LazyVariable<VBaseClassField, CodeViewTypeRecord?>(pointerType);
         PointerOffset = pointerOffset;
         TableOffset = tableOffset;
         IsIndirect = isIndirect;
@@ -61,8 +61,8 @@ public class VBaseClassField : CodeViewField
     /// </summary>
     public CodeViewTypeRecord? Type
     {
-        get => _baseType.Value;
-        set => _baseType.Value = value;
+        get => _baseType.GetValue(this);
+        set => _baseType.SetValue(value);
     }
 
     /// <summary>
@@ -70,8 +70,8 @@ public class VBaseClassField : CodeViewField
     /// </summary>
     public CodeViewTypeRecord? PointerType
     {
-        get => _basePointerType.Value;
-        set => _basePointerType.Value = value;
+        get => _basePointerType.GetValue(this);
+        set => _basePointerType.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Leaves/VTableField.cs
+++ b/src/AsmResolver.Symbols.Pdb/Leaves/VTableField.cs
@@ -5,7 +5,7 @@ namespace AsmResolver.Symbols.Pdb.Leaves;
 /// </summary>
 public class VTableField : CodeViewField
 {
-    private readonly LazyVariable<CodeViewTypeRecord?> _type;
+    private readonly LazyVariable<VTableField, CodeViewTypeRecord?> _type;
 
     /// <summary>
     /// Initializes an empty virtual function table field.
@@ -14,7 +14,7 @@ public class VTableField : CodeViewField
     protected VTableField(uint typeIndex)
         : base(typeIndex)
     {
-        _type = new LazyVariable<CodeViewTypeRecord?>(GetPointerType);
+        _type = new LazyVariable<VTableField, CodeViewTypeRecord?>(x => x.GetPointerType());
     }
 
     /// <summary>
@@ -24,7 +24,7 @@ public class VTableField : CodeViewField
     public VTableField(CodeViewTypeRecord pointerType)
         : base(0)
     {
-        _type = new LazyVariable<CodeViewTypeRecord?>(pointerType);
+        _type = new LazyVariable<VTableField, CodeViewTypeRecord?>(pointerType);
     }
 
     /// <inheritdoc />
@@ -35,8 +35,8 @@ public class VTableField : CodeViewField
     /// </summary>
     public CodeViewTypeRecord? PointerType
     {
-        get => _type.Value;
-        set => _type.Value = value;
+        get => _type.GetValue(this);
+        set => _type.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Metadata/Dbi/DbiStream.cs
+++ b/src/AsmResolver.Symbols.Pdb/Metadata/Dbi/DbiStream.cs
@@ -20,8 +20,8 @@ public class DbiStream : SegmentBase
     private IList<ModuleDescriptor>? _modules;
     private IList<SectionContribution>? _sectionContributions;
     private IList<SectionMap>? _sectionMaps;
-    private readonly LazyVariable<ISegment?> _typeServerMapStream;
-    private readonly LazyVariable<ISegment?> _ecStream;
+    private readonly LazyVariable<DbiStream, ISegment?> _typeServerMapStream;
+    private readonly LazyVariable<DbiStream, ISegment?> _ecStream;
     private IList<SourceFileCollection>? _sourceFiles;
     private IList<ushort>? _extraStreamIndices;
 
@@ -30,8 +30,8 @@ public class DbiStream : SegmentBase
     /// </summary>
     public DbiStream()
     {
-        _typeServerMapStream = new LazyVariable<ISegment?>(GetTypeServerMapStream);
-        _ecStream = new LazyVariable<ISegment?>(GetECStream);
+        _typeServerMapStream = new LazyVariable<DbiStream, ISegment?>(x => x.GetTypeServerMapStream());
+        _ecStream = new LazyVariable<DbiStream, ISegment?>(x => x.GetECStream());
         IsNewVersionFormat = true;
     }
 
@@ -228,8 +228,8 @@ public class DbiStream : SegmentBase
     /// </remarks>
     public ISegment? TypeServerMapStream
     {
-        get => _typeServerMapStream.Value;
-        set => _typeServerMapStream.Value = value;
+        get => _typeServerMapStream.GetValue(this);
+        set => _typeServerMapStream.SetValue(value);
     }
 
     /// <summary>
@@ -241,8 +241,8 @@ public class DbiStream : SegmentBase
     /// </remarks>
     public ISegment? ECStream
     {
-        get => _ecStream.Value;
-        set => _ecStream.Value = value;
+        get => _ecStream.GetValue(this);
+        set => _ecStream.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Metadata/Modi/ModiStream.cs
+++ b/src/AsmResolver.Symbols.Pdb/Metadata/Modi/ModiStream.cs
@@ -8,20 +8,20 @@ namespace AsmResolver.Symbols.Pdb.Metadata.Modi;
 /// </summary>
 public class ModiStream : SegmentBase
 {
-    private readonly LazyVariable<IReadableSegment?> _symbols;
-    private readonly LazyVariable<IReadableSegment?> _c11LineInfo;
-    private readonly LazyVariable<IReadableSegment?> _c13LineInfo;
-    private readonly LazyVariable<IReadableSegment?> _globalReferences;
+    private readonly LazyVariable<ModiStream, IReadableSegment?> _symbols;
+    private readonly LazyVariable<ModiStream, IReadableSegment?> _c11LineInfo;
+    private readonly LazyVariable<ModiStream, IReadableSegment?> _c13LineInfo;
+    private readonly LazyVariable<ModiStream, IReadableSegment?> _globalReferences;
 
     /// <summary>
     /// Creates a new empty module info stream.
     /// </summary>
     public ModiStream()
     {
-        _symbols = new LazyVariable<IReadableSegment?>(GetSymbols);
-        _c11LineInfo = new LazyVariable<IReadableSegment?>(GetC11LineInfo);
-        _c13LineInfo = new LazyVariable<IReadableSegment?>(GetC13LineInfo);
-        _globalReferences = new LazyVariable<IReadableSegment?>(GetGlobalReferences);
+        _symbols = new LazyVariable<ModiStream, IReadableSegment?>(x => x.GetSymbols());
+        _c11LineInfo = new LazyVariable<ModiStream, IReadableSegment?>(x => x.GetC11LineInfo());
+        _c13LineInfo = new LazyVariable<ModiStream, IReadableSegment?>(x => x.GetC13LineInfo());
+        _globalReferences = new LazyVariable<ModiStream, IReadableSegment?>(x => x.GetGlobalReferences());
     }
 
     /// <summary>
@@ -41,8 +41,8 @@ public class ModiStream : SegmentBase
     /// </summary>
     public IReadableSegment? Symbols
     {
-        get => _symbols.Value;
-        set => _symbols.Value = value;
+        get => _symbols.GetValue(this);
+        set => _symbols.SetValue(value);
     }
 
     /// <summary>
@@ -50,8 +50,8 @@ public class ModiStream : SegmentBase
     /// </summary>
     public IReadableSegment? C11LineInfo
     {
-        get => _c11LineInfo.Value;
-        set => _c11LineInfo.Value = value;
+        get => _c11LineInfo.GetValue(this);
+        set => _c11LineInfo.SetValue(value);
     }
 
     /// <summary>
@@ -59,8 +59,8 @@ public class ModiStream : SegmentBase
     /// </summary>
     public IReadableSegment? C13LineInfo
     {
-        get => _c13LineInfo.Value;
-        set => _c13LineInfo.Value = value;
+        get => _c13LineInfo.GetValue(this);
+        set => _c13LineInfo.SetValue(value);
     }
 
     /// <summary>
@@ -71,8 +71,8 @@ public class ModiStream : SegmentBase
     /// </remarks>
     public IReadableSegment? GlobalReferences
     {
-        get => _globalReferences.Value;
-        set => _globalReferences.Value = value;
+        get => _globalReferences.GetValue(this);
+        set => _globalReferences.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/PdbModule.cs
+++ b/src/AsmResolver.Symbols.Pdb/PdbModule.cs
@@ -10,10 +10,10 @@ namespace AsmResolver.Symbols.Pdb;
 /// </summary>
 public class PdbModule : ICodeViewSymbolProvider
 {
-    private readonly LazyVariable<Utf8String?> _name;
-    private readonly LazyVariable<Utf8String?> _objectFileName;
+    private readonly LazyVariable<PdbModule, Utf8String?> _name;
+    private readonly LazyVariable<PdbModule, Utf8String?> _objectFileName;
     private IList<PdbSourceFile>? _sourceFiles;
-    private readonly LazyVariable<SectionContribution> _sectionContribution;
+    private readonly LazyVariable<PdbModule, SectionContribution> _sectionContribution;
 
     private IList<ICodeViewSymbol>? _symbols;
 
@@ -22,9 +22,9 @@ public class PdbModule : ICodeViewSymbolProvider
     /// </summary>
     protected PdbModule()
     {
-        _name = new LazyVariable<Utf8String?>(GetName);
-        _objectFileName = new LazyVariable<Utf8String?>(GetObjectFileName);
-        _sectionContribution = new LazyVariable<SectionContribution>(GetSectionContribution);
+        _name = new LazyVariable<PdbModule, Utf8String?>(x => x.GetName());
+        _objectFileName = new LazyVariable<PdbModule, Utf8String?>(x => x.GetObjectFileName());
+        _sectionContribution = new LazyVariable<PdbModule, SectionContribution>(x => x.GetSectionContribution());
     }
 
     /// <summary>
@@ -43,9 +43,9 @@ public class PdbModule : ICodeViewSymbolProvider
     /// <param name="objectFileName">The path to the object file.</param>
     public PdbModule(Utf8String name, Utf8String objectFileName)
     {
-        _name = new LazyVariable<Utf8String?>(name);
-        _objectFileName = new LazyVariable<Utf8String?>(objectFileName);
-        _sectionContribution = new LazyVariable<SectionContribution>(new SectionContribution());
+        _name = new LazyVariable<PdbModule, Utf8String?>(name);
+        _objectFileName = new LazyVariable<PdbModule, Utf8String?>(objectFileName);
+        _sectionContribution = new LazyVariable<PdbModule, SectionContribution>(new SectionContribution());
     }
 
     /// <summary>
@@ -57,8 +57,8 @@ public class PdbModule : ICodeViewSymbolProvider
     /// </remarks>
     public Utf8String? Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <summary>
@@ -70,8 +70,8 @@ public class PdbModule : ICodeViewSymbolProvider
     /// </remarks>
     public Utf8String? ObjectFileName
     {
-        get => _objectFileName.Value;
-        set => _objectFileName.Value = value;
+        get => _objectFileName.GetValue(this);
+        set => _objectFileName.SetValue(value);
     }
 
     /// <summary>
@@ -93,8 +93,8 @@ public class PdbModule : ICodeViewSymbolProvider
     /// </summary>
     public SectionContribution SectionContribution
     {
-        get => _sectionContribution.Value;
-        set => _sectionContribution.Value = value;
+        get => _sectionContribution.GetValue(this);
+        set => _sectionContribution.SetValue(value);
     }
 
     /// <inheritdoc />

--- a/src/AsmResolver.Symbols.Pdb/Records/BasePointerRelativeSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/BasePointerRelativeSymbol.cs
@@ -7,16 +7,16 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public class BasePointerRelativeSymbol : CodeViewSymbol, IRegisterRelativeSymbol
 {
-    private readonly LazyVariable<CodeViewTypeRecord?> _variableType;
-    private readonly LazyVariable<Utf8String?> _name;
+    private readonly LazyVariable<BasePointerRelativeSymbol, CodeViewTypeRecord?> _variableType;
+    private readonly LazyVariable<BasePointerRelativeSymbol, Utf8String?> _name;
 
     /// <summary>
     /// Initializes an empty base-pointer relative symbol.
     /// </summary>
     protected BasePointerRelativeSymbol()
     {
-        _name = new LazyVariable<Utf8String?>(GetName);
-        _variableType = new LazyVariable<CodeViewTypeRecord?>(GetVariableType);
+        _name = new LazyVariable<BasePointerRelativeSymbol, Utf8String?>(x => x.GetName());
+        _variableType = new LazyVariable<BasePointerRelativeSymbol, CodeViewTypeRecord?>(x => x.GetVariableType());
     }
 
     /// <summary>
@@ -27,8 +27,8 @@ public class BasePointerRelativeSymbol : CodeViewSymbol, IRegisterRelativeSymbol
     /// <param name="variableType">The type of variable the symbol stores.</param>
     public BasePointerRelativeSymbol(Utf8String name, CodeViewTypeRecord variableType, int offset)
     {
-        _name = new LazyVariable<Utf8String?>(name);
-        _variableType = new LazyVariable<CodeViewTypeRecord?>(variableType);
+        _name = new LazyVariable<BasePointerRelativeSymbol, Utf8String?>(name);
+        _variableType = new LazyVariable<BasePointerRelativeSymbol, CodeViewTypeRecord?>(variableType);
         Offset = offset;
     }
 
@@ -49,8 +49,8 @@ public class BasePointerRelativeSymbol : CodeViewSymbol, IRegisterRelativeSymbol
     /// </summary>
     public CodeViewTypeRecord? VariableType
     {
-        get => _variableType.Value;
-        set => _variableType.Value = value;
+        get => _variableType.GetValue(this);
+        set => _variableType.SetValue(value);
     }
 
     /// <summary>
@@ -58,8 +58,8 @@ public class BasePointerRelativeSymbol : CodeViewSymbol, IRegisterRelativeSymbol
     /// </summary>
     public Utf8String? Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Records/BuildInfoSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/BuildInfoSymbol.cs
@@ -7,14 +7,14 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public class BuildInfoSymbol : CodeViewSymbol
 {
-    private readonly LazyVariable<BuildInfoLeaf?> _info;
+    private readonly LazyVariable<BuildInfoSymbol, BuildInfoLeaf?> _info;
 
     /// <summary>
     /// Initializes an empty build information symbol.
     /// </summary>
     protected BuildInfoSymbol()
     {
-        _info = new LazyVariable<BuildInfoLeaf?>(GetInfo);
+        _info = new LazyVariable<BuildInfoSymbol, BuildInfoLeaf?>(x => x.GetInfo());
     }
 
     /// <summary>
@@ -23,7 +23,7 @@ public class BuildInfoSymbol : CodeViewSymbol
     /// <param name="info">The information to wrap.</param>
     public BuildInfoSymbol(BuildInfoLeaf info)
     {
-        _info = new LazyVariable<BuildInfoLeaf?>(info);
+        _info = new LazyVariable<BuildInfoSymbol, BuildInfoLeaf?>(info);
     }
 
     /// <inheritdoc />
@@ -34,8 +34,8 @@ public class BuildInfoSymbol : CodeViewSymbol
     /// </summary>
     public BuildInfoLeaf? Info
     {
-        get => _info.Value;
-        set => _info.Value = value;
+        get => _info.GetValue(this);
+        set => _info.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Records/CallSiteSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/CallSiteSymbol.cs
@@ -7,14 +7,14 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public class CallSiteSymbol : CodeViewSymbol
 {
-    private readonly LazyVariable<CodeViewTypeRecord?> _functionType;
+    private readonly LazyVariable<CallSiteSymbol, CodeViewTypeRecord?> _functionType;
 
     /// <summary>
     /// Initializes an empty call site symbol.
     /// </summary>
     protected CallSiteSymbol()
     {
-        _functionType = new LazyVariable<CodeViewTypeRecord?>(GetFunctionType);
+        _functionType = new LazyVariable<CallSiteSymbol, CodeViewTypeRecord?>(x => x.GetFunctionType());
     }
 
     /// <summary>
@@ -27,7 +27,7 @@ public class CallSiteSymbol : CodeViewSymbol
     {
         SectionIndex = sectionIndex;
         Offset = offset;
-        _functionType = new LazyVariable<CodeViewTypeRecord?>(functionType);
+        _functionType = new LazyVariable<CallSiteSymbol, CodeViewTypeRecord?>(functionType);
     }
 
     /// <inheritdoc />
@@ -56,8 +56,8 @@ public class CallSiteSymbol : CodeViewSymbol
     /// </summary>
     public CodeViewTypeRecord? FunctionType
     {
-        get => _functionType.Value;
-        set => _functionType.Value = value;
+        get => _functionType.GetValue(this);
+        set => _functionType.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Records/CoffGroupSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/CoffGroupSymbol.cs
@@ -7,14 +7,14 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public class CoffGroupSymbol : CodeViewSymbol
 {
-    private readonly LazyVariable<Utf8String?> _name;
+    private readonly LazyVariable<CoffGroupSymbol, Utf8String?> _name;
 
     /// <summary>
     /// Initializes an empty COFF group symbol.
     /// </summary>
     protected CoffGroupSymbol()
     {
-        _name = new LazyVariable<Utf8String?>(GetName);
+        _name = new LazyVariable<CoffGroupSymbol, Utf8String?>(x => x.GetName());
     }
 
     /// <summary>
@@ -27,7 +27,7 @@ public class CoffGroupSymbol : CodeViewSymbol
     /// <param name="characteristics">The characteristics describing the group.</param>
     public CoffGroupSymbol(Utf8String name, ushort segmentIndex, uint offset, uint size, SectionFlags characteristics)
     {
-        _name = new LazyVariable<Utf8String?>(name);
+        _name = new LazyVariable<CoffGroupSymbol, Utf8String?>(name);
         SegmentIndex = segmentIndex;
         Offset = offset;
         Size = size;
@@ -78,8 +78,8 @@ public class CoffGroupSymbol : CodeViewSymbol
     /// </summary>
     public Utf8String? Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Records/CompileSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/CompileSymbol.cs
@@ -5,14 +5,14 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public abstract class CompileSymbol : CodeViewSymbol
 {
-    private readonly LazyVariable<Utf8String> _compilerVersion;
+    private readonly LazyVariable<CompileSymbol, Utf8String> _compilerVersion;
 
     /// <summary>
     /// Initializes an empty compile symbol.
     /// </summary>
     protected CompileSymbol()
     {
-        _compilerVersion = new LazyVariable<Utf8String>(GetCompilerVersion);
+        _compilerVersion = new LazyVariable<CompileSymbol, Utf8String>(x => x.GetCompilerVersion());
     }
 
     /// <summary>
@@ -101,8 +101,8 @@ public abstract class CompileSymbol : CodeViewSymbol
     /// </summary>
     public Utf8String CompilerVersion
     {
-        get => _compilerVersion.Value;
-        set => _compilerVersion.Value = value;
+        get => _compilerVersion.GetValue(this);
+        set => _compilerVersion.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Records/ConstantSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/ConstantSymbol.cs
@@ -7,16 +7,16 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public class ConstantSymbol : CodeViewSymbol
 {
-    private readonly LazyVariable<Utf8String> _name;
-    private readonly LazyVariable<CodeViewTypeRecord> _type;
+    private readonly LazyVariable<ConstantSymbol, Utf8String> _name;
+    private readonly LazyVariable<ConstantSymbol, CodeViewTypeRecord> _type;
 
     /// <summary>
     /// Initializes a named constant
     /// </summary>
     protected ConstantSymbol()
     {
-        _name = new LazyVariable<Utf8String>(GetName);
-        _type = new LazyVariable<CodeViewTypeRecord>(GetConstantType);
+        _name = new LazyVariable<ConstantSymbol, Utf8String>(x => x.GetName());
+        _type = new LazyVariable<ConstantSymbol, CodeViewTypeRecord>(x => x.GetConstantType());
     }
 
     /// <summary>
@@ -27,8 +27,8 @@ public class ConstantSymbol : CodeViewSymbol
     /// <param name="value">The value to assign to the constant.</param>
     public ConstantSymbol(Utf8String name, CodeViewTypeRecord type, ushort value)
     {
-        _name = new LazyVariable<Utf8String>(name);
-        _type = new LazyVariable<CodeViewTypeRecord>(type);
+        _name = new LazyVariable<ConstantSymbol, Utf8String>(name);
+        _type = new LazyVariable<ConstantSymbol, CodeViewTypeRecord>(type);
         Value = value;
     }
 
@@ -40,8 +40,8 @@ public class ConstantSymbol : CodeViewSymbol
     /// </summary>
     public CodeViewTypeRecord Type
     {
-        get => _type.Value;
-        set => _type.Value = value;
+        get => _type.GetValue(this);
+        set => _type.SetValue(value);
     }
 
     /// <summary>
@@ -58,8 +58,8 @@ public class ConstantSymbol : CodeViewSymbol
     /// </summary>
     public Utf8String Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Records/DataSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/DataSymbol.cs
@@ -7,16 +7,16 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public class DataSymbol : CodeViewSymbol, IVariableSymbol
 {
-    private readonly LazyVariable<Utf8String?> _name;
-    private readonly LazyVariable<CodeViewTypeRecord?> _variableType;
+    private readonly LazyVariable<DataSymbol, Utf8String?> _name;
+    private readonly LazyVariable<DataSymbol, CodeViewTypeRecord?> _variableType;
 
     /// <summary>
     /// Initializes an empty data symbol.
     /// </summary>
     protected DataSymbol()
     {
-        _name = new LazyVariable<Utf8String?>(GetName);
-        _variableType = new LazyVariable<CodeViewTypeRecord?>(GetVariableType);
+        _name = new LazyVariable<DataSymbol, Utf8String?>(x => x.GetName());
+        _variableType = new LazyVariable<DataSymbol, CodeViewTypeRecord?>(x => x.GetVariableType());
     }
 
     /// <summary>
@@ -26,8 +26,8 @@ public class DataSymbol : CodeViewSymbol, IVariableSymbol
     /// <param name="variableType">The data type of the symbol.</param>
     public DataSymbol(Utf8String name, CodeViewTypeRecord variableType)
     {
-        _name = new LazyVariable<Utf8String?>(name);
-        _variableType = new LazyVariable<CodeViewTypeRecord?>(variableType);
+        _name = new LazyVariable<DataSymbol, Utf8String?>(name);
+        _variableType = new LazyVariable<DataSymbol, CodeViewTypeRecord?>(variableType);
     }
 
     /// <inheritdoc />
@@ -74,15 +74,15 @@ public class DataSymbol : CodeViewSymbol, IVariableSymbol
     /// <inheritdoc />
     public Utf8String? Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <inheritdoc />
     public CodeViewTypeRecord? VariableType
     {
-        get => _variableType.Value;
-        set => _variableType.Value = value;
+        get => _variableType.GetValue(this);
+        set => _variableType.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Records/FileStaticSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/FileStaticSymbol.cs
@@ -7,16 +7,16 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public class FileStaticSymbol : CodeViewSymbol, IVariableSymbol
 {
-    private readonly LazyVariable<Utf8String?> _name;
-    private readonly LazyVariable<CodeViewTypeRecord?> _variableType;
+    private readonly LazyVariable<FileStaticSymbol, Utf8String?> _name;
+    private readonly LazyVariable<FileStaticSymbol, CodeViewTypeRecord?> _variableType;
 
     /// <summary>
     /// Initializes an empty file static symbol.
     /// </summary>
     protected FileStaticSymbol()
     {
-        _name = new LazyVariable<Utf8String?>(GetName);
-        _variableType = new LazyVariable<CodeViewTypeRecord?>(GetVariableType);
+        _name = new LazyVariable<FileStaticSymbol, Utf8String?>(x => x.GetName());
+        _variableType = new LazyVariable<FileStaticSymbol, CodeViewTypeRecord?>(x => x.GetVariableType());
     }
 
     /// <summary>
@@ -28,8 +28,8 @@ public class FileStaticSymbol : CodeViewSymbol, IVariableSymbol
     public FileStaticSymbol(Utf8String name, CodeViewTypeRecord variableType, LocalAttributes attributes)
     {
         Attributes = attributes;
-        _name = new LazyVariable<Utf8String?>(name);
-        _variableType = new LazyVariable<CodeViewTypeRecord?>(variableType);
+        _name = new LazyVariable<FileStaticSymbol, Utf8String?>(name);
+        _variableType = new LazyVariable<FileStaticSymbol, CodeViewTypeRecord?>(variableType);
     }
 
     /// <inheritdoc />
@@ -56,15 +56,15 @@ public class FileStaticSymbol : CodeViewSymbol, IVariableSymbol
     /// <inheritdoc />
     public Utf8String? Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <inheritdoc />
     public CodeViewTypeRecord? VariableType
     {
-        get => _variableType.Value;
-        set => _variableType.Value = value;
+        get => _variableType.GetValue(this);
+        set => _variableType.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Records/InlineSiteSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/InlineSiteSymbol.cs
@@ -9,7 +9,7 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public class InlineSiteSymbol : CodeViewSymbol, IScopeCodeViewSymbol
 {
-    private readonly LazyVariable<FunctionIdentifier?> _inlinee;
+    private readonly LazyVariable<InlineSiteSymbol, FunctionIdentifier?> _inlinee;
 
     private IList<ICodeViewSymbol>? _symbols;
     private IList<BinaryAnnotation>? _annotations;
@@ -19,7 +19,7 @@ public class InlineSiteSymbol : CodeViewSymbol, IScopeCodeViewSymbol
     /// </summary>
     protected InlineSiteSymbol()
     {
-        _inlinee = new LazyVariable<FunctionIdentifier?>(GetInlinee);
+        _inlinee = new LazyVariable<InlineSiteSymbol, FunctionIdentifier?>(x => x.GetInlinee());
     }
 
     /// <summary>
@@ -28,7 +28,7 @@ public class InlineSiteSymbol : CodeViewSymbol, IScopeCodeViewSymbol
     /// <param name="inlinee">The function that is being inlined.</param>
     public InlineSiteSymbol(FunctionIdentifier inlinee)
     {
-        _inlinee = new LazyVariable<FunctionIdentifier?>(inlinee);
+        _inlinee = new LazyVariable<InlineSiteSymbol, FunctionIdentifier?>(inlinee);
     }
 
     /// <inheritdoc />
@@ -50,8 +50,8 @@ public class InlineSiteSymbol : CodeViewSymbol, IScopeCodeViewSymbol
     /// </summary>
     public FunctionIdentifier? Inlinee
     {
-        get => _inlinee.Value;
-        set => _inlinee.Value = value;
+        get => _inlinee.GetValue(this);
+        set => _inlinee.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Records/LabelSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/LabelSymbol.cs
@@ -5,14 +5,14 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public class LabelSymbol : CodeViewSymbol
 {
-    private readonly LazyVariable<Utf8String?> _name;
+    private readonly LazyVariable<LabelSymbol, Utf8String?> _name;
 
     /// <summary>
     /// Initializes an empty label symbol.
     /// </summary>
     protected LabelSymbol()
     {
-        _name = new LazyVariable<Utf8String?>(GetName);
+        _name = new LazyVariable<LabelSymbol, Utf8String?>(x => x.GetName());
     }
 
     /// <summary>
@@ -24,7 +24,7 @@ public class LabelSymbol : CodeViewSymbol
     /// <param name="attributes">The attributes describing the label.</param>
     public LabelSymbol(Utf8String name, ushort segmentIndex, uint offset, ProcedureAttributes attributes)
     {
-        _name = new LazyVariable<Utf8String?>(name);
+        _name = new LazyVariable<LabelSymbol, Utf8String?>(name);
         SegmentIndex = segmentIndex;
         Offset = offset;
         Attributes = attributes;
@@ -65,8 +65,8 @@ public class LabelSymbol : CodeViewSymbol
     /// </summary>
     public Utf8String? Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Records/LocalSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/LocalSymbol.cs
@@ -7,16 +7,16 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public class LocalSymbol : CodeViewSymbol, IVariableSymbol
 {
-    private readonly LazyVariable<CodeViewTypeRecord?> _variableType;
-    private readonly LazyVariable<Utf8String?> _name;
+    private readonly LazyVariable<LocalSymbol, CodeViewTypeRecord?> _variableType;
+    private readonly LazyVariable<LocalSymbol, Utf8String?> _name;
 
     /// <summary>
     /// Initializes an empty local variable symbol.
     /// </summary>
     protected LocalSymbol()
     {
-        _variableType = new LazyVariable<CodeViewTypeRecord?>(GetVariableType);
-        _name = new LazyVariable<Utf8String?>(GetName);
+        _variableType = new LazyVariable<LocalSymbol, CodeViewTypeRecord?>(x => x.GetVariableType());
+        _name = new LazyVariable<LocalSymbol, Utf8String?>(x => x.GetName());
     }
 
     /// <summary>
@@ -27,8 +27,8 @@ public class LocalSymbol : CodeViewSymbol, IVariableSymbol
     /// <param name="attributes">The attributes describing the variable.</param>
     public LocalSymbol(Utf8String? name, CodeViewTypeRecord? variableType, LocalAttributes attributes)
     {
-        _variableType = new LazyVariable<CodeViewTypeRecord?>(variableType);
-        _name = new LazyVariable<Utf8String?>(name);
+        _variableType = new LazyVariable<LocalSymbol, CodeViewTypeRecord?>(variableType);
+        _name = new LazyVariable<LocalSymbol, Utf8String?>(name);
         Attributes = attributes;
     }
 
@@ -38,8 +38,8 @@ public class LocalSymbol : CodeViewSymbol, IVariableSymbol
     /// <inheritdoc />
     public CodeViewTypeRecord? VariableType
     {
-        get => _variableType.Value;
-        set => _variableType.Value = value;
+        get => _variableType.GetValue(this);
+        set => _variableType.SetValue(value);
     }
 
     /// <summary>
@@ -54,8 +54,8 @@ public class LocalSymbol : CodeViewSymbol, IVariableSymbol
     /// <inheritdoc />
     public Utf8String? Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Records/ObjectNameSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/ObjectNameSymbol.cs
@@ -5,14 +5,14 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public class ObjectNameSymbol : CodeViewSymbol
 {
-    private readonly LazyVariable<Utf8String> _name;
+    private readonly LazyVariable<ObjectNameSymbol, Utf8String> _name;
 
     /// <summary>
     /// Initializes an empty object name symbol.
     /// </summary>
     protected ObjectNameSymbol()
     {
-        _name = new LazyVariable<Utf8String>(GetName);
+        _name = new LazyVariable<ObjectNameSymbol, Utf8String>(x => x.GetName());
     }
 
     /// <summary>
@@ -23,7 +23,7 @@ public class ObjectNameSymbol : CodeViewSymbol
     public ObjectNameSymbol(uint signature, Utf8String name)
     {
         Signature = signature;
-        _name = new LazyVariable<Utf8String>(name);
+        _name = new LazyVariable<ObjectNameSymbol, Utf8String>(name);
     }
 
     /// <inheritdoc />
@@ -43,8 +43,8 @@ public class ObjectNameSymbol : CodeViewSymbol
     /// </summary>
     public Utf8String Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Records/ProcedureReferenceSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/ProcedureReferenceSymbol.cs
@@ -5,7 +5,7 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public class ProcedureReferenceSymbol : CodeViewSymbol
 {
-    private readonly LazyVariable<Utf8String> _name;
+    private readonly LazyVariable<ProcedureReferenceSymbol, Utf8String> _name;
     private readonly bool _local;
 
     /// <summary>
@@ -14,7 +14,7 @@ public class ProcedureReferenceSymbol : CodeViewSymbol
     /// <param name="local">If true, this represents a local procedure reference.</param>
     protected ProcedureReferenceSymbol(bool local)
     {
-        _name = new LazyVariable<Utf8String>(GetName);
+        _name = new LazyVariable<ProcedureReferenceSymbol, Utf8String>(x => x.GetName());
         _local = local;
     }
 
@@ -31,18 +31,14 @@ public class ProcedureReferenceSymbol : CodeViewSymbol
         Checksum = checksum;
         Offset = offset;
         Module = module;
-        _name = new LazyVariable<Utf8String>(name);
+        _name = new LazyVariable<ProcedureReferenceSymbol, Utf8String>(name);
         _local = local;
     }
 
     /// <inheritdoc/>
-    public override CodeViewSymbolType CodeViewSymbolType
-    {
-        get
-        {
-            return _local ? CodeViewSymbolType.LProcRef : CodeViewSymbolType.ProcRef;
-        }
-    }
+    public override CodeViewSymbolType CodeViewSymbolType => _local
+        ? CodeViewSymbolType.LProcRef
+        : CodeViewSymbolType.ProcRef;
 
     /// <summary>
     /// Is the symbol a Local Procedure Reference?
@@ -83,8 +79,8 @@ public class ProcedureReferenceSymbol : CodeViewSymbol
     /// </summary>
     public Utf8String Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Records/ProcedureSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/ProcedureSymbol.cs
@@ -9,8 +9,8 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public class ProcedureSymbol : CodeViewSymbol, IScopeCodeViewSymbol
 {
-    private readonly LazyVariable<Utf8String?> _name;
-    private readonly LazyVariable<CodeViewLeaf?> _type;
+    private readonly LazyVariable<ProcedureSymbol, Utf8String?> _name;
+    private readonly LazyVariable<ProcedureSymbol, CodeViewLeaf?> _type;
 
     private IList<ICodeViewSymbol>? _symbols;
 
@@ -19,8 +19,8 @@ public class ProcedureSymbol : CodeViewSymbol, IScopeCodeViewSymbol
     /// </summary>
     protected ProcedureSymbol()
     {
-        _name = new LazyVariable<Utf8String?>(GetName);
-        _type = new LazyVariable<CodeViewLeaf?>(GetFunctionType);
+        _name = new LazyVariable<ProcedureSymbol, Utf8String?>(x => x.GetName());
+        _type = new LazyVariable<ProcedureSymbol, CodeViewLeaf?>(x => x.GetFunctionType());
     }
 
     /// <summary>
@@ -30,8 +30,8 @@ public class ProcedureSymbol : CodeViewSymbol, IScopeCodeViewSymbol
     /// <param name="id">The function identifier of the procedure.</param>
     public ProcedureSymbol(Utf8String name, FunctionIdentifier id)
     {
-        _name = new LazyVariable<Utf8String?>(name);
-        _type = new LazyVariable<CodeViewLeaf?>(id);
+        _name = new LazyVariable<ProcedureSymbol, Utf8String?>(name);
+        _type = new LazyVariable<ProcedureSymbol, CodeViewLeaf?>(id);
     }
 
     /// <summary>
@@ -41,8 +41,8 @@ public class ProcedureSymbol : CodeViewSymbol, IScopeCodeViewSymbol
     /// <param name="type">The type describing the shape of the procedure.</param>
     public ProcedureSymbol(Utf8String name, ProcedureTypeRecord type)
     {
-        _name = new LazyVariable<Utf8String?>(name);
-        _type = new LazyVariable<CodeViewLeaf?>(type);
+        _name = new LazyVariable<ProcedureSymbol, Utf8String?>(name);
+        _type = new LazyVariable<ProcedureSymbol, CodeViewLeaf?>(type);
     }
 
     /// <inheritdoc />
@@ -124,8 +124,8 @@ public class ProcedureSymbol : CodeViewSymbol, IScopeCodeViewSymbol
     /// </summary>
     public CodeViewLeaf? Type
     {
-        get => _type.Value;
-        set => _type.Value = value;
+        get => _type.GetValue(this);
+        set => _type.SetValue(value);
     }
 
     /// <summary>
@@ -178,8 +178,8 @@ public class ProcedureSymbol : CodeViewSymbol, IScopeCodeViewSymbol
     /// </summary>
     public Utf8String? Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Records/PublicSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/PublicSymbol.cs
@@ -5,14 +5,14 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public class PublicSymbol : CodeViewSymbol
 {
-    private readonly LazyVariable<Utf8String> _name;
+    private readonly LazyVariable<PublicSymbol, Utf8String> _name;
 
     /// <summary>
     /// Initializes a new empty public symbol.
     /// </summary>
     protected PublicSymbol()
     {
-        _name = new LazyVariable<Utf8String>(GetName);
+        _name = new LazyVariable<PublicSymbol, Utf8String>(x => x.GetName());
     }
 
     /// <summary>
@@ -26,7 +26,7 @@ public class PublicSymbol : CodeViewSymbol
     {
         SegmentIndex = segmentIndex;
         Offset = offset;
-        _name = new LazyVariable<Utf8String>(name);
+        _name = new LazyVariable<PublicSymbol, Utf8String>(name);
         Attributes = attributes;
     }
 
@@ -105,8 +105,8 @@ public class PublicSymbol : CodeViewSymbol
     /// </summary>
     public Utf8String Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Records/RegisterRelativeSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/RegisterRelativeSymbol.cs
@@ -7,16 +7,16 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public class RegisterRelativeSymbol : CodeViewSymbol, IRegisterRelativeSymbol
 {
-    private readonly LazyVariable<CodeViewTypeRecord?> _variableType;
-    private readonly LazyVariable<Utf8String?> _name;
+    private readonly LazyVariable<RegisterRelativeSymbol, CodeViewTypeRecord?> _variableType;
+    private readonly LazyVariable<RegisterRelativeSymbol, Utf8String?> _name;
 
     /// <summary>
     /// Initializes an empty relative register symbol.
     /// </summary>
     protected RegisterRelativeSymbol()
     {
-        _variableType = new LazyVariable<CodeViewTypeRecord?>(GetVariableType);
-        _name = new LazyVariable<Utf8String?>(GetName);
+        _variableType = new LazyVariable<RegisterRelativeSymbol, CodeViewTypeRecord?>(x => x.GetVariableType());
+        _name = new LazyVariable<RegisterRelativeSymbol, Utf8String?>(x => x.GetName());
     }
 
     /// <summary>
@@ -28,10 +28,10 @@ public class RegisterRelativeSymbol : CodeViewSymbol, IRegisterRelativeSymbol
     /// <param name="variableType">The type of variable the register+offset pair stores.</param>
     public RegisterRelativeSymbol(Utf8String name, ushort baseRegister, int offset, CodeViewTypeRecord variableType)
     {
-        _name = new LazyVariable<Utf8String?>(name);
+        _name = new LazyVariable<RegisterRelativeSymbol, Utf8String?>(name);
         BaseRegister = baseRegister;
         Offset = offset;
-        _variableType = new LazyVariable<CodeViewTypeRecord?>(variableType);
+        _variableType = new LazyVariable<RegisterRelativeSymbol, CodeViewTypeRecord?>(variableType);
     }
 
     /// <inheritdoc />
@@ -58,15 +58,15 @@ public class RegisterRelativeSymbol : CodeViewSymbol, IRegisterRelativeSymbol
     /// <inheritdoc />
     public CodeViewTypeRecord? VariableType
     {
-        get => _variableType.Value;
-        set => _variableType.Value = value;
+        get => _variableType.GetValue(this);
+        set => _variableType.SetValue(value);
     }
 
     /// <inheritdoc />
     public Utf8String? Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Records/RegisterSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/RegisterSymbol.cs
@@ -7,16 +7,16 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public class RegisterSymbol : CodeViewSymbol, IVariableSymbol
 {
-    private readonly LazyVariable<CodeViewTypeRecord?> _variableType;
-    private readonly LazyVariable<Utf8String?> _name;
+    private readonly LazyVariable<RegisterSymbol, CodeViewTypeRecord?> _variableType;
+    private readonly LazyVariable<RegisterSymbol, Utf8String?> _name;
 
     /// <summary>
     /// Initializes an empty register variable symbol.
     /// </summary>
     protected RegisterSymbol()
     {
-        _variableType = new LazyVariable<CodeViewTypeRecord?>(GetVariableType);
-        _name = new LazyVariable<Utf8String?>(GetName);
+        _variableType = new LazyVariable<RegisterSymbol, CodeViewTypeRecord?>(x => x.GetVariableType());
+        _name = new LazyVariable<RegisterSymbol, Utf8String?>(x => x.GetName());
     }
 
     /// <summary>
@@ -28,8 +28,8 @@ public class RegisterSymbol : CodeViewSymbol, IVariableSymbol
     public RegisterSymbol(Utf8String? name, CodeViewTypeRecord? variableType, ushort register)
     {
         Register = register;
-        _variableType = new LazyVariable<CodeViewTypeRecord?>(variableType);
-        _name = new LazyVariable<Utf8String?>(name);
+        _variableType = new LazyVariable<RegisterSymbol, CodeViewTypeRecord?>(variableType);
+        _name = new LazyVariable<RegisterSymbol, Utf8String?>(name);
     }
 
     /// <inheritdoc />
@@ -47,15 +47,15 @@ public class RegisterSymbol : CodeViewSymbol, IVariableSymbol
     /// <inheritdoc />
     public Utf8String? Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <inheritdoc />
     public CodeViewTypeRecord? VariableType
     {
-        get => _variableType.Value;
-        set => _variableType.Value = value;
+        get => _variableType.GetValue(this);
+        set => _variableType.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Records/SectionSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/SectionSymbol.cs
@@ -7,14 +7,14 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public class SectionSymbol : CodeViewSymbol
 {
-    private readonly LazyVariable<Utf8String?> _name;
+    private readonly LazyVariable<SectionSymbol, Utf8String?> _name;
 
     /// <summary>
     /// Initializes an empty section symbol.
     /// </summary>
     protected SectionSymbol()
     {
-        _name = new LazyVariable<Utf8String?>(GetName);
+        _name = new LazyVariable<SectionSymbol, Utf8String?>(x => x.GetName());
     }
 
     /// <summary>
@@ -23,7 +23,7 @@ public class SectionSymbol : CodeViewSymbol
     /// <param name="name">The name of the section.</param>
     public SectionSymbol(Utf8String name)
     {
-        _name = new LazyVariable<Utf8String?>(name);
+        _name = new LazyVariable<SectionSymbol, Utf8String?>(name);
     }
 
     /// <inheritdoc />
@@ -82,8 +82,8 @@ public class SectionSymbol : CodeViewSymbol
     /// </summary>
     public Utf8String? Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Records/ThunkSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/ThunkSymbol.cs
@@ -8,7 +8,7 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public class ThunkSymbol : CodeViewSymbol, IScopeCodeViewSymbol
 {
-    private readonly LazyVariable<Utf8String?> _name;
+    private readonly LazyVariable<ThunkSymbol, Utf8String?> _name;
 
     private IList<ICodeViewSymbol>? _symbols;
 
@@ -17,7 +17,7 @@ public class ThunkSymbol : CodeViewSymbol, IScopeCodeViewSymbol
     /// </summary>
     protected ThunkSymbol()
     {
-        _name = new LazyVariable<Utf8String?>(GetName);
+        _name = new LazyVariable<ThunkSymbol, Utf8String?>(x => x.GetName());
     }
 
     /// <summary>
@@ -27,7 +27,7 @@ public class ThunkSymbol : CodeViewSymbol, IScopeCodeViewSymbol
     /// <param name="size">The size of the thunk in bytes.</param>
     public ThunkSymbol(Utf8String name, ushort size)
     {
-        _name = new LazyVariable<Utf8String?>(name);
+        _name = new LazyVariable<ThunkSymbol, Utf8String?>(name);
         Size = size;
     }
 
@@ -86,8 +86,8 @@ public class ThunkSymbol : CodeViewSymbol, IScopeCodeViewSymbol
     /// </summary>
     public Utf8String? Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Records/UserDefinedTypeSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/UserDefinedTypeSymbol.cs
@@ -7,16 +7,16 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public class UserDefinedTypeSymbol : CodeViewSymbol
 {
-    private readonly LazyVariable<Utf8String> _name;
-    private readonly LazyVariable<CodeViewTypeRecord> _type;
+    private readonly LazyVariable<UserDefinedTypeSymbol, Utf8String> _name;
+    private readonly LazyVariable<UserDefinedTypeSymbol, CodeViewTypeRecord> _type;
 
     /// <summary>
     /// Initializes a new empty user-defined type symbol.
     /// </summary>
     protected UserDefinedTypeSymbol()
     {
-        _name = new LazyVariable<Utf8String>(GetName);
-        _type = new LazyVariable<CodeViewTypeRecord>(GetSymbolType);
+        _name = new LazyVariable<UserDefinedTypeSymbol, Utf8String>(x => x.GetName());
+        _type = new LazyVariable<UserDefinedTypeSymbol, CodeViewTypeRecord>(x => x.GetSymbolType());
     }
 
     /// <summary>
@@ -26,8 +26,8 @@ public class UserDefinedTypeSymbol : CodeViewSymbol
     /// <param name="type">The type.</param>
     public UserDefinedTypeSymbol(Utf8String name, CodeViewTypeRecord type)
     {
-        _name = new LazyVariable<Utf8String>(name);
-        _type = new LazyVariable<CodeViewTypeRecord>(type);
+        _name = new LazyVariable<UserDefinedTypeSymbol, Utf8String>(name);
+        _type = new LazyVariable<UserDefinedTypeSymbol, CodeViewTypeRecord>(type);
     }
 
     /// <inheritdoc />
@@ -38,8 +38,8 @@ public class UserDefinedTypeSymbol : CodeViewSymbol
     /// </summary>
     public Utf8String Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <summary>
@@ -47,8 +47,8 @@ public class UserDefinedTypeSymbol : CodeViewSymbol
     /// </summary>
     public CodeViewTypeRecord Type
     {
-        get => _type.Value;
-        set => _type.Value = value;
+        get => _type.GetValue(this);
+        set => _type.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver.Symbols.Pdb/Records/UsingNamespaceSymbol.cs
+++ b/src/AsmResolver.Symbols.Pdb/Records/UsingNamespaceSymbol.cs
@@ -5,14 +5,14 @@ namespace AsmResolver.Symbols.Pdb.Records;
 /// </summary>
 public class UsingNamespaceSymbol : CodeViewSymbol
 {
-    private readonly LazyVariable<Utf8String> _name;
+    private readonly LazyVariable<UsingNamespaceSymbol, Utf8String> _name;
 
     /// <summary>
     /// Initializes a new empty using namespace.
     /// </summary>
     protected UsingNamespaceSymbol()
     {
-        _name = new LazyVariable<Utf8String>(GetName);
+        _name = new LazyVariable<UsingNamespaceSymbol, Utf8String>(x => x.GetName());
     }
 
     /// <summary>
@@ -21,7 +21,7 @@ public class UsingNamespaceSymbol : CodeViewSymbol
     /// <param name="name">The namespace to use.</param>
     public UsingNamespaceSymbol(Utf8String name)
     {
-        _name = new LazyVariable<Utf8String>(name);
+        _name = new LazyVariable<UsingNamespaceSymbol, Utf8String>(name);
     }
 
     /// <inheritdoc />
@@ -32,8 +32,8 @@ public class UsingNamespaceSymbol : CodeViewSymbol
     /// </summary>
     public Utf8String Name
     {
-        get => _name.Value;
-        set => _name.Value = value;
+        get => _name.GetValue(this);
+        set => _name.SetValue(value);
     }
 
     /// <summary>

--- a/src/AsmResolver/LazyVariable.cs
+++ b/src/AsmResolver/LazyVariable.cs
@@ -77,9 +77,17 @@ namespace AsmResolver
                 }
             }
         }
-
     }
 
+    /// <summary>
+    /// Represents a variable that can be lazily initialized and/or assigned a new value.
+    /// </summary>
+    /// <typeparam name="TOwner">The type of the owner of the variable.</typeparam>
+    /// <typeparam name="TValue">The type of the values that the variable stores.</typeparam>
+    /// <remarks>
+    /// For performance reasons, this class locks on itself for thread synchronization. Therefore, consumers
+    /// should not lock instances of this class as a lock object to avoid dead-locks.
+    /// </remarks>
     public sealed class LazyVariable<TOwner, TValue>
     {
         private TValue? _value;
@@ -114,6 +122,11 @@ namespace AsmResolver
             private set;
         }
 
+        /// <summary>
+        /// Obtains the value stored in the variable, initializing the variable if necessary.
+        /// </summary>
+        /// <param name="owner">The owner of the variable.</param>
+        /// <returns>The value.</returns>
         public TValue GetValue(TOwner owner)
         {
             if (!IsInitialized)
@@ -121,6 +134,10 @@ namespace AsmResolver
             return _value!;
         }
 
+        /// <summary>
+        /// Assigns a new value to the variable.
+        /// </summary>
+        /// <param name="value">The new value.</param>
         public void SetValue(TValue value)
         {
             lock (this)
@@ -141,7 +158,5 @@ namespace AsmResolver
                 }
             }
         }
-
     }
-
 }

--- a/src/AsmResolver/LazyVariable.cs
+++ b/src/AsmResolver/LazyVariable.cs
@@ -6,21 +6,21 @@ namespace AsmResolver
     /// <summary>
     /// Represents a variable that can be lazily initialized and/or assigned a new value.
     /// </summary>
-    /// <typeparam name="T">The type of the values that the variable stores.</typeparam>
+    /// <typeparam name="TValue">The type of the values that the variable stores.</typeparam>
     /// <remarks>
     /// For performance reasons, this class locks on itself for thread synchronization. Therefore, consumers
     /// should not lock instances of this class as a lock object to avoid dead-locks.
     /// </remarks>
-    public class LazyVariable<T>
+    public sealed class LazyVariable<TValue>
     {
-        private T? _value;
-        private readonly Func<T?>? _getValue;
+        private TValue? _value;
+        private readonly Func<TValue?>? _getValue;
 
         /// <summary>
         /// Creates a new lazy variable and initialize it with a constant.
         /// </summary>
         /// <param name="value">The value to initialize the variable with.</param>
-        public LazyVariable(T value)
+        public LazyVariable(TValue value)
         {
             _value = value;
             IsInitialized = true;
@@ -30,7 +30,7 @@ namespace AsmResolver
         /// Creates a new lazy variable and delays the initialization of the default value.
         /// </summary>
         /// <param name="getValue">The method to execute when initializing the default value.</param>
-        public LazyVariable(Func<T?> getValue)
+        public LazyVariable(Func<TValue?> getValue)
         {
             _getValue = getValue ?? throw new ArgumentNullException(nameof(getValue));
         }
@@ -48,7 +48,7 @@ namespace AsmResolver
         /// <summary>
         /// Gets or sets the value of the variable.
         /// </summary>
-        public T Value
+        public TValue Value
         {
             get
             {
@@ -79,4 +79,69 @@ namespace AsmResolver
         }
 
     }
+
+    public sealed class LazyVariable<TOwner, TValue>
+    {
+        private TValue? _value;
+        private readonly Func<TOwner, TValue?>? _getValue;
+
+        /// <summary>
+        /// Creates a new lazy variable and initialize it with a constant.
+        /// </summary>
+        /// <param name="value">The value to initialize the variable with.</param>
+        public LazyVariable(TValue value)
+        {
+            _value = value;
+            IsInitialized = true;
+        }
+
+        /// <summary>
+        /// Creates a new lazy variable and delays the initialization of the default value.
+        /// </summary>
+        /// <param name="getValue">The method to execute when initializing the default value.</param>
+        public LazyVariable(Func<TOwner, TValue?> getValue)
+        {
+            _getValue = getValue ?? throw new ArgumentNullException(nameof(getValue));
+        }
+
+        /// <summary>
+        /// Gets a value indicating the value has been initialized.
+        /// </summary>
+        [MemberNotNullWhen(false, nameof(_getValue))]
+        public bool IsInitialized
+        {
+            get;
+            private set;
+        }
+
+        public TValue GetValue(TOwner owner)
+        {
+            if (!IsInitialized)
+                InitializeValue(owner);
+            return _value!;
+        }
+
+        public void SetValue(TValue value)
+        {
+            lock (this)
+            {
+                _value = value;
+                IsInitialized = true;
+            }
+        }
+
+        private void InitializeValue(TOwner owner)
+        {
+            lock (this)
+            {
+                if (!IsInitialized)
+                {
+                    _value = _getValue(owner);
+                    IsInitialized = true;
+                }
+            }
+        }
+
+    }
+
 }


### PR DESCRIPTION
Moves the entire code-base from `LazyVariable<T>` to `LazyVariable<TOwner, TValue>`, where the current instance is no longer captured in a closure but instead is passed on as an argument of the `GetValue` method.. This can significantly reduce the amount of allocations when many lazily initialized structures are being initialized (e.g., with large input binaries).