### PR TITLE
Set Accessors for Semantic Methods

### DIFF
--- a/src/AsmResolver.DotNet/EventDefinition.cs
+++ b/src/AsmResolver.DotNet/EventDefinition.cs
@@ -139,20 +139,29 @@ namespace AsmResolver.DotNet
         /// <summary>
         /// Gets the method definition representing the first add accessor of this event definition.
         /// </summary>
-        public MethodDefinition? AddMethod =>
-            Semantics.FirstOrDefault(s => s.Attributes == MethodSemanticsAttributes.AddOn)?.Method;
+        public MethodDefinition? AddMethod
+        {
+            get => Semantics.FirstOrDefault(s => s.Attributes == MethodSemanticsAttributes.AddOn)?.Method;
+            set => SetSemanticMethods(value, RemoveMethod, FireMethod);
+        }
 
         /// <summary>
         /// Gets the method definition representing the first remove accessor of this event definition.
         /// </summary>
-        public MethodDefinition? RemoveMethod =>
-            Semantics.FirstOrDefault(s => s.Attributes == MethodSemanticsAttributes.RemoveOn)?.Method;
+        public MethodDefinition? RemoveMethod
+        {
+            get => Semantics.FirstOrDefault(s => s.Attributes == MethodSemanticsAttributes.RemoveOn)?.Method;
+            set => SetSemanticMethods(AddMethod, value, FireMethod);
+        }
 
         /// <summary>
         /// Gets the method definition representing the first fire accessor of this event definition.
         /// </summary>
-        public MethodDefinition? FireMethod =>
-            Semantics.FirstOrDefault(s => s.Attributes == MethodSemanticsAttributes.Fire)?.Method;
+        public MethodDefinition? FireMethod
+        {
+            get => Semantics.FirstOrDefault(s => s.Attributes == MethodSemanticsAttributes.Fire)?.Method;
+            set => SetSemanticMethods(AddMethod, RemoveMethod, value);
+        }
 
         /// <inheritdoc />
         public IList<CustomAttribute> CustomAttributes

--- a/src/AsmResolver.DotNet/PropertyDefinition.cs
+++ b/src/AsmResolver.DotNet/PropertyDefinition.cs
@@ -173,14 +173,20 @@ namespace AsmResolver.DotNet
         /// <summary>
         /// Gets the method definition representing the first get accessor of this property definition.
         /// </summary>
-        public MethodDefinition? GetMethod =>
-            Semantics.FirstOrDefault(s => s.Attributes == MethodSemanticsAttributes.Getter)?.Method;
+        public MethodDefinition? GetMethod
+        {
+            get => Semantics.FirstOrDefault(s => s.Attributes == MethodSemanticsAttributes.Getter)?.Method;
+            set => SetSemanticMethods(value, SetMethod);
+        }
 
         /// <summary>
         /// Gets the method definition representing the first set accessor of this property definition.
         /// </summary>
-        public MethodDefinition? SetMethod =>
-            Semantics.FirstOrDefault(s => s.Attributes == MethodSemanticsAttributes.Setter)?.Method;
+        public MethodDefinition? SetMethod
+        {
+            get => Semantics.FirstOrDefault(s => s.Attributes == MethodSemanticsAttributes.Setter)?.Method;
+            set => SetSemanticMethods(GetMethod, value);
+        }
 
         /// <summary>
         /// Clear <see cref="Semantics"/> and apply these methods to the property definition.

--- a/test/AsmResolver.DotNet.Tests/PropertyDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/PropertyDefinitionTest.cs
@@ -96,5 +96,38 @@ namespace AsmResolver.DotNet.Tests
 
             Assert.Equal("System.Int32 AsmResolver.DotNet.TestCases.Properties.MultipleProperties::Item[System.Int32]", property.FullName);
         }
+
+        [Fact]
+        public void GetMethodSetMethodProperties()
+        {
+            var module = new ModuleDefinition("TestModule");
+            var type = new TypeDefinition("Namespace", "Name", TypeAttributes.Public);
+            module.TopLevelTypes.Add(type);
+
+            var get1 = new MethodDefinition("get_Property1", default, MethodSignature.CreateInstance(module.CorLibTypeFactory.Int32));
+            var get2 = new MethodDefinition("get_Property2", default, MethodSignature.CreateInstance(module.CorLibTypeFactory.Int32));
+            var set = new MethodDefinition("set_Property", default, MethodSignature.CreateInstance(module.CorLibTypeFactory.Void, module.CorLibTypeFactory.Int32));
+            type.Methods.Add(get1);
+            type.Methods.Add(get2);
+            type.Methods.Add(set);
+
+            Assert.False(get1.IsGetMethod || get1.IsSetMethod);
+            Assert.False(get2.IsGetMethod || get2.IsSetMethod);
+            Assert.False(set.IsGetMethod || set.IsSetMethod);
+
+            var property = new PropertyDefinition("Property", PropertyAttributes.None, PropertySignature.CreateInstance(module.CorLibTypeFactory.Int32));
+            type.Properties.Add(property);
+            property.SetSemanticMethods(get1, set);
+
+            Assert.True(get1.IsGetMethod);
+            Assert.False(get2.IsGetMethod);
+            Assert.True(set.IsSetMethod);
+
+            property.GetMethod = get2;
+
+            Assert.False(get1.IsGetMethod);
+            Assert.True(get2.IsGetMethod);
+            Assert.True(set.IsSetMethod);
+        }
     }
 }


### PR DESCRIPTION
Should these set accessors modify `MethodDefinition.Semantics` too?