### PR TITLE
Relax Validation on Final Nested Type Ordering

### DIFF
--- a/src/AsmResolver.DotNet/Builder/Discovery/MemberDiscoverer.cs
+++ b/src/AsmResolver.DotNet/Builder/Discovery/MemberDiscoverer.cs
@@ -31,7 +31,7 @@ namespace AsmResolver.DotNet.Builder.Discovery
         private readonly TypeReference _eventHandlerTypeRef;
         private readonly TypeSignature _eventHandlerTypeSig;
 
-        private readonly Dictionary<TableIndex, IList<uint>> _freeRids = new()
+        private readonly Dictionary<TableIndex, List<uint>> _freeRids = new()
         {
             [TableIndex.TypeDef] = new List<uint>(),
             [TableIndex.Field] = new List<uint>(),
@@ -41,7 +41,7 @@ namespace AsmResolver.DotNet.Builder.Discovery
             [TableIndex.Event] = new List<uint>(),
         };
 
-        private readonly Dictionary<TableIndex, IList<IMetadataMember>> _floatingMembers = new()
+        private readonly Dictionary<TableIndex, List<IMetadataMember>> _floatingMembers = new()
         {
             [TableIndex.TypeDef] = new List<IMetadataMember>(),
             [TableIndex.Field] = new List<IMetadataMember>(),
@@ -253,10 +253,7 @@ namespace AsmResolver.DotNet.Builder.Discovery
 
                 // Check if the slot is available.
                 if (memberList[(int) member.MetadataToken.Rid - 1] is { } slot)
-                {
-                    throw new ArgumentException(
-                        $"{slot.SafeToString()} and {member.SafeToString()} are assigned the same RID {member.MetadataToken.Rid}.");
-                }
+                    throw new MetadataTokenConflictException(slot, member, member.MetadataToken.Rid);
 
                 memberList[(int) member.MetadataToken.Rid - 1] = member;
                 freeRids.Remove(member.MetadataToken.Rid);

--- a/src/AsmResolver.DotNet/Builder/DotNetDirectoryBuffer.MemberTree.cs
+++ b/src/AsmResolver.DotNet/Builder/DotNetDirectoryBuffer.MemberTree.cs
@@ -173,7 +173,8 @@ namespace AsmResolver.DotNet.Builder
                     if (enclosingTypeToken.Rid == 0)
                     {
                         ErrorListener.MetadataBuilder(
-                            $"Nested type {type.SafeToString()} is added before its enclosing class {type.DeclaringType.SafeToString()}.");
+                            $"Nested type {type.SafeToString()} is added before its enclosing class {type.DeclaringType.SafeToString()}."
+                        );
                     }
 
                     var nestedClassRow = new NestedClassRow(

--- a/src/AsmResolver.DotNet/Builder/MetadataTokenConflictException.cs
+++ b/src/AsmResolver.DotNet/Builder/MetadataTokenConflictException.cs
@@ -1,0 +1,47 @@
+using AsmResolver.PE.DotNet.Metadata.Tables;
+
+namespace AsmResolver.DotNet.Builder;
+
+/// <summary>
+/// Represents the exception that occurs when two metadata members are assigned the same metadata token.
+/// </summary>
+public class MetadataTokenConflictException : MetadataBuilderException
+{
+    /// <summary>
+    /// Creates a new instance of the <see cref="MetadataTokenConflictException"/> class.
+    /// </summary>
+    /// <param name="member1">The first conflicting member.</param>
+    /// <param name="member2">The second conflicting member.</param>
+    /// <param name="token">The metadata token they are both assigned to.</param>
+    public MetadataTokenConflictException(IMetadataMember member1, IMetadataMember member2, MetadataToken token)
+        : base($"{member1.SafeToString()} and {member2.SafeToString()} are assigned the same RID {token.Rid}.")
+    {
+        Member1 = member1;
+        Member2 = member2;
+        Token = token;
+    }
+
+    /// <summary>
+    /// Gets the first conflicting member.
+    /// </summary>
+    public IMetadataMember Member1
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets the second conflicting member.
+    /// </summary>
+    public IMetadataMember Member2
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets the metadata token the two members were assigned.
+    /// </summary>
+    public MetadataToken Token
+    {
+        get;
+    }
+}

--- a/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/TokenPreservationTestBase.cs
+++ b/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/TokenPreservationTestBase.cs
@@ -32,15 +32,12 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
 
         protected static ModuleDefinition RebuildAndReloadModule(ModuleDefinition module, MetadataBuilderFlags builderFlags)
         {
-            var builder = new ManagedPEImageBuilder(builderFlags);
+            var bag = new DiagnosticBag();
+            var builder = new ManagedPEImageBuilder(new DotNetDirectoryFactory(builderFlags), bag);
 
             var result = builder.CreateImage(module);
-            if (result.HasFailed)
-            {
-                if (result.ErrorListener is DiagnosticBag diagnosticBag)
-                    throw new AggregateException(diagnosticBag.Exceptions);
-                throw new Exception("Image creation failed.");
-            }
+            if (bag.IsFatal || result.HasFailed)
+                throw new AggregateException(bag.Exceptions);
 
             var newImage = result.ConstructedImage;
 

--- a/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/TokenPreservationTestBase.cs
+++ b/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/TokenPreservationTestBase.cs
@@ -32,7 +32,11 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
 
         protected static ModuleDefinition RebuildAndReloadModule(ModuleDefinition module, MetadataBuilderFlags builderFlags)
         {
-            var bag = new DiagnosticBag();
+            return RebuildAndReloadModule(module, builderFlags, new DiagnosticBag());
+        }
+
+        protected static ModuleDefinition RebuildAndReloadModule(ModuleDefinition module, MetadataBuilderFlags builderFlags, DiagnosticBag bag)
+        {
             var builder = new ManagedPEImageBuilder(new DotNetDirectoryFactory(builderFlags), bag);
 
             var result = builder.CreateImage(module);

--- a/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/TypeDefTokenPreservationTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/TypeDefTokenPreservationTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using AsmResolver.DotNet.Builder;
 using AsmResolver.PE.DotNet.Metadata.Tables;
@@ -67,12 +68,56 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
             var newModule = RebuildAndReloadModule(module, MetadataBuilderFlags.PreserveTypeDefinitionIndices);
             var newTypeDefs = GetMembers<TypeDefinition>(newModule, TableIndex.TypeDef);
 
-            for (int i = 0; i < originalTypeDefs.Count; i++)
+            Assert.All(Enumerable.Range(0, originalTypeDefs.Count), i =>
             {
                 if (i != indexToRemove)
                     Assert.Equal(originalTypeDefs[i], newTypeDefs[i], Comparer);
-            }
+            });
         }
 
+        [Fact]
+        public void PreserveTypeDefsAfterInsertingNewModuleTypeShouldThrow()
+        {
+            // Prepare.
+            var module = new ModuleDefinition("SomeModule", KnownCorLibs.SystemRuntime_v8_0_0_0);
+            module = RebuildAndReloadModule(module, MetadataBuilderFlags.None);
+
+            // Insert new module type, but keep original module type around.
+            module.GetOrCreateModuleType().Name = "<NotModule>";
+            var newModuleType = module.GetOrCreateModuleType();
+
+            // Rebuild with type preservation should conflict.
+            var exception = Assert.Throws<AggregateException>(() => RebuildAndReloadModule(module, MetadataBuilderFlags.PreserveTypeDefinitionIndices));
+            Assert.Contains(exception.InnerExceptions, ex =>
+            {
+                return ex is MetadataTokenConflictException conflict
+                    && (conflict.Member1 == newModuleType || conflict.Member2 == newModuleType)
+                    && conflict.Token.Rid == 1;
+            });
+        }
+
+        [Fact]
+        public void PreserveTypeDefsAfterInsertingNewModuleTypeAndRemovingOldShouldNotThrow()
+        {
+            // Prepare.
+            var module = new ModuleDefinition("SomeModule", KnownCorLibs.SystemRuntime_v8_0_0_0);
+            var moduleType = module.GetOrCreateModuleType();
+            moduleType.Fields.Add(new FieldDefinition("SomeField", FieldAttributes.Static, module.CorLibTypeFactory.Int32));
+            module = RebuildAndReloadModule(module, MetadataBuilderFlags.None);
+
+            // Insert new module type, and remove original module type.
+            module.TopLevelTypes.Remove(module.GetModuleType());
+            moduleType = module.GetOrCreateModuleType();
+            moduleType.Fields.Add(new FieldDefinition("OtherField", FieldAttributes.Static, module.CorLibTypeFactory.Int16));
+
+            // Rebuild should not conflict.
+            var newModule = RebuildAndReloadModule(module, MetadataBuilderFlags.PreserveTypeDefinitionIndices);
+
+            // Assert that the module type was replaced with the new one.
+            var newModuleType = newModule.GetModuleType();
+            Assert.NotNull(newModuleType);
+            var fields = Assert.Single(newModuleType.Fields);
+            Assert.Equal("OtherField", fields.Name);
+        }
     }
 }

--- a/test/AsmResolver.DotNet.Tests/ModuleDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/ModuleDefinitionTest.cs
@@ -590,6 +590,14 @@ namespace AsmResolver.DotNet.Tests
             Assert.Same(type, module.GetModuleType());
         }
 
+        [Fact]
+        public void CreateModuleTypeShouldHaveFirstRid()
+        {
+            var module = new ModuleDefinition("SomeModule");
+            var type = module.GetOrCreateModuleType();
+            Assert.Equal(1u, type.MetadataToken.Rid);
+        }
+
         [Theory]
         [InlineData(false, false, false)]
         [InlineData(false, true, false)]


### PR DESCRIPTION
ECMA-335 II.2 states TypeDefs should be sorted based on nested class relationships. That is, every enclosing class should be defined before its nested types in the TypeDef table. However, from empirical testing, CLR, CoreCLR and Mono do not actually implement checks for this, allowing for nested classes to be defined before their enclosing types.

This PR relaxes the NestedClass validation in AsmResolver to a non-fatal exception that can be ignored at rebuild time, to allow for typedef tokens to be preserved even if that results in nested classes being ordered incorrectly according to spec.

This PR also ensures the `<Module>` type is always assigned a RID of `1` when creating a new module.

Closes #545 
