### PR TITLE
TypeDefinition::GetConstructor and others

### DIFF
--- a/docs/guides/dotnet/cloning.md
+++ b/docs/guides/dotnet/cloning.md
@@ -82,8 +82,8 @@ look up the members by metadata token.
 
 ``` csharp
 var sourceModule = ModuleDefinition.FromFile(typeof(Rectangle).Assembly.Location);
-var rectangleType = (TypeDefinition) sourceModule.LookupMember(typeof(Rectangle).MetadataToken);
-var vectorType = (TypeDefinition) sourceModule.LookupMember(typeof(Vector2).MetadataToken);
+var rectangleType = sourceModule.LookupMember<TypeDefinition>(typeof(Rectangle).MetadataToken);
+var vectorType = sourceModule.LookupMember<TypeDefinition>(typeof(Vector2).MetadataToken);
 ```
 
 We can then use `MemberCloner.Include` to include the types in the
@@ -103,7 +103,7 @@ cloner.Include(rectangleType);
 cloner.Include(vectorType);
 ```
 
-`Include` returns the same `MemberCloner` instance, allowing for more fluent 
+`Include` returns the same `MemberCloner` instance, allowing for more fluent
 syntax:
 
 ``` csharp
@@ -305,8 +305,8 @@ foreach (var clonedType in clonedTypes)
 ```
 
 Injecting the cloned top level types is a very common use-case for the cloner.
-AsmResolver defines the `InjectTypeClonerListener` class that implements a 
-cloner listener that injects all top-level types automatically into 
+AsmResolver defines the `InjectTypeClonerListener` class that implements a
+cloner listener that injects all top-level types automatically into
 the destination module. In such a case, the code can be reduced to the following:
 
 ``` csharp

--- a/docs/guides/dotnet/managed-method-bodies.md
+++ b/docs/guides/dotnet/managed-method-bodies.md
@@ -1,5 +1,10 @@
 # CIL Method Bodies
 
+Most methods defined in a .NET module are implemented using the Common
+Intermediate Language (CIL), and AsmResolver provides high-level
+disassembler and assembler capabilities for creating, reading and writing
+method bodies written in this language.
+
 The relevant models in this document can be found in the following
 namespaces:
 
@@ -33,7 +38,9 @@ blocks:
 -   `ExceptionHandlers`: A collection of regions protected by an
     exception handler.
 
-## Basic structure of CIL instructions
+## Instructions
+
+### Basic structure of CIL instructions
 
 Instructions that are assembled into the method body are automatically
 disassembled and put in a mutable collection of `CilInstruction`,
@@ -53,27 +60,27 @@ The `CilInstruction` class defines three basic properties:
 By default, depending on the value of `OpCode.OperandType`, `Operand`
 contains (and always should contain) one of the following:
 
-|OpCode.OperandType                  |Type of Operand                         |                
-|------------------------------------|----------------------------------------|                                        
-|`CilOperandType.InlineNone`         |N/A (is always `null`)                  |                        
-|`CilOperandType.ShortInlineI`       |`sbyte`                                 |        
-|`CilOperandType.InlineI`            |`int`                                   |        
-|`CilOperandType.InlineI8`           |`long`                                  |        
-|`CilOperandType.ShortInlineR`       |`float`                                 |        
-|`CilOperandType.InlineR`            |`double`                                |            
-|`CilOperandType.InlineString`       |`string` or `MetadataToken`             |                            
-|`CilOperandType.InlineBrTarget`     |`ICilLabel` or `int`                    |                        
-|`CilOperandType.ShortInlineBrTarget`|`ICilLabel` or `sbyte`                  |                        
-|`CilOperandType.InlineSwitch`       |`IList<ICilLabel>`                      |                    
-|`CilOperandType.ShortInlineVar`     |`CilLocalVariable` or `byte`            |                                
-|`CilOperandType.InlineVar`          |`CilLocalVariable` or `ushort`          |                                
-|`CilOperandType.ShortInlineArgument`|`Parameter` or `byte`                   |                        
-|`CilOperandType.InlineArgument`     |`Parameter` or `ushort`                 |                        
-|`CilOperandType.InlineField`        |`IFieldDescriptor` or `MetadataToken`   |                                        
-|`CilOperandType.InlineMethod`       |`IMethodDescriptor` or `MetadataToken`  |                                        
-|`CilOperandType.InlineSig`          |`StandAloneSignature` or `MetadataToken`|                                            
-|`CilOperandType.InlineTok`          |`IMetadataMember` or `MetadataToken`    |                                        
-|`CilOperandType.InlineType`         |`ITypeDefOrRef` or `MetadataToken`      |                                        
+|OpCode.OperandType                  |Type of Operand                         |
+|------------------------------------|----------------------------------------|
+|`CilOperandType.InlineNone`         |N/A (is always `null`)                  |
+|`CilOperandType.ShortInlineI`       |`sbyte`                                 |
+|`CilOperandType.InlineI`            |`int`                                   |
+|`CilOperandType.InlineI8`           |`long`                                  |
+|`CilOperandType.ShortInlineR`       |`float`                                 |
+|`CilOperandType.InlineR`            |`double`                                |
+|`CilOperandType.InlineString`       |`string` or `MetadataToken`             |
+|`CilOperandType.InlineBrTarget`     |`ICilLabel` or `int`                    |
+|`CilOperandType.ShortInlineBrTarget`|`ICilLabel` or `sbyte`                  |
+|`CilOperandType.InlineSwitch`       |`IList<ICilLabel>`                      |
+|`CilOperandType.ShortInlineVar`     |`CilLocalVariable` or `byte`            |
+|`CilOperandType.InlineVar`          |`CilLocalVariable` or `ushort`          |
+|`CilOperandType.ShortInlineArgument`|`Parameter` or `byte`                   |
+|`CilOperandType.InlineArgument`     |`Parameter` or `ushort`                 |
+|`CilOperandType.InlineField`        |`IFieldDescriptor` or `MetadataToken`   |
+|`CilOperandType.InlineMethod`       |`IMethodDescriptor` or `MetadataToken`  |
+|`CilOperandType.InlineSig`          |`StandAloneSignature` or `MetadataToken`|
+|`CilOperandType.InlineTok`          |`IMetadataMember` or `MetadataToken`    |
+|`CilOperandType.InlineType`         |`ITypeDefOrRef` or `MetadataToken`      |
 
 
 > [!WARNING]
@@ -103,7 +110,7 @@ instructions.Add(CilOpCodes.Ldstr, "Hello, World!");
 instructions.Add(CilOpCodes.Ret);
 ```
 
-## Pushing 32-bit integer constants onto the stack
+### Pushing 32-bit integer constants onto the stack
 
 In CIL, pushing integer constants onto the stack is done using one of
 the `ldc.i4` instruction variants.
@@ -124,7 +131,7 @@ If we want to get the pushed value, we can use the
 the `ldc.i4` variants, including all the macro opcodes that do not
 explicitly define an operand such as `ldc.i4.1`.
 
-## Branching Instructions
+### Branching Instructions
 
 Branch instructions are instructions that (might) transfer control to
 another part of the method body. To reference the instruction to jump to
@@ -160,7 +167,7 @@ The `switch` operation uses a `IList<ICilLabel>` instead.
 > code stream. This can be disabled by setting `VerifyLabelsOnBuild` to
 > `false`.
 
-## Finding instructions by offset
+### Finding Instructions by Offset
 
 Instructions stored in a method body are indexed not by offset, but by
 order of occurrence. If it is required to find an instruction by offset,
@@ -187,7 +194,7 @@ int index = body.Instructions.GetIndexByOffset(0x0012);
 instruction1 = body.Instructions[index];
 ```
 
-## Referencing members
+### Referencing Members
 
 As specified by the table above, operations such as a `call` require a
 member as operand.
@@ -211,7 +218,7 @@ More information on the capabilities and limitations of the
 `ReferenceImporter` can be found in
 [Reference Importing](importing.md).
 
-## Expanding and optimising macros
+### Expanding and Optimizing Macros
 
 CIL defines a couple of macro operations that do the same as their full
 counterpart, but require less space to be encoded. For example, the
@@ -240,7 +247,7 @@ body.Instructions.ExpandMacros();
 // instruction is now expanded to "ldc.i4 1".
 ```
 
-## Pretty printing CIL instructions
+### Pretty printing CIL Instructions
 
 Instructions can be formatted using e.g. an instance of the
 `CilInstructionFormatter`:
@@ -251,7 +258,7 @@ foreach (CilInstruction instruction in body.Instructions)
     Console.WriteLine(formatter.FormatInstruction(instruction));
 ```
 
-## Patching CIL instructions
+### Patching CIL Instructions
 
 Instructions can be added or removed using the `Add`, `Insert`, `Remove`
 and `RemoveAt` methods:
@@ -297,7 +304,32 @@ helper function:
 body.Instructions[i].ReplaceWithNop();
 ```
 
-## Exception handlers
+## Local Variables
+
+Most methods will define local variables to temporarily store state
+throughout the execution of the method's code. Local variables are
+exposed through the `CilMethodBody.LocalVariables` property, and are
+represented using the `CilLocalVariable` class.
+
+```csharp
+CilMethodBody body = ...;
+foreach (var local in body.LocalVariables)
+    Console.WriteLine($"{local.Index}: {local.VariableType}");
+```
+
+New variables can be created by calling its constructor:
+
+```csharp
+ModuleDefinition module = ...;
+var local = new CilLocalVariable(module.CorLibTypeFactory.Int32);
+```
+
+New variables can be added to the method:
+```csharp
+body.LocalVariables.Add(local);
+```
+
+## Exception Handlers
 
 Exception handlers are regions in the method body that are protected
 from exceptions. In AsmResolver, they are represented by the
@@ -321,6 +353,45 @@ from exceptions. In AsmResolver, they are represented by the
 Depending on the value of `HandlerType`, either `FilterStart` or
 `ExceptionType`, or neither has a value.
 
+```csharp
+CilMethodBody body = ...;
+foreach (var handler in body.ExceptionHandlers)
+{
+    Console.WriteLine($"HandlerType:   {handler.HandlerType}");
+    Console.WriteLine($"TryStart:      {handler.TryStart}");
+    Console.WriteLine($"TryEnd:        {handler.TryEnd}");
+    Console.WriteLine($"HandlerStart:  {handler.HandlerStart}");
+    Console.WriteLine($"HandlerEnd:    {handler.HandlerEnd}");
+
+    if (handler.HandlerType == CilExceptionHandlerType.Exception)
+    {
+        // handler is a try-catch with an exception type.
+        Console.WriteLine($"ExceptionType: {handler.ExceptionType}");
+    }
+    else if if (handler.HandlerType == CilExceptionHandlerType.Filter)
+    {
+        // handler is a try-catch with a custom filter:
+        Console.WriteLine($"FilterStart:   {handler.FilterStart}");
+    }
+}
+```
+
+New handlers can be added to the method body:
+
+```csharp
+body.ExceptionHandlers.Add(new CilExceptionHandler
+{
+    HandlerType = CilExceptionHandlerType.Exception,
+    TryStart = body.Instructions[0].CreateLabel(),
+    TryEnd = body.Instructions[4].CreateLabel(),
+    HandlerStart = body.Instructions[4].CreateLabel(),
+    HandlerEnd = body.Instructions[8].CreateLabel(),
+    ExceptionType = module.CorLibTypeFactory.CorLibScope
+        .CreateTypeReference("System", "Exception")
+        .ImprotWith(module.DefaultImporter)
+});
+```
+
 > [!NOTE]
 > Similar to branch instructions, when an exception handler contains a
 > `null` label or a label that references an instruction that is not
@@ -328,7 +399,8 @@ Depending on the value of `HandlerType`, either `FilterStart` or
 > serializing the code stream. This can be disabled by setting
 > `VerifyLabelsOnBuild` to `false`.
 
-## Maximum stack depth
+
+## Maximum Stack Depth
 
 CIL method bodies work with a stack, and the stack has a pre-defined
 size. This pre-defined size is defined by the `MaxStack` property.

--- a/docs/guides/dotnet/member-tree.md
+++ b/docs/guides/dotnet/member-tree.md
@@ -1,6 +1,6 @@
 # The Member Tree
 
-## Assemblies and modules
+## Assemblies and Modules
 
 The root of every .NET assembly is represented by the
 `AssemblyDefinition` class. This class exposes basic information such as
@@ -20,14 +20,32 @@ Most .NET assemblies only have one module. This main module is also
 known as the manifest module, and can be accessed directly through the
 `AssemblyDefinition.ManifestModule` property.
 
-## Obtaining types in a module
+Executable modules can have an entry point, which can be obtained using
+the `ManagedEntryPoint` property:
 
-Types are represented by the `TypeDefinition` class. To get the types
-defined in a module, use the `ModuleDefinition.TopLevelTypes` property.
-A top level types is any non-nested type. Nested types are exposed
-through the `TypeDefinition.NestedTypes`. Alternatively, to get all
-types, including nested types, it is possible to call the
-`ModuleDefinition.GetAllTypes` method instead.
+```csharp
+var entryPoint = module.ManagedEntryPoint;
+```
+
+Often, modules also contain a static module constructor, which is executed
+the moment the module is loaded into memory by the CLR (and thus before the
+entry point is executed). AsmResolver provides helper methods to quickly
+locate such a constructor:
+
+```csharp
+var cctor = module.GetModuleConstructor();
+```
+
+## Types
+
+Types form logical units or data type defined in a module, and are
+represented by the `TypeDefinition` class.
+
+### Inspecting Types in a Module
+
+Types defined in a module are exposed through the `ModuleDefinition.TopLevelTypes`
+property. A top level types is any non-nested type. Nested types
+are exposed through the `TypeDefinition.NestedTypes`.
 
 Below is an example program that iterates through all types recursively
 and prints them:
@@ -55,33 +73,169 @@ private static void DumpTypes(IEnumerable<TypeDefinition> types, int indentation
 }
 ```
 
-## Obtaining methods and fields
-
-The `TypeDefinition` class exposes collections of methods and fields
-that the type defines:
+Alternatively, you can get all the types including nested types using the
+`ModuleDefinition.GetAllTypes()` method:
 
 ``` csharp
-foreach (var method in type.Methods)
-    Console.WriteLine($"{method.Name} : {method.MetadataToken}");
+var module = ModuleDefinition.FromFile(...);
+foreach (var type in module.GetAllTypes())
+    Console.WriteLine(type.FullName);
 ```
+
+### Creating New Types
+
+New types can be created by calling one of its constructors:
+
+```csharp
+ModuleDefinition module = ...
+var newType = new TypeDefinition(
+    "Namespace",
+    "Name",
+    TypeAttributes.Public,
+    module.CorLibTypeFactory.Object);
+```
+
+> [!WARNING]
+> For classes, ensure that you specify a non-null base type or the CLR will
+> not load the binary properly.
+
+For structures, make sure that your type inherits from `System.ValueType`:
+
+```csharp
+ModuleDefinition module = ...
+var newType = new TypeDefinition(
+    "Namespace",
+    "Name",
+    TypeAttributes.Public,
+    module.CorLibTypeFactory.CorLibScope
+        .CreateTypeReference("System", "ValueType")
+        .ImportWith(module.DefaultImporter));
+```
+
+Interfaces in a .NET module do not have a base type, and as such, creating
+new interfaces will not require specifying one:
+
+```csharp
+ModuleDefinition module = ...
+var newType = new TypeDefinition(
+    "Namespace",
+    "IName",
+    TypeAttributes.Public | TypeAttributes.Interface);
+```
+
+Once a type has been constructed, it can be added to either a `ModuleDefinition`
+as a top-level type, or to another `TypeDefinition` as a nested type:
+
+```csharp
+ModuleDefinition module = ...;
+module.TopLevelTypes.Add(newType);
+```
+```csharp
+TypeDefinition type = ...;
+type.NestedTypes.Add(newType);
+```
+
+## Fields
+
+Fields comprise all the data a type stores, and form the internal structure
+of a class or value type. They are represented using the `FieldDefinition`
+class.
+
+### Inspecting Fields in a Type
+
+The `TypeDefinition` class exposes a collection of fields that the type
+defines:
 
 ``` csharp
 foreach (var field in type.Fields)
     Console.WriteLine($"{field.Name} : {field.MetadataToken}");
 ```
 
+Fields have a signature which contains the field's type.
+
+``` csharp
+FieldDefinition field = ...
+Console.WriteLine($"Field type: {field.Signature.FieldType}");
+```
+
+Fields can also have constants attached, exposed via the `Constant`
+property:
+
+``` csharp
+FieldDefinition field = ...
+if (field.Constant is { } constant)
+    Console.WriteLine($"Field Constant Data: {BitConverter.ToString(constant.Value>Data)}");
+```
+
+For fields that have an RVA attached (such as fields with an initial
+value set), you can access the `FieldRva` property containing the
+`ISegment` value with the raw data. This is in particular useful for
+inspecting fields containing the initial raw data of an array.
+
+``` csharp
+FieldDefinition field = ...
+if (field.FieldRva is { } rva)
+    Console.WriteLine($"Field Initial Data: {BitConverter.ToString(rva.WriteIntoArray())}");
+```
+
+Refer to [Reading and Writing File Segments](../core/segments.md) for more
+information on how to use `ISegment`s.
+
+
+### Creating New Fields
+
+Creating and adding new fields can be done by using one of its constructors.
+
+``` csharp
+ModuleDefinition module = ...;
+var field = new FieldDefinition(
+    "MyField",
+    FieldAttributes.Public,
+    module.CorLibTypeFactory.Int32);"
+```
+
+Fields can be added to a type:
+
+```csharp
+TypeDefinition type = ...;
+type.Fields.Add(field);
+```
+
+Most properties in `FieldDefinition` are mutable, allowing you to configure
+however you want your new field to be.
+
+
+## Methods
+
+Methods are functions defined in a type, and provide a way to define
+operations that can be applied to a type. They are represented using
+the `MethodDefinition` class.
+
+### Inspecting Methods in a Type
+
+The `TypeDefinition` class exposes a collection of methods that the type
+defines:
+
+``` csharp
+foreach (var method in type.Methods)
+    Console.WriteLine($"{method.Name} : {method.MetadataToken}");
+```
+
+AsmResolver provides helper methods to find constructors in a type:
+
+``` csharp
+var parameterlessCtor = type.GetConstructor();
+var parameterizedCtor = type.GetConstructor(module.CorLibFactory.Int32);
+var cctor = type.GetStaticConstructor();
+```
+
 Methods and fields have a `Signature` property, that contain the return
-and parameter types, or the field type respectively.
+and parameter types:
 
 ``` csharp
 MethodDefinition method = ...
 Console.WriteLine($"Return type:     {method.Signature.ReturnType}");
 Console.WriteLine($"Parameter types: {string.Join(", ", method.Signature.ParameterTypes)}");
-```
-
-``` csharp
-FieldDefinition field = ...
-Console.WriteLine($"Field type: {field.Signature.FieldType}");
 ```
 
 However, for reading parameters from a method definition, it is
@@ -96,19 +250,106 @@ foreach (var parameter in method.Parameters)
     Console.WriteLine($"{parameter.Name} : {parameter.ParameterType}");
 ```
 
-## Obtaining properties and events
+Methods may or may not be assigned a method body. This can be verified
+using `HasMethodBody`:
+
+```csharp
+if (method.HasMethodBody)
+{
+    // ...
+}
+```
+
+
+Typically, a method body implemented using the Common Intermediate
+Language (CIL), the bytecode used by .NET. This method body can be
+inspected using the `CilMethodBody` property:
+
+```csharp
+if (method.CilMethodBody is { } body)
+{
+    foreach (var instruction in body.Instructions)
+        Console.WriteLine(instruction);
+}
+```
+
+For more information on CIL method bodies, refer to
+[CIL Method Bodies](managed-method-bodies.md).
+
+
+### Creating New Methods
+
+Creating new methods can be done either through one of its constructors,
+taking a name, attributes, and a method signature.
+
+For static methods, use the `MethodSignature.CreateStatic` to create
+the signature:
+
+``` csharp
+ModuleDefinition module = ...;
+var method = new MethodDefinition(
+    "MyMethod",
+    MethodAttributes.Public | MethodAttributes.Static,
+    MethodSignature.CreateStatic(
+        module.CorLibTypeFactory.Void,   // Return type
+        module.CorLibTypeFactory.Int32,  // Parameter 1
+        module.CorLibTypeFactory.String // Parameter 2
+    ));
+```
+
+Similarly, for instance methods, use the `MethodSignature.CreateInstance`
+to create the signature:
+
+``` csharp
+ModuleDefinition module = ...;
+var method = new MethodDefinition(
+    "MyMethod",
+    MethodAttributes.Public,
+    MethodSignature.CreateInstance(
+        module.CorLibTypeFactory.Void,   // Return type
+        module.CorLibTypeFactory.Int32,  // Parameter 1
+        module.CorLibTypeFactory.String // Parameter 2
+    ));
+```
+
+AsmResolver provides helper methods to create special methods such as
+constructors that automatically set the right attributes and initialize
+it with a default method body.
+
+```csharp
+ModuleDefinition module = ...;
+var ctor = MethodDefinition.CreateConstructor(module.CorLibTypeFactory.Int32);
+var cctor = MethodDefinition.CreateStaticConstructor();
+```
+
+After creating methods, they can be added to a type:
+
+```csharp
+TypeDefinition type = ...;
+type.Methods.Add(method);
+```
+
+Most properties in `MethodDefinition` are mutable, allowing you to configure
+however you want your new method to be.
+
+
+## Properties and Events
+
+Properties and Events add special semantics to groups of methods, and are
+represented using the `PropertyDefinition` and `EventDefinition` classes
+respectively.
 
 Obtaining properties and events is similar to obtaining methods and
 fields; `TypeDefinition` exposes them in a list as well:
 
 ``` csharp
-foreach (var @event in type.Events)
-    Console.WriteLine($"{@event.Name} : {@event.MetadataToken}");
+foreach (var property in type.Properties)
+    Console.WriteLine($"{property.Name} : {property.MetadataToken}");
 ```
 
 ``` csharp
-foreach (var property in type.Properties)
-    Console.WriteLine($"{property.Name} : {property.MetadataToken}");
+foreach (var @event in type.Events)
+    Console.WriteLine($"{@event.Name} : {@event.MetadataToken}");
 ```
 
 Properties and events have methods associated to them. These are
@@ -116,7 +357,22 @@ accessible through the `Semantics` property:
 
 ``` csharp
 foreach (MethodSemantics semantic in property.Semantics)
-{
     Console.WriteLine($"{semantic.Attributes} {semantic.Method.Name} : {semantic.MetadataToken}");
-}
+```
+
+For properties, there are helpers defined to quickly access the getter
+or setter methods of the property:
+
+```csharp
+MethodDefinition getter = property.GetMethod;
+MethodDefinition setter = property.SetMethod;
+```
+
+Similarly, for events, there exists helpers for obtaining the add,
+remove, and fire methods:
+
+```csharp
+MethodDefinition adder = property.AddMethod;
+MethodDefinition remover = property.RemoveMethod;
+MethodDefinition fire = property.FireMethod;
 ```

--- a/src/AsmResolver.DotNet/TypeDefinition.cs
+++ b/src/AsmResolver.DotNet/TypeDefinition.cs
@@ -832,16 +832,7 @@ namespace AsmResolver.DotNet
                 if (module == null)
                     throw new ArgumentNullException(nameof(module));
 
-                cctor = new MethodDefinition(".cctor",
-                    MethodAttributes.Private
-                    | MethodAttributes.Static
-                    | MethodAttributes.SpecialName
-                    | MethodAttributes.RuntimeSpecialName,
-                    MethodSignature.CreateStatic(module.CorLibTypeFactory.Void));
-
-                cctor.CilMethodBody = new CilMethodBody(cctor);
-                cctor.CilMethodBody.Instructions.Add(new CilInstruction(0, CilOpCodes.Ret));
-
+                cctor = MethodDefinition.CreateStaticConstructor(module);
                 Methods.Insert(0, cctor);
             }
 
@@ -860,44 +851,44 @@ namespace AsmResolver.DotNet
         /// <summary>
         /// Finds the instance constructor with the provided parameter types this type defines.
         /// </summary>
-        /// <param name="arguments">An ordered list of types the parameters of the constructor should have.</param>
+        /// <param name="parameterTypes">An ordered list of types the parameters of the constructor should have.</param>
         /// <returns>The constructor, or <c>null</c> if none is present.</returns>
-        public MethodDefinition? GetConstructor(params TypeSignature[] arguments)
+        public MethodDefinition? GetConstructor(params TypeSignature[] parameterTypes)
         {
-            return GetConstructor(SignatureComparer.Default, arguments);
+            return GetConstructor(SignatureComparer.Default, parameterTypes);
         }
 
         /// <summary>
         /// Finds the instance constructor with the provided parameter types this type defines.
         /// </summary>
         /// <param name="comparer">The signature comparer to use when comparing the parameter types.</param>
-        /// <param name="arguments">An ordered list of types the parameters of the constructor should have.</param>
+        /// <param name="parameterTypes">An ordered list of types the parameters of the constructor should have.</param>
         /// <returns>The constructor, or <c>null</c> if none is present.</returns>
-        public MethodDefinition? GetConstructor(SignatureComparer comparer, params TypeSignature[] arguments)
+        public MethodDefinition? GetConstructor(SignatureComparer comparer, params TypeSignature[] parameterTypes)
         {
-            return GetConstructor(comparer, (IList<TypeSignature>) arguments);
+            return GetConstructor(comparer, (IList<TypeSignature>) parameterTypes);
         }
 
         /// <summary>
         /// Finds the instance constructor with the provided parameter types this type defines.
         /// </summary>
         /// <param name="comparer">The signature comparer to use when comparing the parameter types.</param>
-        /// <param name="arguments">An ordered list of types the parameters of the constructor should have.</param>
+        /// <param name="parameterTypes">An ordered list of types the parameters of the constructor should have.</param>
         /// <returns>The constructor, or <c>null</c> if none is present.</returns>
-        public MethodDefinition? GetConstructor(SignatureComparer comparer, IList<TypeSignature> arguments)
+        public MethodDefinition? GetConstructor(SignatureComparer comparer, IList<TypeSignature> parameterTypes)
         {
             for (int i = 0; i < Methods.Count; i++)
             {
                 if (Methods[i] is not {IsConstructor: true, IsStatic: false} method)
                     continue;
 
-                if (method.Parameters.Count != arguments.Count)
+                if (method.Parameters.Count != parameterTypes.Count)
                     continue;
 
                 bool fullMatch = true;
                 for (int j = 0; j < method.Parameters.Count && fullMatch; j++)
                 {
-                    if (!comparer.Equals(method.Parameters[j].ParameterType, arguments[j]))
+                    if (!comparer.Equals(method.Parameters[j].ParameterType, parameterTypes[j]))
                         fullMatch = false;
                 }
 

--- a/test/AsmResolver.DotNet.Tests/MethodDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/MethodDefinitionTest.cs
@@ -566,5 +566,28 @@ namespace AsmResolver.DotNet.Tests
 
             Assert.Equal(expectedFullName, method.FullName);
         }
+
+        [Fact]
+        public void CreateParameterlessConstructor()
+        {
+            var module = ModuleDefinition.FromFile(typeof(Constructors).Assembly.Location);
+            var ctor = MethodDefinition.CreateConstructor(module);
+
+            Assert.True(ctor.IsConstructor);
+            Assert.Empty(ctor.Parameters);
+            Assert.NotNull(ctor.CilMethodBody);
+            Assert.Equal(CilOpCodes.Ret, Assert.Single(ctor.CilMethodBody.Instructions).OpCode);
+        }
+
+        [Fact]
+        public void CreateConstructor()
+        {
+            var module = ModuleDefinition.FromFile(typeof(Constructors).Assembly.Location);
+            var factory = module.CorLibTypeFactory;
+            var ctor = MethodDefinition.CreateConstructor(module, factory.Int32, factory.Double);
+
+            Assert.True(ctor.IsConstructor);
+            Assert.Equal(new[] {factory.Int32, factory.Double}, ctor.Parameters.Select(x => x.ParameterType));
+        }
     }
 }

--- a/test/AsmResolver.DotNet.Tests/TypeDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/TypeDefinitionTest.cs
@@ -554,6 +554,16 @@ namespace AsmResolver.DotNet.Tests
         }
 
         [Fact]
+        public void InheritanceMultipleLevelsTypeOf()
+        {
+            var module = ModuleDefinition.FromFile(typeof(DerivedDerivedClass).Assembly.Location);
+            var type = module.TopLevelTypes.First(t => t.Name == nameof(DerivedDerivedClass));
+
+            Assert.True(type.InheritsFrom(typeof(AbstractClass).Namespace, nameof(AbstractClass)));
+            Assert.False(type.InheritsFrom(typeof(Class).Namespace, nameof(Class)));
+        }
+
+        [Fact]
         public void InterfaceImplementedFromInheritanceHierarchy()
         {
             var module = ModuleDefinition.FromFile(typeof(DerivedInterfaceImplementations).Assembly.Location);
@@ -563,6 +573,18 @@ namespace AsmResolver.DotNet.Tests
             Assert.True(type.Implements(typeof(IInterface2).FullName!));
             Assert.True(type.Implements(typeof(IInterface3).FullName!));
             Assert.False(type.Implements(typeof(IInterface4).FullName!));
+        }
+
+        [Fact]
+        public void InterfaceImplementedFromInheritanceHierarchyTypeOf()
+        {
+            var module = ModuleDefinition.FromFile(typeof(DerivedInterfaceImplementations).Assembly.Location);
+            var type = module.TopLevelTypes.First(t => t.Name == nameof(DerivedInterfaceImplementations));
+
+            Assert.True(type.Implements(typeof(IInterface1).Namespace, nameof(IInterface1)));
+            Assert.True(type.Implements(typeof(IInterface2).Namespace, nameof(IInterface2)));
+            Assert.True(type.Implements(typeof(IInterface3).Namespace, nameof(IInterface3)));
+            Assert.False(type.Implements(typeof(IInterface4).Namespace, nameof(IInterface4)));
         }
 
         [Fact]

--- a/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Methods/Constructors.cs
+++ b/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Methods/Constructors.cs
@@ -23,4 +23,20 @@ public class Constructors
     public Constructors(int a, string b, double c)
     {
     }
+
+    public void NonConstructorMethod()
+    {
+    }
+
+    public void NonConstructorMethod(int a, int b)
+    {
+    }
+
+    public void NonConstructorMethod(int a, string b)
+    {
+    }
+
+    public void NonConstructorMethod(int a, string b, double c)
+    {
+    }
 }

--- a/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Methods/Constructors.cs
+++ b/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Methods/Constructors.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace AsmResolver.DotNet.TestCases.Methods;
+
+public class Constructors
+{
+    static Constructors()
+    {
+    }
+
+    public Constructors()
+    {
+    }
+
+    public Constructors(int a, int b)
+    {
+    }
+
+    public Constructors(int a, string b)
+    {
+    }
+
+    public Constructors(int a, string b, double c)
+    {
+    }
+}

--- a/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Methods/NoStaticConstructor.cs
+++ b/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Methods/NoStaticConstructor.cs
@@ -1,0 +1,5 @@
+namespace AsmResolver.DotNet.TestCases.Methods;
+
+public class NoStaticConstructor
+{
+}


### PR DESCRIPTION
Includes:
- Add `TypeDefinition::GetConstructor`
- Add overloads for `TypeDefinition::InheritsFrom` and `Implements` taking a namespace-name pair.
- Add `MethodDefinition::CreateConstructor` and `MethodDefinition::CreateStaticConstructor`.
- Expand docs on how to create and access metadata.