### PR TITLE
Use inbox memory-mapped file APIs where available.

### DIFF
--- a/src/AsmResolver/AsmResolver.csproj
+++ b/src/AsmResolver/AsmResolver.csproj
@@ -16,8 +16,12 @@
     <DocumentationFile>bin\Release\netstandard2.0\AsmResolver.xml</DocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net35'">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageReference Include="MonoMod.Backports" Version="1.1.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462'">
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/AsmResolver/Shims/MemoryMappedFileShim.Unix.cs
+++ b/src/AsmResolver/Shims/MemoryMappedFileShim.Unix.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿#if NET35
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 
 namespace AsmResolver.Shims;
@@ -50,3 +51,4 @@ internal sealed unsafe partial class MemoryMappedFileShim
         munmap(filePointer, (nuint)_size);
     }
 }
+#endif

--- a/src/AsmResolver/Shims/MemoryMappedFileShim.Windows.cs
+++ b/src/AsmResolver/Shims/MemoryMappedFileShim.Windows.cs
@@ -1,3 +1,4 @@
+#if NET35
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
@@ -72,3 +73,4 @@ internal sealed unsafe partial class MemoryMappedFileShim
         CloseHandle(_fileHandle);
     }
 }
+#endif

--- a/src/AsmResolver/Shims/MemoryMappedFileShim.cs
+++ b/src/AsmResolver/Shims/MemoryMappedFileShim.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if NET35
+using System;
 using System.Threading;
 
 namespace AsmResolver.Shims;
@@ -54,3 +55,4 @@ internal sealed unsafe partial class MemoryMappedFileShim : IDisposable
         DisposeCore();
     }
 }
+#endif

--- a/src/AsmResolver/Shims/MemoryMappedFileShim.inbox.cs
+++ b/src/AsmResolver/Shims/MemoryMappedFileShim.inbox.cs
@@ -12,11 +12,13 @@ internal sealed unsafe class MemoryMappedFileShim : IDisposable
 
     public MemoryMappedFileShim(string path)
     {
-        _file = MemoryMappedFile.CreateFromFile(path, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+        var file = File.OpenRead(path);
+        _file = MemoryMappedFile.CreateFromFile(file, null, 0, MemoryMappedFileAccess.Read, HandleInheritability.None, leaveOpen: false);
+        Size = file.Length;
         _accessor = _file.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
     }
 
-    public long Size => _accessor.Capacity;
+    public long Size { get; }
     public byte* BasePointer => (byte*)_accessor.SafeMemoryMappedViewHandle.DangerousGetHandle();
 
     public void Dispose()

--- a/src/AsmResolver/Shims/MemoryMappedFileShim.inbox.cs
+++ b/src/AsmResolver/Shims/MemoryMappedFileShim.inbox.cs
@@ -1,0 +1,28 @@
+#if !NET35
+using System;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+
+namespace AsmResolver.Shims;
+
+internal sealed unsafe class MemoryMappedFileShim : IDisposable
+{
+    private readonly MemoryMappedFile _file;
+    private readonly MemoryMappedViewAccessor _accessor;
+
+    public MemoryMappedFileShim(string path)
+    {
+        _file = MemoryMappedFile.CreateFromFile(path, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+        _accessor = _file.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
+    }
+
+    public long Size => _accessor.Capacity;
+    public byte* BasePointer => (byte*)_accessor.SafeMemoryMappedViewHandle.DangerousGetHandle();
+
+    public void Dispose()
+    {
+        _accessor.Dispose();
+        _file.Dispose();
+    }
+}
+#endif

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net6.0;net35;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net8.0;net6.0;net35;net462;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Nullable>enable</Nullable>
         <IsTrimmable>true</IsTrimmable>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net6.0;net35;net462;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net8.0;net6.0;net462;net472;net35;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Nullable>enable</Nullable>
         <IsTrimmable>true</IsTrimmable>


### PR DESCRIPTION
This PR makes the memory-mapped file shim implementation added in #544 to be used only when targeting .NET Framework 3.5. For all newer frameworks, the `MemoryMappedFileShim` class' implementation simply forwards to the inbox framework APIs.

We also multi-target to .NET Framework 4.6.2 (the earliest supported 4.x version) in order to avoid the shims where we can.