### PR TITLE
Let MemberCloner keep track of included types by value

### DIFF
--- a/src/AsmResolver.DotNet/Cloning/MemberCloneContext.cs
+++ b/src/AsmResolver.DotNet/Cloning/MemberCloneContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using AsmResolver.DotNet.Signatures;
 
 namespace AsmResolver.DotNet.Cloning
 {
@@ -49,5 +50,17 @@ namespace AsmResolver.DotNet.Cloning
         {
             get;
         } = new Dictionary<IMemberDescriptor, IMemberDescriptor>();
+
+        /// <summary>
+        /// Gets a mapping of original types to their cloned counterparts.
+        /// </summary>
+        /// <remarks>
+        /// This dictionary performs lookups based on value using a <see cref="SignatureComparer"/> instead of object
+        /// identity, and can thus be used to translate type references to included type definitions.
+        /// </remarks>
+        public IDictionary<ITypeDescriptor, ITypeDescriptor> ClonedTypes
+        {
+            get;
+        } = new Dictionary<ITypeDescriptor, ITypeDescriptor>(SignatureComparer.Default);
     }
 }

--- a/src/AsmResolver.DotNet/Cloning/MemberCloner.cs
+++ b/src/AsmResolver.DotNet/Cloning/MemberCloner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.Signatures.Marshal;
 using AsmResolver.DotNet.Signatures.Security;
+using AsmResolver.DotNet.Signatures.Types;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
 namespace AsmResolver.DotNet.Cloning
@@ -320,6 +321,7 @@ namespace AsmResolver.DotNet.Cloning
 
             var typeStub = new TypeDefinition(type.Namespace, type.Name, type.Attributes);
             context.ClonedMembers.Add(type, typeStub);
+            context.ClonedTypes.Add(type, typeStub);
         }
 
         private void DeepCopyMembers(MemberCloneContext context)
@@ -442,9 +444,17 @@ namespace AsmResolver.DotNet.Cloning
 
             // Copy all elements.
             for (int i = 0; i < argument.Elements.Count; i++)
-                clonedArgument.Elements.Add(argument.Elements[i]);
+                clonedArgument.Elements.Add(CloneElement(context, argument.Elements[i]));
 
             return clonedArgument;
+        }
+
+        private static object? CloneElement(MemberCloneContext context, object? element)
+        {
+            if (element is TypeSignature type)
+                return context.Importer.ImportTypeSignature(type);
+
+            return element;
         }
 
         private static ImplementationMap? CloneImplementationMap(MemberCloneContext context, ImplementationMap? map)

--- a/src/AsmResolver.DotNet/Signatures/Types/CorLibTypeFactory.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/CorLibTypeFactory.cs
@@ -11,16 +11,6 @@ namespace AsmResolver.DotNet.Signatures.Types
     /// </summary>
     public class CorLibTypeFactory
     {
-        /// <summary>
-        /// Creates a new type factory that references mscorlib 4.0.0.0.
-        /// </summary>
-        /// <returns>The factory.</returns>
-        public static CorLibTypeFactory CreateMscorlib40TypeFactory(ModuleDefinition module)
-        {
-            var importer = new ReferenceImporter(module);
-            return new CorLibTypeFactory(importer.ImportScope(KnownCorLibs.MsCorLib_v4_0_0_0));
-        }
-
         private CorLibTypeSignature? _void;
         private CorLibTypeSignature? _boolean;
         private CorLibTypeSignature? _char;
@@ -146,6 +136,16 @@ namespace AsmResolver.DotNet.Signatures.Types
         /// Gets the element type signature for <see cref="System.Object"/>.
         /// </summary>
         public CorLibTypeSignature Object => GetOrCreateCorLibTypeSignature(ref _object, ElementType.Object, nameof(Object));
+        
+        /// <summary>
+        /// Creates a new type factory that references mscorlib 4.0.0.0.
+        /// </summary>
+        /// <returns>The factory.</returns>
+        public static CorLibTypeFactory CreateMscorlib40TypeFactory(ModuleDefinition module)
+        {
+            var importer = new ReferenceImporter(module);
+            return new CorLibTypeFactory(importer.ImportScope(KnownCorLibs.MsCorLib_v4_0_0_0));
+        }
 
         /// <summary>
         /// Transforms the provided type descriptor to a common object runtime type signature.

--- a/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.CustomAttributes/CustomAttributesTestClass.cs
+++ b/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.CustomAttributes/CustomAttributesTestClass.cs
@@ -54,6 +54,11 @@ namespace AsmResolver.DotNet.TestCases.CustomAttributes
         {
         }
 
+        [TestCase(typeof(TestEnum))]
+        public void FIxedLocalTypeArgument()
+        {
+        }
+
         [TestCase(2, "Fixed arg", TestEnum.Value3)]
         public void FixedMultipleArguments()
         {


### PR DESCRIPTION
This solves an issue where imported type references point to cloned type definitions (e.g., in custom attribute arguments of type `System.Type`). 
 
Closes #482 