### PR TITLE
Preserve resource entry order based on ID

### DIFF
--- a/docs/guides/peimage/win32resources.md
+++ b/docs/guides/peimage/win32resources.md
@@ -43,9 +43,10 @@ IResourceData stringDataEntry = image.Resources
 ```
 
 Adding or replacing entries can be by either modifying the `Entries`
-property directly, or by using the `AddOrReplace` method. The latter is
-recommended as it ensures that an existing entry with the same ID is
-replaced with the new one.
+property directly, or by using the `InsertOrReplaceEntry` method.
+The latter is recommended as it ensures that an existing entry with the
+same ID is replaced with the new one, and that the sorting requirements
+according to the PE file specification are presrved.
 
 ``` csharp
 IPEImage image = ...
@@ -56,7 +57,7 @@ image.Resources.Entries.Add(newDirectory);
 ``` csharp
 IPEImage image = ...
 var newDirectory = new ResourceDirectory(ResourceType.String);
-image.Resources.AddOrReplaceEntry(newDirectory);
+image.Resources.InsertOrReplaceEntry(newDirectory);
 ```
 
 Similarly, removing can be done by modifying the `Entries` directory, or
@@ -99,7 +100,7 @@ var data = new ResourceData(id: 1033, contents: new DataSegment(new byte[] { ...
 image.Resources
     .GetDirectory(ResourceType.String)
     .GetDirectory(251)
-    .AddOrReplaceEntry(data);
+    .InsertOrReplaceEntry(data);
 ```
 
 ## Example Traversal

--- a/src/AsmResolver.PE.Win32Resources/IWin32Resource.cs
+++ b/src/AsmResolver.PE.Win32Resources/IWin32Resource.cs
@@ -2,7 +2,7 @@ namespace AsmResolver.PE.Win32Resources
 {
     /// <summary>
     /// Provides a high level view of a native win32 resource that can be stored in the resources data directory of a
-    /// portable executable (PE) image. 
+    /// portable executable (PE) image.
     /// </summary>
     public interface IWin32Resource
     {
@@ -10,6 +10,6 @@ namespace AsmResolver.PE.Win32Resources
         /// Serializes the win32 resource to the provided root win32 resource data directory.
         /// </summary>
         /// <param name="rootDirectory">The root directory to submit the changes to.</param>
-        void WriteToDirectory(IResourceDirectory rootDirectory);
+        void InsertIntoDirectory(IResourceDirectory rootDirectory);
     }
 }

--- a/src/AsmResolver.PE.Win32Resources/Icon/IconResource.cs
+++ b/src/AsmResolver.PE.Win32Resources/Icon/IconResource.cs
@@ -81,13 +81,13 @@ namespace AsmResolver.PE.Win32Resources.Icon
         public IEnumerable<IconGroupDirectory> GetIconGroups() => _entries.Values;
 
         /// <inheritdoc />
-        public void WriteToDirectory(IResourceDirectory rootDirectory)
+        public void InsertIntoDirectory(IResourceDirectory rootDirectory)
         {
             // Construct new directory.
             var newGroupIconDirectory = new ResourceDirectory(ResourceType.GroupIcon);
             foreach (var entry in _entries)
             {
-                newGroupIconDirectory.Entries.Add(new ResourceDirectory(entry.Key)
+                newGroupIconDirectory.InsertOrReplaceEntry(new ResourceDirectory(entry.Key)
                     {Entries = {new ResourceData(0u, entry.Value)}});
             }
 
@@ -97,14 +97,14 @@ namespace AsmResolver.PE.Win32Resources.Icon
             {
                 foreach (var (groupEntry, iconEntry) in entry.Value.GetIconEntries())
                 {
-                    newIconDirectory.Entries.Add(new ResourceDirectory(groupEntry.Id)
+                    newIconDirectory.InsertOrReplaceEntry(new ResourceDirectory(groupEntry.Id)
                         {Entries = {new ResourceData(1033, iconEntry)}});
                 }
             }
 
             // Insert.
-            rootDirectory.AddOrReplaceEntry(newGroupIconDirectory);
-            rootDirectory.AddOrReplaceEntry(newIconDirectory);
+            rootDirectory.InsertOrReplaceEntry(newGroupIconDirectory);
+            rootDirectory.InsertOrReplaceEntry(newIconDirectory);
         }
     }
 }

--- a/src/AsmResolver.PE.Win32Resources/Version/VersionInfoResource.cs
+++ b/src/AsmResolver.PE.Win32Resources/Version/VersionInfoResource.cs
@@ -271,24 +271,24 @@ namespace AsmResolver.PE.Win32Resources.Version
         }
 
         /// <inheritdoc />
-        public void WriteToDirectory(IResourceDirectory rootDirectory)
+        public void InsertIntoDirectory(IResourceDirectory rootDirectory)
         {
             // Add version directory if it doesn't exist yet.
             if (!rootDirectory.TryGetDirectory(ResourceType.Version, out var versionDirectory))
             {
                 versionDirectory = new ResourceDirectory(ResourceType.Version);
-                rootDirectory.Entries.Add(versionDirectory);
+                rootDirectory.InsertOrReplaceEntry(versionDirectory);
             }
 
             // Add category directory if it doesn't exist yet.
             if (!versionDirectory.TryGetDirectory(1, out var categoryDirectory))
             {
                 categoryDirectory = new ResourceDirectory(1);
-                versionDirectory.Entries.Add(categoryDirectory);
+                versionDirectory.InsertOrReplaceEntry(categoryDirectory);
             }
 
             // Insert / replace data entry.
-            categoryDirectory.AddOrReplaceEntry(new ResourceData((uint) Lcid, this));
+            categoryDirectory.InsertOrReplaceEntry(new ResourceData((uint) Lcid, this));
         }
     }
 }

--- a/src/AsmResolver.PE/Win32Resources/IResourceDirectory.cs
+++ b/src/AsmResolver.PE/Win32Resources/IResourceDirectory.cs
@@ -136,10 +136,10 @@ namespace AsmResolver.PE.Win32Resources
         bool TryGetData(uint id, [NotNullWhen(true)] out IResourceData? data);
 
         /// <summary>
-        /// Replaces an existing entry with the same ID with the provided entry, or adds the new entry to the directory.
+        /// Replaces an existing entry with the same ID with the provided entry, or inserts the new entry into the directory.
         /// </summary>
         /// <param name="entry">The entry to store in the directory.</param>
-        void AddOrReplaceEntry(IResourceEntry entry);
+        void InsertOrReplaceEntry(IResourceEntry entry);
 
         /// <summary>
         /// Removes an entry in the directory by its unique identifier.

--- a/test/AsmResolver.PE.Win32Resources.Tests/Icon/IconResourceTest.cs
+++ b/test/AsmResolver.PE.Win32Resources.Tests/Icon/IconResourceTest.cs
@@ -40,7 +40,7 @@ namespace AsmResolver.PE.Win32Resources.Tests.Icon
                 iconGroup.RemoveEntry(4);
                 iconGroup.Count--;
             }
-            iconResource.WriteToDirectory(resources);
+            iconResource.InsertIntoDirectory(resources);
 
             // Rebuild.
             using var stream = new MemoryStream();

--- a/test/AsmResolver.PE.Win32Resources.Tests/Version/VersionInfoResourceTest.cs
+++ b/test/AsmResolver.PE.Win32Resources.Tests/Version/VersionInfoResourceTest.cs
@@ -188,7 +188,7 @@ namespace AsmResolver.PE.Win32Resources.Tests.Version
             Assert.NotNull(versionInfo);
 
             versionInfo.FixedVersionInfo.ProductVersion = new System.Version(1, 2, 3, 4);
-            versionInfo.WriteToDirectory(resources);
+            versionInfo.InsertIntoDirectory(resources);
 
             // Rebuild
             using var stream = new MemoryStream();
@@ -216,7 +216,7 @@ namespace AsmResolver.PE.Win32Resources.Tests.Version
             var versionInfo = VersionInfoResource.FromDirectory(image.Resources!)!;
             var info = versionInfo.GetChild<StringFileInfo>(StringFileInfo.StringFileInfoKey);
             info.Tables[0][StringTable.FileDescriptionKey] = "This is a test application";
-            versionInfo.WriteToDirectory(image.Resources!);
+            versionInfo.InsertIntoDirectory(image.Resources!);
 
             // Replace section.
             var resourceBuffer = new ResourceDirectoryBuffer();


### PR DESCRIPTION
- Renames `ResourceDirectory::AddOrReplaceEntry` to `InsertOrReplaceEntry`
- Renames `IWin32Resource::AddToDirectory` to `InsertIntoDirectory`

Closes #532