### PR TITLE
Fix a couple of corner cases in SignatureComparer.GetHashCode

### DIFF
--- a/src/AsmResolver.DotNet/Signatures/SignatureComparer.TypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/SignatureComparer.TypeSignature.cs
@@ -208,8 +208,8 @@ namespace AsmResolver.DotNet.Signatures
             unchecked
             {
                 int hashCode = (int) obj.ElementType << ElementTypeOffset;
-                hashCode = (hashCode * 397) ^ obj.ModifierType.GetHashCode();
-                hashCode = (hashCode * 397) ^ obj.BaseType.GetHashCode();
+                hashCode = (hashCode * 397) ^ GetHashCode(obj.ModifierType);
+                hashCode = (hashCode * 397) ^ GetHashCode(obj.BaseType);
                 return hashCode;
             }
         }

--- a/src/AsmResolver.DotNet/Signatures/SignatureComparer.TypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/SignatureComparer.TypeSignature.cs
@@ -233,7 +233,7 @@ namespace AsmResolver.DotNet.Signatures
             unchecked
             {
                 int hashCode = (int) obj.ElementType << ElementTypeOffset;
-                hashCode = (hashCode * 397) ^ obj.GenericType.GetHashCode();
+                hashCode = (hashCode * 397) ^ GetHashCode(obj.GenericType);
                 hashCode = (hashCode * 397) ^ GetHashCode(obj.TypeArguments);
                 return hashCode;
             }


### PR DESCRIPTION
Just fixing three instances of object.GetHashCode being called by mistake in `GenericInstanceTypeSignature` and `CustomModifierTypeSignature`. I had a few fields and methods in my assemblies where .Equals returned true (correctly) but .GetHashCode returned distinct hash codes.