### PR TITLE
Be more forgiving about null status of parameters given to CreateMemberReference

### DIFF
--- a/src/AsmResolver.DotNet/TypeDescriptorExtensions.cs
+++ b/src/AsmResolver.DotNet/TypeDescriptorExtensions.cs
@@ -183,8 +183,8 @@ namespace AsmResolver.DotNet
         /// <returns>The constructed reference.</returns>
         public static MemberReference CreateMemberReference(
             this IMemberRefParent parent,
-            string memberName,
-            MemberSignature signature)
+            string? memberName,
+            MemberSignature? signature)
         {
             return new MemberReference(parent, memberName, signature);
         }


### PR DESCRIPTION
The MemberReference constructor is already null forgiving. This just propagates it up.