### PR TITLE
Relax constraints on duplicated members in metadata buffers

### DIFF
--- a/src/AsmResolver.DotNet/Builder/DotNetDirectoryBuffer.TokenProvider.cs
+++ b/src/AsmResolver.DotNet/Builder/DotNetDirectoryBuffer.TokenProvider.cs
@@ -38,7 +38,7 @@ namespace AsmResolver.DotNet.Builder
                 Metadata.StringsStream.GetStringIndex(type.Name),
                 Metadata.StringsStream.GetStringIndex(type.Namespace));
 
-            var token = preserveRid
+            var token = preserveRid && type.MetadataToken.Rid != 0
                 ? table.Insert(type.MetadataToken.Rid, row, allowDuplicates)
                 : table.Add(row, allowDuplicates);
 
@@ -205,7 +205,7 @@ namespace AsmResolver.DotNet.Builder
                 Metadata.StringsStream.GetStringIndex(assembly.Culture),
                 Metadata.BlobStream.GetBlobIndex(assembly.HashValue));
 
-            var token = preserveRid
+            var token = preserveRid && assembly.MetadataToken.Rid != 0
                 ? table.Insert(assembly.MetadataToken.Rid, row, allowDuplicates)
                 : table.Add(row, allowDuplicates);
 
@@ -243,7 +243,7 @@ namespace AsmResolver.DotNet.Builder
             var table = Metadata.TablesStream.GetDistinctTable<ModuleReferenceRow>(TableIndex.ModuleRef);
 
             var row = new ModuleReferenceRow(Metadata.StringsStream.GetStringIndex(reference.Name));
-            var token = preserveRid
+            var token = preserveRid && reference.MetadataToken.Rid != 0
                 ? table.Insert(reference.MetadataToken.Rid, row, allowDuplicates)
                 : table.Add(row, allowDuplicates);
 

--- a/src/AsmResolver.DotNet/Builder/DotNetDirectoryFactory.cs
+++ b/src/AsmResolver.DotNet/Builder/DotNetDirectoryFactory.cs
@@ -215,9 +215,6 @@ namespace AsmResolver.DotNet.Builder
 
         private void ImportBasicTablesIfSpecified(ModuleDefinition module, DotNetDirectoryBuffer buffer)
         {
-            if (module.DotNetDirectory is null)
-                return;
-
             // NOTE: The order of this table importing is crucial.
             //
             // Assembly refs should always be imported prior to importing type refs, which should be imported before
@@ -246,9 +243,6 @@ namespace AsmResolver.DotNet.Builder
 
         private void ImportTypeSpecsIfSpecified(ModuleDefinition module, DotNetDirectoryBuffer buffer)
         {
-            if (module.DotNetDirectory is null)
-                return;
-
             if ((MetadataBuilderFlags & MetadataBuilderFlags.PreserveTypeSpecificationIndices) != 0)
             {
                 ImportTables<TypeSpecification>(module, TableIndex.TypeSpec,
@@ -258,9 +252,6 @@ namespace AsmResolver.DotNet.Builder
 
         private void ImportMemberRefsIfSpecified(ModuleDefinition module, DotNetDirectoryBuffer buffer)
         {
-            if (module.DotNetDirectory is null)
-                return;
-
             if ((MetadataBuilderFlags & MetadataBuilderFlags.PreserveMemberReferenceIndices) != 0)
             {
                 ImportTables<MemberReference>(module, TableIndex.MemberRef,
@@ -270,9 +261,6 @@ namespace AsmResolver.DotNet.Builder
 
         private void ImportRemainingTablesIfSpecified(ModuleDefinition module, DotNetDirectoryBuffer buffer)
         {
-            if (module.DotNetDirectory is null)
-                return;
-
             if ((MetadataBuilderFlags & MetadataBuilderFlags.PreserveStandAloneSignatureIndices) != 0)
             {
                 ImportTables<StandAloneSignature>(module, TableIndex.StandAloneSig,
@@ -289,10 +277,10 @@ namespace AsmResolver.DotNet.Builder
         private static void ImportTables<TMember>(ModuleDefinition module, TableIndex tableIndex,
             Func<TMember, MetadataToken> importAction)
         {
-            int count = module.DotNetDirectory!.Metadata
-                !.GetStream<TablesStream>()
+            int count = module.DotNetDirectory?.Metadata?
+                .GetStream<TablesStream>()
                 .GetTable(tableIndex)
-                .Count;
+                .Count ?? 0;
 
             for (uint rid = 1; rid <= count; rid++)
                 importAction((TMember) module.LookupMember(new MetadataToken(tableIndex, rid)));

--- a/src/AsmResolver.DotNet/Builder/TokenMapping.cs
+++ b/src/AsmResolver.DotNet/Builder/TokenMapping.cs
@@ -64,12 +64,14 @@ namespace AsmResolver.DotNet.Builder
             if (member.MetadataToken.Table != newToken.Table)
                 throw new ArgumentException($"Cannot assign a {newToken.Table} metadata token to a {member.MetadataToken.Table}.");
 
-            if (TryGetNewToken(member, out var existingToken))
-            {
-                if (existingToken.Rid != newToken.Rid)
-                    throw new ArgumentException($"Member {member.SafeToString()} was already assigned a metadata token.");
+            // We allow for members to be duplicated in the mapping, but we will only keep track of the first token that
+            // was registered for this member. This may result in a slightly different binary if token preservation is
+            // enabled (e.g., a member may originally have referenced a duplicated member as opposed to the first one,
+            // and this would always make it reference the first one), but since both members are semantically equivalent,
+            // referencing one or the other should also be semantics-preserving. Note that both duplicated members will
+            // still be present in the final binary with their original RIDs.
+            if (TryGetNewToken(member, out _))
                 return;
-            }
 
             switch (member.MetadataToken.Table)
             {

--- a/src/AsmResolver/Collections/BitList.cs
+++ b/src/AsmResolver/Collections/BitList.cs
@@ -46,7 +46,7 @@ namespace AsmResolver.Collections
         {
             get
             {
-                if (index >= Count)
+                if (index < 0 || index >= Count)
                     throw new IndexOutOfRangeException();
 
                 (int wordIndex, int bitIndex) = SplitWordBitIndex(index);
@@ -54,7 +54,7 @@ namespace AsmResolver.Collections
             }
             set
             {
-                if (index >= Count)
+                if (index < 0 || index >= Count)
                     throw new IndexOutOfRangeException();
 
                 (int wordIndex, int bitIndex) = SplitWordBitIndex(index);
@@ -119,7 +119,7 @@ namespace AsmResolver.Collections
         /// <inheritdoc />
         public void Insert(int index, bool item)
         {
-            if (index > Count)
+            if (index < 0 || index > Count)
                 throw new IndexOutOfRangeException();
 
             EnsureCapacity(Count++);


### PR DESCRIPTION
Includes:
- Extra `BitList` bounds checks.
- Fix for token allocation within newly constructed modules.
- Relaxation of rules on duplicated members in metadata buffers.