### PR TITLE
Let TypeNameParser not return fully imported types

### DIFF
--- a/src/AsmResolver.DotNet/DefaultMetadataResolver.cs
+++ b/src/AsmResolver.DotNet/DefaultMetadataResolver.cs
@@ -177,6 +177,13 @@ namespace AsmResolver.DotNet
                 switch (scope.MetadataToken.Table)
                 {
                     case TableIndex.AssemblyRef:
+                        if (reference.Module?.Assembly is { } assembly)
+                        {
+                            // Are we referencing the current assembly the reference was declared in?
+                            if (SignatureComparer.Default.Equals(scope.GetAssembly(), assembly))
+                                return FindTypeInModule(reference.Module, reference.Namespace, reference.Name);
+                        }
+
                         var assemblyDefScope = _assemblyResolver.Resolve((AssemblyReference) scope);
                         return assemblyDefScope is not null
                             ? FindTypeInAssembly(assemblyDefScope, reference.Namespace, reference.Name)

--- a/src/AsmResolver.DotNet/Signatures/CustomAttributeArgument.cs
+++ b/src/AsmResolver.DotNet/Signatures/CustomAttributeArgument.cs
@@ -19,7 +19,9 @@ namespace AsmResolver.DotNet.Signatures
         /// <param name="argumentType">The type of the argument to read.</param>
         /// <param name="reader">The input stream.</param>
         /// <returns>The argument.</returns>
-        public static CustomAttributeArgument FromReader(in BlobReaderContext context, TypeSignature argumentType,
+        public static CustomAttributeArgument FromReader(
+            in BlobReaderContext context,
+            TypeSignature argumentType,
             ref BinaryStreamReader reader)
         {
             var elementReader = CustomAttributeArgumentReader.Create();

--- a/src/AsmResolver.DotNet/TypeReference.cs
+++ b/src/AsmResolver.DotNet/TypeReference.cs
@@ -140,7 +140,8 @@ namespace AsmResolver.DotNet
         }
 
         /// <inheritdoc />
-        public bool IsImportedInModule(ModuleDefinition module) => Module == module;
+        public bool IsImportedInModule(ModuleDefinition module) =>
+            Module == module && (Scope?.IsImportedInModule(module) ?? false);
 
         /// <summary>
         /// Imports the type reference using the provided reference importer object.

--- a/test/AsmResolver.DotNet.Tests/ReferenceImporterTest.cs
+++ b/test/AsmResolver.DotNet.Tests/ReferenceImporterTest.cs
@@ -421,9 +421,10 @@ namespace AsmResolver.DotNet.Tests
         [Fact]
         public void ImportFullyImportedCustomModifierTypeShouldResultInSameInstance()
         {
-            var signature = new TypeReference(_module, _dummyAssembly, "SomeNamespace", "SomeType")
+            var assembly = _importer.ImportScope(_dummyAssembly);
+            var signature = new TypeReference(_module, assembly, "SomeNamespace", "SomeType")
                 .ToTypeSignature()
-                .MakeModifierType(new TypeReference(_module, _dummyAssembly, "SomeNamespace", "SomeModifierType"), true);
+                .MakeModifierType(new TypeReference(_module, assembly, "SomeNamespace", "SomeModifierType"), true);
 
             var imported = _importer.ImportTypeSignature(signature);
 
@@ -470,10 +471,11 @@ namespace AsmResolver.DotNet.Tests
         [Fact]
         public void ImportFullyImportedFunctionPointerTypeShouldResultInSameInstance()
         {
+            var assembly = _importer.ImportScope(_dummyAssembly);
             var signature = MethodSignature
                 .CreateStatic(
                     _module.CorLibTypeFactory.Void,
-                    new TypeReference(_module, _dummyAssembly, "SomeNamespace", "SomeType").ToTypeSignature())
+                    new TypeReference(_module, assembly, "SomeNamespace", "SomeType").ToTypeSignature())
                 .MakeFunctionPointerType();
 
             var imported = _importer.ImportTypeSignature(signature);


### PR DESCRIPTION
Add declaring scope test in `type.IsImportedInModule`.