### PR TITLE
Exclude AssemblyDescriptor::Version in hashcode computation when relaxing version comparisons

### DIFF
--- a/src/AsmResolver.DotNet/Signatures/SignatureComparer.ResolutionScope.cs
+++ b/src/AsmResolver.DotNet/Signatures/SignatureComparer.ResolutionScope.cs
@@ -92,7 +92,10 @@ namespace AsmResolver.DotNet.Signatures
                 int hashCode = obj.Name is null ? 0 : obj.Name.GetHashCode();
                 hashCode = (hashCode * 397) ^ (obj.Culture is not null ? obj.Culture.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (int) TableIndex.AssemblyRef;
-                hashCode = (hashCode * 397) ^ obj.Version.GetHashCode();
+
+                if (!AcceptNewerAssemblyVersionNumbers && !AcceptOlderAssemblyVersionNumbers)
+                    hashCode = (hashCode * 397) ^ obj.Version.GetHashCode();
+
                 hashCode = (hashCode * 397) ^ (int) obj.Attributes;
 
                 byte[]? publicKeyToken = obj.GetPublicKeyToken();

--- a/test/AsmResolver.DotNet.Tests/Bundles/BundleManifestTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Bundles/BundleManifestTest.cs
@@ -205,21 +205,21 @@ namespace AsmResolver.DotNet.Tests.Bundles
             Assert.Equal(manifest.BundleID, newManifest.GenerateDeterministicBundleID());
         }
 
-        [Fact]
+        [SkippableFact]
         public void PatchAndRepackageExistingBundleV1()
         {
             Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
             AssertPatchAndRepackageChangesOutput(Properties.Resources.HelloWorld_SingleFile_V1);
         }
 
-        [Fact]
+        [SkippableFact]
         public void PatchAndRepackageExistingBundleV2()
         {
             Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
             AssertPatchAndRepackageChangesOutput(Properties.Resources.HelloWorld_SingleFile_V2);
         }
 
-        [Fact]
+        [SkippableFact]
         public void PatchAndRepackageExistingBundleV6()
         {
             Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));

--- a/test/AsmResolver.DotNet.Tests/Signatures/SignatureComparerTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Signatures/SignatureComparerTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Types;
@@ -186,6 +187,22 @@ namespace AsmResolver.DotNet.Tests.Signatures
             Assert.Equal(
                 comparer.GetHashCode((AssemblyDescriptor) assembly1),
                 comparer.GetHashCode((AssemblyDescriptor) assembly2));
+        }
+
+        [Fact]
+        public void CorlibComparison()
+        {
+            // https://github.com/Washi1337/AsmResolver/issues/427
+            
+            var comparer = new SignatureComparer(SignatureComparisonFlags.VersionAgnostic);
+
+            var reference1 = KnownCorLibs.SystemRuntime_v5_0_0_0;
+            var reference2 = KnownCorLibs.SystemRuntime_v6_0_0_0;
+            Assert.Equal(reference1, reference2, comparer);
+
+            var set = new HashSet<AssemblyReference>(comparer);
+            Assert.True(set.Add(reference1));
+            Assert.False(set.Add(reference2));
         }
 
         private class NestedTypes

--- a/test/AsmResolver.DotNet.Tests/Signatures/SignatureComparerTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Signatures/SignatureComparerTest.cs
@@ -193,7 +193,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
         public void CorlibComparison()
         {
             // https://github.com/Washi1337/AsmResolver/issues/427
-            
+
             var comparer = new SignatureComparer(SignatureComparisonFlags.VersionAgnostic);
 
             var reference1 = KnownCorLibs.SystemRuntime_v5_0_0_0;

--- a/test/AsmResolver.DotNet.Tests/Signatures/SignatureComparerTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Signatures/SignatureComparerTest.cs
@@ -165,6 +165,29 @@ namespace AsmResolver.DotNet.Tests.Signatures
             Assert.NotEqual(type2, resolvedType1, _comparer); // Fails
         }
 
+        [Fact]
+        public void AssemblyHashCodeStrict()
+        {
+            var assembly1 = new AssemblyReference("SomeAssembly", new Version(1, 2, 3, 4));
+            var assembly2 = new AssemblyReference("SomeAssembly", new Version(1, 2, 3, 4));
+
+            Assert.Equal(
+                _comparer.GetHashCode((AssemblyDescriptor) assembly1),
+                _comparer.GetHashCode((AssemblyDescriptor) assembly2));
+        }
+
+        [Fact]
+        public void AssemblyHashCodeVersionAgnostic()
+        {
+            var assembly1 = new AssemblyReference("SomeAssembly", new Version(1, 2, 3, 4));
+            var assembly2 = new AssemblyReference("SomeAssembly", new Version(5, 6, 7, 8));
+
+            var comparer = new SignatureComparer(SignatureComparisonFlags.VersionAgnostic);
+            Assert.Equal(
+                comparer.GetHashCode((AssemblyDescriptor) assembly1),
+                comparer.GetHashCode((AssemblyDescriptor) assembly2));
+        }
+
         private class NestedTypes
         {
             public class FirstType


### PR DESCRIPTION
Closes #427 