### PR TITLE
Multiple cloner listeners

### DIFF
--- a/src/AsmResolver.DotNet/Cloning/AssignTokensClonerListener.cs
+++ b/src/AsmResolver.DotNet/Cloning/AssignTokensClonerListener.cs
@@ -1,0 +1,33 @@
+namespace AsmResolver.DotNet.Cloning
+{
+    /// <summary>
+    /// Provides an implementation of a <see cref="IMemberClonerListener"/> that pre-emptively assigns new metadata
+    /// tokens to the cloned metadata members using the target module's <see cref="TokenAllocator"/>.
+    /// </summary>
+    public class AssignTokensClonerListener : MemberClonerListener
+    {
+        /// <summary>
+        /// Creates a new instance of the token allocator listener.
+        /// </summary>
+        /// <param name="targetModule">The module that will contain the cloned members.</param>
+        public AssignTokensClonerListener(ModuleDefinition targetModule)
+        {
+            TargetModule = targetModule;
+        }
+
+        /// <summary>
+        /// Gets the module that will contain the cloned members.
+        /// </summary>
+        public ModuleDefinition TargetModule
+        {
+            get;
+        }
+
+        /// <inheritdoc />
+        public override void OnClonedMember(IMemberDefinition original, IMemberDefinition cloned)
+        {
+            TargetModule.TokenAllocator.AssignNextAvailableToken((MetadataMember) cloned);
+            base.OnClonedMember(original, cloned);
+        }
+    }
+}

--- a/src/AsmResolver.DotNet/Cloning/AssignTokensClonerListener.cs
+++ b/src/AsmResolver.DotNet/Cloning/AssignTokensClonerListener.cs
@@ -1,7 +1,7 @@
 namespace AsmResolver.DotNet.Cloning
 {
     /// <summary>
-    /// Provides an implementation of a <see cref="IMemberClonerListener"/> that pre-emptively assigns new metadata
+    /// Provides an implementation of a <see cref="IMemberClonerListener"/> that preemptively assigns new metadata
     /// tokens to the cloned metadata members using the target module's <see cref="TokenAllocator"/>.
     /// </summary>
     public class AssignTokensClonerListener : MemberClonerListener

--- a/src/AsmResolver.DotNet/Cloning/MemberCloner.Fields.cs
+++ b/src/AsmResolver.DotNet/Cloning/MemberCloner.Fields.cs
@@ -42,8 +42,8 @@ namespace AsmResolver.DotNet.Cloning
             {
                 DeepCopyField(context, field);
                 var clonedMember = (FieldDefinition)context.ClonedMembers[field];
-                _clonerListener.OnClonedMember(field, clonedMember);
-                _clonerListener.OnClonedField(field, clonedMember);
+                _listeners.OnClonedMember(field, clonedMember);
+                _listeners.OnClonedField(field, clonedMember);
             }
         }
 

--- a/src/AsmResolver.DotNet/Cloning/MemberCloner.Methods.cs
+++ b/src/AsmResolver.DotNet/Cloning/MemberCloner.Methods.cs
@@ -57,8 +57,8 @@ namespace AsmResolver.DotNet.Cloning
             {
                 DeepCopyMethod(context, method);
                 var clonedMember = (MethodDefinition)context.ClonedMembers[method];
-                _clonerListener.OnClonedMember(method, clonedMember);
-                _clonerListener.OnClonedMethod(method, clonedMember);
+                _listeners.OnClonedMember(method, clonedMember);
+                _listeners.OnClonedMethod(method, clonedMember);
             }
         }
 

--- a/src/AsmResolver.DotNet/Cloning/MemberCloner.Semantics.cs
+++ b/src/AsmResolver.DotNet/Cloning/MemberCloner.Semantics.cs
@@ -18,8 +18,8 @@ namespace AsmResolver.DotNet.Cloning
                     declaringType.Properties.Add(clonedProperty);
                 }
                 var clonedMember = clonedProperty;
-                _clonerListener.OnClonedMember(property, clonedMember);
-                _clonerListener.OnClonedProperty(property, clonedMember);
+                _listeners.OnClonedMember(property, clonedMember);
+                _listeners.OnClonedProperty(property, clonedMember);
             }
         }
 
@@ -55,8 +55,8 @@ namespace AsmResolver.DotNet.Cloning
                     declaringType.Events.Add(clonedEvent);
                 }
                 var clonedMember = clonedEvent;
-                _clonerListener.OnClonedMember(@event, clonedMember);
-                _clonerListener.OnClonedEvent(@event, clonedMember);
+                _listeners.OnClonedMember(@event, clonedMember);
+                _listeners.OnClonedEvent(@event, clonedMember);
             }
         }
 

--- a/src/AsmResolver.DotNet/Cloning/MemberCloner.cs
+++ b/src/AsmResolver.DotNet/Cloning/MemberCloner.cs
@@ -17,7 +17,7 @@ namespace AsmResolver.DotNet.Cloning
     /// </remarks>
     public partial class MemberCloner
     {
-        private readonly IMemberClonerListener _clonerListener;
+        private readonly MemberClonerListenerList _listeners;
         private readonly Func<MemberCloneContext, CloneContextAwareReferenceImporter>? _importerFactory;
         private readonly ModuleDefinition _targetModule;
 
@@ -32,7 +32,7 @@ namespace AsmResolver.DotNet.Cloning
         /// </summary>
         /// <param name="targetModule">The target module to copy the members into.</param>
         public MemberCloner(ModuleDefinition targetModule)
-            : this(targetModule, (original, cloned) => { })
+            : this(targetModule, null, null)
         {
         }
 
@@ -79,7 +79,9 @@ namespace AsmResolver.DotNet.Cloning
         {
             _targetModule = targetModule ?? throw new ArgumentNullException(nameof(targetModule));
             _importerFactory = importerFactory;
-            _clonerListener = clonerListener ?? CallbackClonerListener.EmptyInstance;
+            _listeners = new MemberClonerListenerList();
+            if (clonerListener is not null)
+                _listeners.Add(clonerListener);
         }
 
         /// <summary>
@@ -263,6 +265,28 @@ namespace AsmResolver.DotNet.Cloning
         }
 
         /// <summary>
+        /// Adds a member cloner listener to the cloner.
+        /// </summary>
+        /// <param name="listener">The listener to add.</param>
+        /// <returns>The metadata cloner that the listener is added to.</returns>
+        public MemberCloner WithListener(Action<IMemberDefinition, IMemberDefinition> listener)
+        {
+            _listeners.Add(new CallbackClonerListener(listener));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a member cloner listener to the cloner.
+        /// </summary>
+        /// <param name="listener">The listener to add.</param>
+        /// <returns>The metadata cloner that the listener is added to.</returns>
+        public MemberCloner WithListener(IMemberClonerListener listener)
+        {
+            _listeners.Add(listener);
+            return this;
+        }
+
+        /// <summary>
         /// Clones all included members.
         /// </summary>
         /// <returns>An object representing the result of the cloning process.</returns>
@@ -313,8 +337,8 @@ namespace AsmResolver.DotNet.Cloning
             {
                 DeepCopyType(context, type);
                 var clonedMember = (TypeDefinition)context.ClonedMembers[type];
-                _clonerListener.OnClonedMember(type, clonedMember);
-                _clonerListener.OnClonedType(type, clonedMember);
+                _listeners.OnClonedMember(type, clonedMember);
+                _listeners.OnClonedType(type, clonedMember);
             }
         }
 

--- a/src/AsmResolver.DotNet/Cloning/MemberCloner.cs
+++ b/src/AsmResolver.DotNet/Cloning/MemberCloner.cs
@@ -269,7 +269,7 @@ namespace AsmResolver.DotNet.Cloning
         /// </summary>
         /// <param name="listener">The listener to add.</param>
         /// <returns>The metadata cloner that the listener is added to.</returns>
-        public MemberCloner WithListener(Action<IMemberDefinition, IMemberDefinition> listener)
+        public MemberCloner AddListener(Action<IMemberDefinition, IMemberDefinition> listener)
         {
             _listeners.Add(new CallbackClonerListener(listener));
             return this;
@@ -280,7 +280,7 @@ namespace AsmResolver.DotNet.Cloning
         /// </summary>
         /// <param name="listener">The listener to add.</param>
         /// <returns>The metadata cloner that the listener is added to.</returns>
-        public MemberCloner WithListener(IMemberClonerListener listener)
+        public MemberCloner AddListener(IMemberClonerListener listener)
         {
             _listeners.Add(listener);
             return this;

--- a/src/AsmResolver.DotNet/Cloning/MemberClonerListenerList.cs
+++ b/src/AsmResolver.DotNet/Cloning/MemberClonerListenerList.cs
@@ -1,0 +1,52 @@
+using System.Collections.ObjectModel;
+
+namespace AsmResolver.DotNet.Cloning
+{
+    /// <summary>
+    /// Wraps a list of <see cref="IMemberClonerListener"/>s into a single instance of <see cref="IMemberClonerListener"/>.
+    /// </summary>
+    public class MemberClonerListenerList : Collection<IMemberClonerListener>, IMemberClonerListener
+    {
+        /// <inheritdoc />
+        public void OnClonedMember(IMemberDefinition original, IMemberDefinition cloned)
+        {
+            for (int i = 0; i < Items.Count; i++)
+                Items[i].OnClonedMember(original, cloned);
+        }
+
+        /// <inheritdoc />
+        public void OnClonedType(TypeDefinition original, TypeDefinition cloned)
+        {
+            for (int i = 0; i < Items.Count; i++)
+                Items[i].OnClonedType(original, cloned);
+        }
+
+        /// <inheritdoc />
+        public void OnClonedMethod(MethodDefinition original, MethodDefinition cloned)
+        {
+            for (int i = 0; i < Items.Count; i++)
+                Items[i].OnClonedMethod(original, cloned);
+        }
+
+        /// <inheritdoc />
+        public void OnClonedField(FieldDefinition original, FieldDefinition cloned)
+        {
+            for (int i = 0; i < Items.Count; i++)
+                Items[i].OnClonedField(original, cloned);
+        }
+
+        /// <inheritdoc />
+        public void OnClonedProperty(PropertyDefinition original, PropertyDefinition cloned)
+        {
+            for (int i = 0; i < Items.Count; i++)
+                Items[i].OnClonedProperty(original, cloned);
+        }
+
+        /// <inheritdoc />
+        public void OnClonedEvent(EventDefinition original, EventDefinition cloned)
+        {
+            for (int i = 0; i < Items.Count; i++)
+                Items[i].OnClonedEvent(original, cloned);
+        }
+    }
+}

--- a/test/AsmResolver.DotNet.Tests/Cloning/MetadataClonerTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Cloning/MetadataClonerTest.cs
@@ -401,8 +401,8 @@ namespace AsmResolver.DotNet.Tests.Cloning
 
             var result = new MemberCloner(targetModule)
                 .Include(type)
-                .WithListener(new InjectTypeClonerListener(targetModule))
-                .WithListener(new AssignTokensClonerListener(targetModule))
+                .AddListener(new InjectTypeClonerListener(targetModule))
+                .AddListener(new AssignTokensClonerListener(targetModule))
                 .Clone();
 
             Assert.All(result.ClonedTopLevelTypes, t => Assert.Contains(t, targetModule.TopLevelTypes));

--- a/test/AsmResolver.DotNet.Tests/Cloning/MetadataClonerTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Cloning/MetadataClonerTest.cs
@@ -76,7 +76,7 @@ namespace AsmResolver.DotNet.Tests.Cloning
             return clonedMethod;
         }
 
-        private static FieldDefinition CloneIntializerField(FieldInfo field, out FieldDefinition originalFieldDef)
+        private static FieldDefinition CloneInitializerField(FieldInfo field, out FieldDefinition originalFieldDef)
         {
             var sourceModule = ModuleDefinition.FromFile(field.Module.Assembly.Location);
             originalFieldDef = (FieldDefinition) sourceModule.LookupMember(field.MetadataToken);
@@ -279,10 +279,10 @@ namespace AsmResolver.DotNet.Tests.Cloning
         public void CloneFieldRva()
         {
             var clonedInitializerField =
-                CloneIntializerField(typeof(InitialValues).GetField(nameof(InitialValues.ByteArray)), out var field);
+                CloneInitializerField(typeof(InitialValues).GetField(nameof(InitialValues.ByteArray)), out var field);
 
-            var originalData = ((IReadableSegment) field.FieldRva).ToArray();
-            var newData = ((IReadableSegment) clonedInitializerField.FieldRva).ToArray();
+            var originalData = ((IReadableSegment) field.FieldRva!).ToArray();
+            var newData = ((IReadableSegment) clonedInitializerField.FieldRva!).ToArray();
 
             Assert.Equal(originalData, newData);
         }
@@ -391,5 +391,22 @@ namespace AsmResolver.DotNet.Tests.Cloning
             Assert.All(result.ClonedTopLevelTypes, t => Assert.Contains(t, targetModule.TopLevelTypes));
         }
 
+        [Fact]
+        public void CloneAndInjectAndAssignToken()
+        {
+            var sourceModule = ModuleDefinition.FromFile(typeof(Miscellaneous).Assembly.Location);
+            var targetModule = PrepareTempModule();
+
+            var type = sourceModule.TopLevelTypes.First(t => t.Name == nameof(Miscellaneous));
+
+            var result = new MemberCloner(targetModule)
+                .Include(type)
+                .WithListener(new InjectTypeClonerListener(targetModule))
+                .WithListener(new AssignTokensClonerListener(targetModule))
+                .Clone();
+
+            Assert.All(result.ClonedTopLevelTypes, t => Assert.Contains(t, targetModule.TopLevelTypes));
+            Assert.All(result.ClonedMembers, m => Assert.NotEqual(0u, ((IMetadataMember) m).MetadataToken.Rid));
+        }
     }
 }


### PR DESCRIPTION
Includes
- `MemberClonerListenerList` for chaining multiple cloner listeners
- `AssignTokensClonerListener` for automatically assigning new tokens to cloned members.
- `MemberCloner::AddListener` for adding new listeners easily.