### PR TITLE
BUGFIX: Prevent the same metadata members to be added twice to the exact same collection

### DIFF
--- a/src/AsmResolver.DotNet/Collections/MemberCollection.cs
+++ b/src/AsmResolver.DotNet/Collections/MemberCollection.cs
@@ -1,0 +1,31 @@
+using AsmResolver.Collections;
+
+namespace AsmResolver.DotNet.Collections
+{
+    /// <summary>
+    /// Represents an indexed member collection where each member is owned by some object, and prevents the member from
+    /// being added to any other instance of the collection.
+    /// </summary>
+    /// <typeparam name="TOwner">The type of the owner object.</typeparam>
+    /// <typeparam name="TMember">The type of elements to store.</typeparam>
+    public class MemberCollection<TOwner, TMember> : OwnedCollection<TOwner, TMember>
+        where TOwner : class
+        where TMember : class, IOwnedCollectionElement<TOwner>
+    {
+        internal MemberCollection(TOwner owner)
+            : base(owner)
+        {
+        }
+
+        internal MemberCollection(TOwner owner, int capacity)
+            : base(owner, capacity)
+        {
+        }
+
+        internal void AddNoOwnerCheck(TMember member)
+        {
+            member.Owner = Owner;
+            Items.Add(member);
+        }
+    }
+}

--- a/src/AsmResolver.DotNet/Collections/MethodSemanticsCollection.cs
+++ b/src/AsmResolver.DotNet/Collections/MethodSemanticsCollection.cs
@@ -1,15 +1,13 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using AsmResolver.Collections;
 
 namespace AsmResolver.DotNet.Collections
 {
     /// <summary>
     /// Provides an implementation of a list of method semantics that are associated to a property or event.
     /// </summary>
-    public class MethodSemanticsCollection : OwnedCollection< IHasSemantics, MethodSemantics>
+    public class MethodSemanticsCollection : MemberCollection<IHasSemantics, MethodSemantics>
     {
         /// <summary>
         /// Creates a new instance of the <see cref="MethodSemanticsCollection"/> class.
@@ -36,7 +34,7 @@ namespace AsmResolver.DotNet.Collections
             set;
         } = true;
 
-        private void AssertSemanticsValidity([NotNull] MethodSemantics item)
+        private void AssertSemanticsValidity(MethodSemantics item)
         {
             if (!ValidateMembership)
                 return;

--- a/src/AsmResolver.DotNet/ModuleDefinition.cs
+++ b/src/AsmResolver.DotNet/ModuleDefinition.cs
@@ -302,7 +302,6 @@ namespace AsmResolver.DotNet
             Name = name;
 
             CorLibTypeFactory = CorLibTypeFactory.CreateMscorlib40TypeFactory(this);
-            AssemblyReferences.Add((AssemblyReference)CorLibTypeFactory.CorLibScope);
             MetadataResolver = new DefaultMetadataResolver(new DotNetFrameworkAssemblyResolver());
 
             TopLevelTypes.Add(new TypeDefinition(null, TypeDefinition.ModuleTypeName, 0));

--- a/src/AsmResolver.DotNet/Serialized/SerializedAssemblyDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedAssemblyDefinition.cs
@@ -2,8 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.Versioning;
 using AsmResolver.Collections;
-using AsmResolver.PE.DotNet.Metadata.Blob;
-using AsmResolver.PE.DotNet.Metadata.Strings;
+using AsmResolver.DotNet.Collections;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 using FileAttributes = AsmResolver.PE.DotNet.Metadata.Tables.Rows.FileAttributes;
@@ -58,11 +57,8 @@ namespace AsmResolver.DotNet.Serialized
         /// <inheritdoc />
         protected override IList<ModuleDefinition> GetModules()
         {
-            _manifestModule.Assembly = null;
-            var result = new OwnedCollection<AssemblyDefinition, ModuleDefinition>(this)
-            {
-                _manifestModule
-            };
+            var result = new MemberCollection<AssemblyDefinition, ModuleDefinition>(this);
+            result.AddNoOwnerCheck(_manifestModule);
 
             var moduleResolver = _context.Parameters.ModuleResolver;
             if (moduleResolver is not null)

--- a/src/AsmResolver.DotNet/Serialized/SerializedEventDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedEventDefinition.cs
@@ -69,7 +69,7 @@ namespace AsmResolver.DotNet.Serialized
             foreach (uint rid in module.GetMethodSemantics(MetadataToken))
             {
                 var semanticsToken = new MetadataToken(TableIndex.MethodSemantics, rid);
-                result.Add((MethodSemantics) module.LookupMember(semanticsToken));
+                result.AddNoOwnerCheck((MethodSemantics) module.LookupMember(semanticsToken));
             }
 
             result.ValidateMembership = true;

--- a/src/AsmResolver.DotNet/Serialized/SerializedGenericParameter.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedGenericParameter.cs
@@ -54,12 +54,12 @@ namespace AsmResolver.DotNet.Serialized
         {
             var module = _context.ParentModule;
             var rids = module.GetGenericParameterConstraints(MetadataToken);
-            var result = new OwnedCollection<GenericParameter, GenericParameterConstraint>(this, rids.Count);
+            var result = new MemberCollection<GenericParameter, GenericParameterConstraint>(this, rids.Count);
 
             foreach (uint rid in rids)
             {
                 var constraintToken = new MetadataToken(TableIndex.GenericParamConstraint, rid);
-                result.Add((GenericParameterConstraint) module.LookupMember(constraintToken));
+                result.AddNoOwnerCheck((GenericParameterConstraint) module.LookupMember(constraintToken));
             }
 
             return result;

--- a/src/AsmResolver.DotNet/Serialized/SerializedMethodDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedMethodDefinition.cs
@@ -78,12 +78,12 @@ namespace AsmResolver.DotNet.Serialized
         protected override IList<ParameterDefinition> GetParameterDefinitions()
         {
             var parameterRange = _context.ParentModule.GetParameterRange(MetadataToken.Rid);
-            var result = new OwnedCollection<MethodDefinition, ParameterDefinition>(this, parameterRange.Count);
+            var result = new MemberCollection<MethodDefinition, ParameterDefinition>(this, parameterRange.Count);
 
             foreach (var token in parameterRange)
             {
                 if (_context.ParentModule.TryLookupMember(token, out var member) && member is ParameterDefinition parameter)
-                    result.Add(parameter);
+                    result.AddNoOwnerCheck(parameter);
             }
 
             return result;
@@ -106,14 +106,14 @@ namespace AsmResolver.DotNet.Serialized
         protected override IList<GenericParameter> GetGenericParameters()
         {
             var rids = _context.ParentModule.GetGenericParameters(MetadataToken);
-            var result = new OwnedCollection<IHasGenericParameters, GenericParameter>(this, rids.Count);
+            var result = new MemberCollection<IHasGenericParameters, GenericParameter>(this, rids.Count);
 
             foreach (uint rid in rids)
             {
                 if (_context.ParentModule.TryLookupMember(new MetadataToken(TableIndex.GenericParam, rid), out var member)
                     && member is GenericParameter genericParameter)
                 {
-                    result.Add(genericParameter);
+                    result.AddNoOwnerCheck(genericParameter);
                 }
             }
 

--- a/src/AsmResolver.DotNet/Serialized/SerializedModuleDefinition.Metadata.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedModuleDefinition.Metadata.cs
@@ -229,12 +229,12 @@ namespace AsmResolver.DotNet.Serialized
         {
             EnsureCustomAttributesInitialized();
             var rids = _customAttributes.GetValues(owner.MetadataToken);
-            var result = new OwnedCollection<IHasCustomAttribute, CustomAttribute>(owner, rids.Count);
+            var result = new MemberCollection<IHasCustomAttribute, CustomAttribute>(owner, rids.Count);
 
             foreach (uint rid in rids)
             {
                 var attribute = (CustomAttribute) LookupMember(new MetadataToken(TableIndex.CustomAttribute, rid));
-                result.Add(attribute);
+                result.AddNoOwnerCheck(attribute);
             }
 
             return result;
@@ -274,12 +274,12 @@ namespace AsmResolver.DotNet.Serialized
         {
             EnsureSecurityDeclarationsInitialized();
             var rids = _securityDeclarations.GetValues(owner.MetadataToken);
-            var result = new OwnedCollection<IHasSecurityDeclaration, SecurityDeclaration>(owner, rids.Count);
+            var result = new MemberCollection<IHasSecurityDeclaration, SecurityDeclaration>(owner, rids.Count);
 
             foreach (uint rid in rids)
             {
                 var attribute = (SecurityDeclaration) LookupMember(new MetadataToken(TableIndex.DeclSecurity, rid));
-                result.Add(attribute);
+                result.AddNoOwnerCheck(attribute);
             }
 
             return result;

--- a/src/AsmResolver.DotNet/Serialized/SerializedModuleDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedModuleDefinition.cs
@@ -1,17 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using AsmResolver.Collections;
 using AsmResolver.DotNet.Collections;
 using AsmResolver.DotNet.Signatures.Types;
 using AsmResolver.PE;
 using AsmResolver.PE.Debug;
 using AsmResolver.PE.DotNet;
-using AsmResolver.PE.DotNet.Metadata.Guid;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
-using AsmResolver.PE.DotNet.Metadata.UserStrings;
 using AsmResolver.PE.Win32Resources;
 
 namespace AsmResolver.DotNet.Serialized

--- a/src/AsmResolver.DotNet/Serialized/SerializedModuleDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedModuleDefinition.cs
@@ -191,7 +191,7 @@ namespace AsmResolver.DotNet.Serialized
             var typeDefTable = ReaderContext.TablesStream.GetTable<TypeDefinitionRow>(TableIndex.TypeDef);
             int nestedTypeCount = ReaderContext.TablesStream.GetTable(TableIndex.NestedClass).Count;
 
-            var types = new OwnedCollection<ModuleDefinition, TypeDefinition>(this,
+            var types = new MemberCollection<ModuleDefinition, TypeDefinition>(this,
                 typeDefTable.Count - nestedTypeCount);
 
             for (int i = 0; i < typeDefTable.Count; i++)
@@ -200,7 +200,7 @@ namespace AsmResolver.DotNet.Serialized
                 if (_typeDefTree.GetKey(rid) == 0)
                 {
                     var token = new MetadataToken(TableIndex.TypeDef, rid);
-                    types.Add(_memberFactory.LookupTypeDefinition(token)!);
+                    types.AddNoOwnerCheck(_memberFactory.LookupTypeDefinition(token)!);
                 }
             }
 
@@ -212,13 +212,13 @@ namespace AsmResolver.DotNet.Serialized
         {
             var table = ReaderContext.TablesStream.GetTable<AssemblyReferenceRow>(TableIndex.AssemblyRef);
 
-            var result = new OwnedCollection<ModuleDefinition, AssemblyReference>(this, table.Count);
+            var result = new MemberCollection<ModuleDefinition, AssemblyReference>(this, table.Count);
 
             // Don't use the member factory here, this method may be called before the member factory is initialized.
             for (int i = 0; i < table.Count; i++)
             {
                 var token = new MetadataToken(TableIndex.AssemblyRef, (uint) i + 1);
-                result.Add(new SerializedAssemblyReference(ReaderContext, token, table[i]));
+                result.AddNoOwnerCheck(new SerializedAssemblyReference(ReaderContext, token, table[i]));
             }
 
             return result;
@@ -229,13 +229,13 @@ namespace AsmResolver.DotNet.Serialized
         {
             var table = ReaderContext.TablesStream.GetTable(TableIndex.ModuleRef);
 
-            var result = new OwnedCollection<ModuleDefinition, ModuleReference>(this, table.Count);
+            var result = new MemberCollection<ModuleDefinition, ModuleReference>(this, table.Count);
 
             for (int i = 0; i < table.Count; i++)
             {
                 var token = new MetadataToken(TableIndex.ModuleRef, (uint) i + 1);
                 if (_memberFactory.TryLookupMember(token, out var member) && member is ModuleReference module)
-                    result.Add(module);
+                    result.AddNoOwnerCheck(module);
             }
 
             return result;
@@ -246,13 +246,13 @@ namespace AsmResolver.DotNet.Serialized
         {
             var table = ReaderContext.TablesStream.GetTable(TableIndex.File);
 
-            var result = new OwnedCollection<ModuleDefinition, FileReference>(this, table.Count);
+            var result = new MemberCollection<ModuleDefinition, FileReference>(this, table.Count);
 
             for (int i = 0; i < table.Count; i++)
             {
                 var token = new MetadataToken(TableIndex.File, (uint) i + 1);
                 if (_memberFactory.TryLookupMember(token, out var member) && member is FileReference file)
-                    result.Add(file);
+                    result.AddNoOwnerCheck(file);
             }
 
             return result;
@@ -263,13 +263,13 @@ namespace AsmResolver.DotNet.Serialized
         {
             var table = ReaderContext.TablesStream.GetTable(TableIndex.ManifestResource);
 
-            var result = new OwnedCollection<ModuleDefinition, ManifestResource>(this, table.Count);
+            var result = new MemberCollection<ModuleDefinition, ManifestResource>(this, table.Count);
 
             for (int i = 0; i < table.Count; i++)
             {
                 var token = new MetadataToken(TableIndex.ManifestResource, (uint) i + 1);
                 if (_memberFactory.TryLookupMember(token, out var member) && member is ManifestResource resource)
-                    result.Add(resource);
+                    result.AddNoOwnerCheck(resource);
             }
 
             return result;
@@ -280,13 +280,13 @@ namespace AsmResolver.DotNet.Serialized
         {
             var table = ReaderContext.TablesStream.GetTable(TableIndex.ExportedType);
 
-            var result = new OwnedCollection<ModuleDefinition, ExportedType>(this, table.Count);
+            var result = new MemberCollection<ModuleDefinition, ExportedType>(this, table.Count);
 
             for (int i = 0; i < table.Count; i++)
             {
                 var token = new MetadataToken(TableIndex.ExportedType, (uint) i + 1);
                 if (_memberFactory.TryLookupMember(token, out var member) && member is ExportedType exportedType)
-                    result.Add(exportedType);
+                    result.AddNoOwnerCheck(exportedType);
             }
 
             return result;

--- a/src/AsmResolver.DotNet/Serialized/SerializedPropertyDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedPropertyDefinition.cs
@@ -76,7 +76,7 @@ namespace AsmResolver.DotNet.Serialized
             foreach (uint rid in rids)
             {
                 var semanticsToken = new MetadataToken(TableIndex.MethodSemantics, rid);
-                result.Add((MethodSemantics) module.LookupMember(semanticsToken));
+                result.AddNoOwnerCheck((MethodSemantics) module.LookupMember(semanticsToken));
             }
 
             result.ValidateMembership = true;

--- a/src/AsmResolver.DotNet/Serialized/SerializedTypeDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedTypeDefinition.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using AsmResolver.Collections;
 using AsmResolver.DotNet.Collections;
-using AsmResolver.PE.DotNet.Metadata;
-using AsmResolver.PE.DotNet.Metadata.Strings;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
@@ -58,12 +55,12 @@ namespace AsmResolver.DotNet.Serialized
         protected override IList<TypeDefinition> GetNestedTypes()
         {
             var rids = _context.ParentModule.GetNestedTypeRids(MetadataToken.Rid);
-            var result = new OwnedCollection<TypeDefinition, TypeDefinition>(this, rids.Count);
+            var result = new MemberCollection<TypeDefinition, TypeDefinition>(this, rids.Count);
 
             foreach (uint rid in rids)
             {
                 var nestedType = (TypeDefinition) _context.ParentModule.LookupMember(new MetadataToken(TableIndex.TypeDef, rid));
-                result.Add(nestedType);
+                result.AddNoOwnerCheck(nestedType);
             }
 
             return result;
@@ -97,10 +94,10 @@ namespace AsmResolver.DotNet.Serialized
         private IList<TMember> CreateMemberCollection<TMember>(MetadataRange range)
             where TMember : class, IMetadataMember, IOwnedCollectionElement<TypeDefinition>
         {
-            var result = new OwnedCollection<TypeDefinition, TMember>(this, range.Count);
+            var result = new MemberCollection<TypeDefinition, TMember>(this, range.Count);
 
             foreach (var token in range)
-                result.Add((TMember) _context.ParentModule.LookupMember(token));
+                result.AddNoOwnerCheck((TMember) _context.ParentModule.LookupMember(token));
 
             return result;
         }
@@ -117,14 +114,14 @@ namespace AsmResolver.DotNet.Serialized
         protected override IList<GenericParameter> GetGenericParameters()
         {
             var rids = _context.ParentModule.GetGenericParameters(MetadataToken);
-            var result = new OwnedCollection<IHasGenericParameters, GenericParameter>(this, rids.Count);
+            var result = new MemberCollection<IHasGenericParameters, GenericParameter>(this, rids.Count);
 
             foreach (uint rid in rids)
             {
                 if (_context.ParentModule.TryLookupMember(new MetadataToken(TableIndex.GenericParam, rid), out var member)
                     && member is GenericParameter genericParameter)
                 {
-                    result.Add(genericParameter);
+                    result.AddNoOwnerCheck(genericParameter);
                 }
             }
 
@@ -135,14 +132,14 @@ namespace AsmResolver.DotNet.Serialized
         protected override IList<InterfaceImplementation> GetInterfaces()
         {
             var rids = _context.ParentModule.GetInterfaceImplementationRids(MetadataToken);
-            var result = new OwnedCollection<TypeDefinition, InterfaceImplementation>(this, rids.Count);
+            var result = new MemberCollection<TypeDefinition, InterfaceImplementation>(this, rids.Count);
 
             foreach (uint rid in rids)
             {
                 if (_context.ParentModule.TryLookupMember(new MetadataToken(TableIndex.InterfaceImpl, rid), out var member)
                     && member is InterfaceImplementation type)
                 {
-                    result.Add(type);
+                    result.AddNoOwnerCheck(type);
                 }
             }
 

--- a/src/AsmResolver.DotNet/Signatures/Types/CorLibTypeFactory.cs
+++ b/src/AsmResolver.DotNet/Signatures/Types/CorLibTypeFactory.cs
@@ -136,15 +136,14 @@ namespace AsmResolver.DotNet.Signatures.Types
         /// Gets the element type signature for <see cref="System.Object"/>.
         /// </summary>
         public CorLibTypeSignature Object => GetOrCreateCorLibTypeSignature(ref _object, ElementType.Object, nameof(Object));
-        
+
         /// <summary>
         /// Creates a new type factory that references mscorlib 4.0.0.0.
         /// </summary>
         /// <returns>The factory.</returns>
         public static CorLibTypeFactory CreateMscorlib40TypeFactory(ModuleDefinition module)
         {
-            var importer = new ReferenceImporter(module);
-            return new CorLibTypeFactory(importer.ImportScope(KnownCorLibs.MsCorLib_v4_0_0_0));
+            return new CorLibTypeFactory(KnownCorLibs.MsCorLib_v4_0_0_0.ImportWith(module.DefaultImporter));
         }
 
         /// <summary>

--- a/src/AsmResolver/Collections/OwnedCollection.cs
+++ b/src/AsmResolver/Collections/OwnedCollection.cs
@@ -55,7 +55,7 @@ namespace AsmResolver.Collections
         {
             if (item is null)
                 throw new ArgumentNullException(nameof(item));
-            if (item.Owner != null && item.Owner != Owner)
+            if (item.Owner is not null)
                 throw new ArgumentException("Item is already added to another collection.");
         }
 

--- a/test/AsmResolver.DotNet.Tests/FieldDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/FieldDefinitionTest.cs
@@ -6,6 +6,7 @@ using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.TestCases.Fields;
 using AsmResolver.DotNet.TestCases.Types.Structs;
 using AsmResolver.PE.DotNet.Cil;
+using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 using Xunit;
 
 namespace AsmResolver.DotNet.Tests
@@ -198,6 +199,25 @@ namespace AsmResolver.DotNet.Tests
             Assert.Equal(offset, newField.FieldOffset);
         }
 
+        [Fact]
+        public void AddSameFieldTwiceToTypeShouldThrow()
+        {
+            var module = new ModuleDefinition("SomeModule");
+            var field = new FieldDefinition("SomeField", FieldAttributes.Public, module.CorLibTypeFactory.Int32);
+            var type = new TypeDefinition("SomeNamespace", "SomeType", TypeAttributes.Public);
+            type.Fields.Add(field);
+            Assert.Throws<ArgumentException>(() => type.Fields.Add(field));
+        }
 
+        [Fact]
+        public void AddSameFieldToDifferentTypesShouldThrow()
+        {
+            var module = new ModuleDefinition("SomeModule");
+            var field = new FieldDefinition("SomeField", FieldAttributes.Public, module.CorLibTypeFactory.Int32);
+            var type1 = new TypeDefinition("SomeNamespace", "SomeType1", TypeAttributes.Public);
+            var type2 = new TypeDefinition("SomeNamespace", "SomeType2", TypeAttributes.Public);
+            type1.Fields.Add(field);
+            Assert.Throws<ArgumentException>(() => type2.Fields.Add(field));
+        }
     }
 }


### PR DESCRIPTION
Introduces internal `MemberCollection` to the metadata reader that can bypass owner checks when adding members. This should both fix a bug where members could be added to the exact same owner instance, and slightly improve performance as well when reading files.