### PR TITLE
Add basic Span<T> support

### DIFF
--- a/src/AsmResolver.DotNet.Dynamic/AsmResolver.DotNet.Dynamic.csproj
+++ b/src/AsmResolver.DotNet.Dynamic/AsmResolver.DotNet.Dynamic.csproj
@@ -6,7 +6,7 @@
         <PackageTags>exe pe directories imports exports resources dotnet cil inspection manipulation assembly disassembly dynamic</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <NoWarn>1701;1702;NU5105</NoWarn>
-        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/src/AsmResolver.DotNet/AsmResolver.DotNet.csproj
+++ b/src/AsmResolver.DotNet/AsmResolver.DotNet.csproj
@@ -7,7 +7,7 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <NoWarn>1701;1702;NU5105</NoWarn>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
         <IsTrimmable>true</IsTrimmable>
     </PropertyGroup>
 

--- a/src/AsmResolver.PE.File/AsmResolver.PE.File.csproj
+++ b/src/AsmResolver.PE.File/AsmResolver.PE.File.csproj
@@ -8,7 +8,7 @@
         <NoWarn>1701;1702;NU5105</NoWarn>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
         <IsTrimmable>true</IsTrimmable>
     </PropertyGroup>
 

--- a/src/AsmResolver.PE.Win32Resources/AsmResolver.PE.Win32Resources.csproj
+++ b/src/AsmResolver.PE.Win32Resources/AsmResolver.PE.Win32Resources.csproj
@@ -6,7 +6,7 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <NoWarn>1701;1702;NU5105</NoWarn>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
         <IsTrimmable>true</IsTrimmable>
     </PropertyGroup>
 

--- a/src/AsmResolver.PE/AsmResolver.PE.csproj
+++ b/src/AsmResolver.PE/AsmResolver.PE.csproj
@@ -7,7 +7,7 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <NoWarn>1701;1702;NU5105</NoWarn>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
         <IsTrimmable>true</IsTrimmable>
     </PropertyGroup>
 

--- a/src/AsmResolver.Symbols.Pdb/AsmResolver.Symbols.Pdb.csproj
+++ b/src/AsmResolver.Symbols.Pdb/AsmResolver.Symbols.Pdb.csproj
@@ -5,7 +5,7 @@
         <Description>Windows PDB models for the AsmResolver executable file inspection toolsuite.</Description>
         <PackageTags>windows pdb symbols</PackageTags>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
         <IsTrimmable>true</IsTrimmable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>

--- a/src/AsmResolver/AsmResolver.csproj
+++ b/src/AsmResolver/AsmResolver.csproj
@@ -7,7 +7,7 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <NoWarn>1701;1702;NU5105</NoWarn>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
         <IsTrimmable>true</IsTrimmable>
     </PropertyGroup>
 

--- a/src/AsmResolver/IO/BinaryStreamReader.cs
+++ b/src/AsmResolver/IO/BinaryStreamReader.cs
@@ -311,6 +311,20 @@ namespace AsmResolver.IO
             return new decimal(_buffer);
         }
 
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+        /// <summary>
+        /// Attempts to read the provided amount of bytes from the input stream.
+        /// </summary>
+        /// <param name="buffer">The buffer that receives the read bytes.</param>
+        /// <returns>The number of bytes that were read.</returns>
+        public int ReadBytes(Span<byte> buffer)
+        {
+            int actualLength = DataSource.ReadBytes(Offset, buffer);
+            Offset += (uint) actualLength;
+            return actualLength;
+        }
+#endif
+
         /// <summary>
         /// Attempts to read the provided amount of bytes from the input stream.
         /// </summary>

--- a/src/AsmResolver/IO/BinaryStreamWriter.cs
+++ b/src/AsmResolver/IO/BinaryStreamWriter.cs
@@ -7,6 +7,9 @@ namespace AsmResolver.IO
     /// Provides a default implementation of a binary writer that writes the data to an output stream.
     /// </summary>
     public class BinaryStreamWriter : IBinaryStreamWriter
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+        , ISpanBinaryStreamWriter
+#endif
     {
         /// <summary>
         /// Creates a new binary stream writer using the provided output stream.
@@ -46,6 +49,14 @@ namespace AsmResolver.IO
         {
             BaseStream.Write(buffer, startIndex, count);
         }
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+        /// <inheritdoc />
+        public void WriteBytes(ReadOnlySpan<byte> buffer)
+        {
+            BaseStream.Write(buffer);
+        }
+#endif
 
         /// <inheritdoc />
         public void WriteByte(byte value)

--- a/src/AsmResolver/IO/ByteArrayDataSource.cs
+++ b/src/AsmResolver/IO/ByteArrayDataSource.cs
@@ -6,6 +6,9 @@ namespace AsmResolver.IO
     /// Provides a <see cref="IDataSource"/> wrapper around a raw byte array.
     /// </summary>
     public sealed class ByteArrayDataSource : IDataSource
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+        , ISpanDataSource
+#endif
     {
         private readonly byte[] _data;
 
@@ -60,5 +63,16 @@ namespace AsmResolver.IO
             Buffer.BlockCopy(_data, relativeIndex, buffer, index, actualLength);
             return actualLength;
         }
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+        /// <inheritdoc />
+        public int ReadBytes(ulong address, Span<byte> buffer)
+        {
+            int relativeIndex = (int) (address - BaseAddress);
+            int actualLength = Math.Min(buffer.Length, _data.Length - relativeIndex);
+            _data.AsSpan(relativeIndex, actualLength).CopyTo(buffer);
+            return actualLength;
+        }
+#endif
     }
 }

--- a/src/AsmResolver/IO/DataSourceExtensions.cs
+++ b/src/AsmResolver/IO/DataSourceExtensions.cs
@@ -1,0 +1,34 @@
+using System;
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP1_0_OR_GREATER
+using System.Buffers;
+#endif
+
+namespace AsmResolver.IO
+{
+    /// <summary>
+    /// Provides extension methods for <see cref="IDataSource"/>.
+    /// </summary>
+    public static class DataSourceExtensions
+    {
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+        /// <summary>
+        /// Reads a block of data from the data source.
+        /// </summary>
+        /// <param name="dataSource">The <see cref="IDataSource"/> to read from.</param>
+        /// <param name="address">The starting address to read from.</param>
+        /// <param name="buffer">The buffer that receives the read bytes.</param>
+        /// <returns>The number of bytes that were read.</returns>
+        public static int ReadBytes(this IDataSource dataSource, ulong address, Span<byte> buffer)
+        {
+            if (dataSource is ISpanDataSource spanDataSource)
+                return spanDataSource.ReadBytes(address, buffer);
+
+            byte[] array = ArrayPool<byte>.Shared.Rent(buffer.Length);
+            int bytesRead = dataSource.ReadBytes(address, array, 0, buffer.Length);
+            new ReadOnlySpan<byte>(array, 0, bytesRead).CopyTo(buffer);
+            ArrayPool<byte>.Shared.Return(array);
+            return bytesRead;
+        }
+#endif
+    }
+}

--- a/src/AsmResolver/IO/DataSourceSlice.cs
+++ b/src/AsmResolver/IO/DataSourceSlice.cs
@@ -6,6 +6,9 @@ namespace AsmResolver.IO
     /// Represents a data source that only exposes a part (slice) of another data source.
     /// </summary>
     public class DataSourceSlice : IDataSource
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+        , ISpanDataSource
+#endif
     {
         private readonly IDataSource _source;
 
@@ -64,5 +67,14 @@ namespace AsmResolver.IO
             int maxCount = Math.Max(0, (int) (Length - (address - BaseAddress)));
             return _source.ReadBytes(address, buffer, index, Math.Min(maxCount, count));
         }
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+        /// <inheritdoc />
+        public int ReadBytes(ulong address, Span<byte> buffer)
+        {
+            int maxCount = Math.Max(0, (int) (Length - (address - BaseAddress)));
+            return _source.ReadBytes(address, buffer[..Math.Min(maxCount, buffer.Length)]);
+        }
+#endif
     }
 }

--- a/src/AsmResolver/IO/DisplacedDataSource.cs
+++ b/src/AsmResolver/IO/DisplacedDataSource.cs
@@ -6,6 +6,9 @@ namespace AsmResolver.IO
     /// Represents a data source that was moved in memory to a different address.
     /// </summary>
     public class DisplacedDataSource : IDataSource
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+        , ISpanDataSource
+#endif
     {
         private readonly IDataSource _dataSource;
         private readonly long _displacement;
@@ -39,5 +42,13 @@ namespace AsmResolver.IO
         {
             return _dataSource.ReadBytes(address - (ulong) _displacement, buffer, index, count);
         }
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+        /// <inheritdoc />
+        public int ReadBytes(ulong address, Span<byte> buffer)
+        {
+            return _dataSource.ReadBytes(address - (ulong) _displacement, buffer);
+        }
+#endif
     }
 }

--- a/src/AsmResolver/IO/ISpanBinaryStreamWriter.cs
+++ b/src/AsmResolver/IO/ISpanBinaryStreamWriter.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace AsmResolver.IO
+{
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+    /// <summary>
+    /// Provides span-based methods for writing data to a binary stream.
+    /// </summary>
+    public interface ISpanBinaryStreamWriter : IBinaryStreamWriter
+    {
+        /// <summary>
+        /// Writes a buffer of data to the stream.
+        /// </summary>
+        /// <param name="buffer">The buffer to write to the stream.</param>
+        void WriteBytes(ReadOnlySpan<byte> buffer);
+    }
+#endif
+}

--- a/src/AsmResolver/IO/ISpanDataSource.cs
+++ b/src/AsmResolver/IO/ISpanDataSource.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace AsmResolver.IO
+{
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+    /// <summary>
+    /// Provides span-based members for reading data from a data source.
+    /// </summary>
+    public interface ISpanDataSource : IDataSource
+    {
+        /// <summary>
+        /// Reads a block of data from the data source.
+        /// </summary>
+        /// <param name="address">The starting address to read from.</param>
+        /// <param name="buffer">The buffer that receives the read bytes.</param>
+        /// <returns>The number of bytes that were read.</returns>
+        int ReadBytes(ulong address, Span<byte> buffer);
+    }
+#endif
+}

--- a/src/AsmResolver/IO/MemoryMappedDataSource.cs
+++ b/src/AsmResolver/IO/MemoryMappedDataSource.cs
@@ -7,6 +7,9 @@ namespace AsmResolver.IO
     /// Represents a data source that obtains its data from a memory mapped file.
     /// </summary>
     public sealed class MemoryMappedDataSource : IDataSource, IDisposable
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+        , ISpanDataSource
+#endif
     {
         private readonly MemoryMappedViewAccessor _accessor;
 
@@ -39,6 +42,24 @@ namespace AsmResolver.IO
         /// <inheritdoc />
         public int ReadBytes(ulong address, byte[] buffer, int index, int count) =>
             _accessor.ReadArray((long) address, buffer, index, count);
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+        /// <inheritdoc />
+        public unsafe int ReadBytes(ulong address, Span<byte> buffer)
+        {
+            var handle = _accessor.SafeMemoryMappedViewHandle;
+            int actualLength = (int) Math.Min(handle.ByteLength, (uint) buffer.Length);
+#if NET6_0_OR_GREATER
+            handle.ReadSpan(address, buffer);
+#else
+            byte* pointer = null;
+            handle.AcquirePointer(ref pointer);
+            new ReadOnlySpan<byte>(pointer, actualLength).CopyTo(buffer);
+            handle.ReleasePointer();
+#endif
+            return actualLength;
+        }
+#endif
 
         /// <inheritdoc />
         public void Dispose() => _accessor?.Dispose();

--- a/src/AsmResolver/IO/MemoryMappedDataSource.cs
+++ b/src/AsmResolver/IO/MemoryMappedDataSource.cs
@@ -53,9 +53,19 @@ namespace AsmResolver.IO
             handle.ReadSpan(address, buffer);
 #else
             byte* pointer = null;
-            handle.AcquirePointer(ref pointer);
-            new ReadOnlySpan<byte>(pointer, actualLength).CopyTo(buffer);
-            handle.ReleasePointer();
+
+            try
+            {
+                handle.AcquirePointer(ref pointer);
+                new ReadOnlySpan<byte>(pointer, actualLength).CopyTo(buffer);
+            }
+            finally
+            {
+                if (pointer != null)
+                {
+                    handle.ReleasePointer();
+                }
+            }
 #endif
             return actualLength;
         }

--- a/src/AsmResolver/IO/MemoryMappedDataSource.cs
+++ b/src/AsmResolver/IO/MemoryMappedDataSource.cs
@@ -50,7 +50,7 @@ namespace AsmResolver.IO
             var handle = _accessor.SafeMemoryMappedViewHandle;
             int actualLength = (int) Math.Min(handle.ByteLength, (uint) buffer.Length);
 #if NET6_0_OR_GREATER
-            handle.ReadSpan(address, buffer);
+            handle.ReadSpan(address, buffer[..actualLength]);
 #else
             byte* pointer = null;
 

--- a/src/AsmResolver/IO/MemoryMappedDataSource.cs
+++ b/src/AsmResolver/IO/MemoryMappedDataSource.cs
@@ -47,8 +47,12 @@ namespace AsmResolver.IO
         /// <inheritdoc />
         public unsafe int ReadBytes(ulong address, Span<byte> buffer)
         {
+            if (!IsValidAddress(address))
+                return 0;
+
             var handle = _accessor.SafeMemoryMappedViewHandle;
-            int actualLength = (int) Math.Min(handle.ByteLength, (uint) buffer.Length);
+            int actualLength = (int) Math.Min(Length - address, (uint) buffer.Length);
+            
 #if NET6_0_OR_GREATER
             handle.ReadSpan(address, buffer[..actualLength]);
 #else

--- a/src/AsmResolver/IO/ZeroesDataSource.cs
+++ b/src/AsmResolver/IO/ZeroesDataSource.cs
@@ -54,7 +54,7 @@ namespace AsmResolver.IO
         public int ReadBytes(ulong address, byte[] buffer, int index, int count)
         {
             int actualLength = (int) Math.Min(Length, (ulong) count);
-            Array.Clear(buffer, index, count);
+            Array.Clear(buffer, index, actualLength);
             return actualLength;
         }
 
@@ -63,7 +63,7 @@ namespace AsmResolver.IO
         public int ReadBytes(ulong address, Span<byte> buffer)
         {
             int actualLength = (int) Math.Min(Length, (uint) buffer.Length);
-            buffer.Clear();
+            buffer[..actualLength].Clear();
             return actualLength;
         }
 #endif

--- a/src/AsmResolver/IO/ZeroesDataSource.cs
+++ b/src/AsmResolver/IO/ZeroesDataSource.cs
@@ -6,6 +6,9 @@ namespace AsmResolver.IO
     /// Implements a data source that reads zero bytes.
     /// </summary>
     public sealed class ZeroesDataSource : IDataSource
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+        , ISpanDataSource
+#endif
     {
         /// <summary>
         /// Creates a new zeroes data source.
@@ -54,5 +57,15 @@ namespace AsmResolver.IO
             Array.Clear(buffer, index, count);
             return actualLength;
         }
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+        /// <inheritdoc />
+        public int ReadBytes(ulong address, Span<byte> buffer)
+        {
+            int actualLength = (int) Math.Min(Length, (uint) buffer.Length);
+            buffer.Clear();
+            return actualLength;
+        }
+#endif
     }
 }

--- a/src/AsmResolver/Utf8String.cs
+++ b/src/AsmResolver/Utf8String.cs
@@ -35,6 +35,27 @@ namespace AsmResolver
         {
         }
 
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+        /// <summary>
+        /// Creates a new UTF-8 string from the provided raw data.
+        /// </summary>
+        /// <param name="data">The raw UTF-8 data.</param>
+        public Utf8String(ReadOnlySpan<byte> data)
+        {
+            _data = data.ToArray();
+        }
+
+        /// <summary>
+        /// Creates a new UTF-8 string from the provided <see cref="System.ReadOnlySpan{Char}"/>.
+        /// </summary>
+        /// <param name="value">The string value to encode as UTF-8.</param>
+        public Utf8String(ReadOnlySpan<char> value)
+        {
+            _data = new byte[Encoding.UTF8.GetByteCount(value)];
+            Encoding.UTF8.GetBytes(value, _data.AsSpan());
+        }
+#endif
+
         /// <summary>
         /// Creates a new UTF-8 string from the provided raw data.
         /// </summary>
@@ -81,6 +102,38 @@ namespace AsmResolver
         /// </summary>
         /// <param name="index">The character index.</param>
         public char this[int index] => Value[index];
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+        /// <summary>
+        /// Creates a new read-only span over the string.
+        /// </summary>
+        /// <returns>The read-only span representation of the string.</returns>
+        public ReadOnlySpan<byte> AsSpan()
+        {
+            return _data.AsSpan();
+        }
+
+        /// <summary>
+        /// Creates a new read-only span over the string.
+        /// </summary>
+        /// <param name="start">The index at which to begin this slice.</param>
+        /// <returns>The read-only span representation of the string.</returns>
+        public ReadOnlySpan<byte> AsSpan(int start)
+        {
+            return _data.AsSpan(start);
+        }
+
+        /// <summary>
+        /// Creates a new read-only span over the string.
+        /// </summary>
+        /// <param name="start">The index at which to begin this slice.</param>
+        /// <param name="length">The desired length for the slice.</param>
+        /// <returns>The read-only span representation of the string.</returns>
+        public ReadOnlySpan<byte> AsSpan(int start, int length)
+        {
+            return _data.AsSpan(start, length);
+        }
+#endif
 
         /// <summary>
         /// Gets the raw UTF-8 bytes of the string.
@@ -336,6 +389,60 @@ namespace AsmResolver
 
             return new Utf8String(value);
         }
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+        /// <summary>
+        /// Converts a raw sequence of bytes into an <see cref="Utf8String"/>.
+        /// </summary>
+        /// <param name="data">The raw data to convert.</param>
+        /// <returns>The new UTF-8 encoded string.</returns>
+        public static implicit operator Utf8String(ReadOnlySpan<byte> data)
+        {
+            if (data.IsEmpty)
+                return Empty;
+
+            return new Utf8String(data);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="System.ReadOnlySpan{Char}"/> into an <see cref="Utf8String"/>.
+        /// </summary>
+        /// <param name="data">The string value to convert.</param>
+        /// <returns>The new UTF-8 encoded string.</returns>
+        public static implicit operator Utf8String(ReadOnlySpan<char> data)
+        {
+            if (data.IsEmpty)
+                return Empty;
+
+            return new Utf8String(data);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Utf8String"/> into a <see cref="System.ReadOnlySpan{Byte}"/>.
+        /// </summary>
+        /// <param name="value">The UTF-8 string value to convert.</param>
+        /// <returns>The span.</returns>
+        public static implicit operator ReadOnlySpan<byte>(Utf8String? value)
+        {
+            if (value is null)
+                return ReadOnlySpan<byte>.Empty;
+
+            return value._data;
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Utf8String"/> into a <see cref="System.ReadOnlySpan{Char}"/>.
+        /// </summary>
+        /// <param name="value">The UTF-8 string value to convert.</param>
+        /// <returns>The span.</returns>
+        public static implicit operator ReadOnlySpan<char>(Utf8String? value)
+        {
+            if (value is null)
+                return ReadOnlySpan<char>.Empty;
+
+            return value.Value;
+        }
+#endif
 
         /// <summary>
         /// Converts a raw sequence of bytes into an <see cref="Utf8String"/>.


### PR DESCRIPTION
This pull request adds basic support for `Span<T>` and `ReadOnlySpan<T>` to the `AsmResolver` and `AsmResolver.IO` namespaces.

Support is only implemented for .NET Standard 2.1 and higher, no attempt has been made to provide `Span<T>` support for .NET Standard 2.0 as it would introduce a dependency on `System.Memory`.

This PR also does not attempt to take advantage of this new support within the library. This is most likely better left to a separate PR (and/or set of issues).

The following new types are provided to avoid source and binary breaking changes in existing code:
```cs
namespace AsmResolver.IO
{
    public interface ISpanDataSource : IDataSource
    {
        int ReadBytes(ulong address, Span<byte> buffer);
    }

    public interface ISpanBinaryStreamWriter : IBinaryStreamWriter
    {
        void WriteBytes(ReadOnlySpan<byte> buffer);
    }

    public static class DataSourceExtensions
    {
        public static int ReadBytes(this IDataSource dataSource, ulong address, Span<byte> buffer);
    }
}
```
`ISpanDataSource` and `ISpanBinaryStreamWriter` can be considered temporary, as they only exist to avoid the breaking change of adding a new member to the corresponding `IDataSource` and `IBinaryStreamWriter` interfaces. In the future, it may be desirable to remove them and take the break.