### PR TITLE
BUGFIX: Address off-by-one bounds check for table column sizes

### DIFF
--- a/src/AsmResolver.PE/DotNet/Metadata/SerializedTableStream.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/SerializedTableStream.cs
@@ -217,7 +217,7 @@ namespace AsmResolver.PE.DotNet.Metadata
             int tableIndexBitCount = (int) Math.Ceiling(Math.Log(tables.Length, 2));
             int maxSmallTableMemberCount = ushort.MaxValue >> tableIndexBitCount;
 
-            return tables.Select(t => _combinedRowCounts[(int) t]).All(c => c < maxSmallTableMemberCount)
+            return tables.Select(t => _combinedRowCounts[(int) t]).All(c => c <= maxSmallTableMemberCount)
                 ? IndexSize.Short
                 : IndexSize.Long;
         }


### PR DESCRIPTION
Closes #608 