### PR TITLE
Add DiagnosticSource to MemberNotImportedException

### DIFF
--- a/src/AsmResolver.DotNet/Builder/DotNetDirectoryBuffer.CodedIndices.cs
+++ b/src/AsmResolver.DotNet/Builder/DotNetDirectoryBuffer.CodedIndices.cs
@@ -24,22 +24,22 @@ namespace AsmResolver.DotNet.Builder
             var encoder = Metadata.TablesStream.GetIndexEncoder(CodedIndex.HasCustomAttribute);
             var row = new CustomAttributeRow(
                 encoder.EncodeToken(ownerToken),
-                AddCustomAttributeType(attribute.Constructor),
-                Metadata.BlobStream.GetBlobIndex(this, attribute.Signature, ErrorListener));
+                AddCustomAttributeType(attribute.Constructor, attribute),
+                Metadata.BlobStream.GetBlobIndex(this, attribute.Signature, ErrorListener, attribute));
 
             table.Add(attribute, row);
         }
 
-        private uint AddResolutionScope(IResolutionScope? scope, bool allowDuplicates, bool preserveRid)
+        private uint AddResolutionScope(IResolutionScope? scope, bool allowDuplicates, bool preserveRid, object? diagnosticSource = null)
         {
-            if (!AssertIsImported(scope))
+            if (!AssertIsImported(scope, diagnosticSource))
                 return 0;
 
             var token = scope.MetadataToken.Table switch
             {
-                TableIndex.AssemblyRef => AddAssemblyReference(scope as AssemblyReference, allowDuplicates, preserveRid),
-                TableIndex.TypeRef => AddTypeReference(scope as TypeReference, allowDuplicates, preserveRid),
-                TableIndex.ModuleRef => AddModuleReference(scope as ModuleReference, allowDuplicates, preserveRid),
+                TableIndex.AssemblyRef => AddAssemblyReference(scope as AssemblyReference, allowDuplicates, preserveRid, diagnosticSource),
+                TableIndex.TypeRef => AddTypeReference(scope as TypeReference, allowDuplicates, preserveRid, diagnosticSource),
+                TableIndex.ModuleRef => AddModuleReference(scope as ModuleReference, allowDuplicates, preserveRid, diagnosticSource),
                 TableIndex.Module => new MetadataToken(TableIndex.Module, 1),
                 _ => throw new ArgumentOutOfRangeException(nameof(scope))
             };
@@ -50,16 +50,16 @@ namespace AsmResolver.DotNet.Builder
         }
 
         /// <inheritdoc />
-        public uint GetTypeDefOrRefIndex(ITypeDefOrRef? type)
+        public uint GetTypeDefOrRefIndex(ITypeDefOrRef? type, object? diagnosticSource = null)
         {
-            if (!AssertIsImported(type))
+            if (!AssertIsImported(type, diagnosticSource))
                 return 0;
 
             var token = type.MetadataToken.Table switch
             {
-                TableIndex.TypeDef => GetTypeDefinitionToken(type as TypeDefinition),
-                TableIndex.TypeRef => GetTypeReferenceToken(type as TypeReference),
-                TableIndex.TypeSpec => GetTypeSpecificationToken(type as TypeSpecification),
+                TableIndex.TypeDef => GetTypeDefinitionToken(type as TypeDefinition, diagnosticSource),
+                TableIndex.TypeRef => GetTypeReferenceToken(type as TypeReference, diagnosticSource),
+                TableIndex.TypeSpec => GetTypeSpecificationToken(type as TypeSpecification, diagnosticSource),
                 _ => throw new ArgumentOutOfRangeException(nameof(type))
             };
 
@@ -68,18 +68,18 @@ namespace AsmResolver.DotNet.Builder
                 .EncodeToken(token);
         }
 
-        private uint AddMemberRefParent(IMemberRefParent? parent)
+        private uint AddMemberRefParent(IMemberRefParent? parent, object? diagnosticSource = null)
         {
-            if (!AssertIsImported(parent))
+            if (!AssertIsImported(parent, diagnosticSource))
                 return 0;
 
             var token = parent.MetadataToken.Table switch
             {
-                TableIndex.TypeDef => GetTypeDefinitionToken(parent as TypeDefinition),
-                TableIndex.TypeRef => GetTypeReferenceToken(parent as TypeReference),
-                TableIndex.TypeSpec => GetTypeSpecificationToken(parent as TypeSpecification),
-                TableIndex.Method => GetMethodDefinitionToken(parent as MethodDefinition),
-                TableIndex.ModuleRef => GetModuleReferenceToken(parent as ModuleReference),
+                TableIndex.TypeDef => GetTypeDefinitionToken(parent as TypeDefinition, diagnosticSource),
+                TableIndex.TypeRef => GetTypeReferenceToken(parent as TypeReference, diagnosticSource),
+                TableIndex.TypeSpec => GetTypeSpecificationToken(parent as TypeSpecification, diagnosticSource),
+                TableIndex.Method => GetMethodDefinitionToken(parent as MethodDefinition, diagnosticSource),
+                TableIndex.ModuleRef => GetModuleReferenceToken(parent as ModuleReference, diagnosticSource),
                 _ => throw new ArgumentOutOfRangeException(nameof(parent))
             };
 
@@ -88,15 +88,15 @@ namespace AsmResolver.DotNet.Builder
                 .EncodeToken(token);
         }
 
-        private uint AddMethodDefOrRef(IMethodDefOrRef? method)
+        private uint AddMethodDefOrRef(IMethodDefOrRef? method, object? diagnosticSource = null)
         {
-            if (!AssertIsImported(method))
+            if (!AssertIsImported(method, diagnosticSource))
                 return 0;
 
             var token = method.MetadataToken.Table switch
             {
-                TableIndex.Method => GetMethodDefinitionToken(method as MethodDefinition),
-                TableIndex.MemberRef => GetMemberReferenceToken(method as MemberReference),
+                TableIndex.Method => GetMethodDefinitionToken(method as MethodDefinition, diagnosticSource),
+                TableIndex.MemberRef => GetMemberReferenceToken(method as MemberReference, diagnosticSource),
                 _ => throw new ArgumentOutOfRangeException(nameof(method))
             };
 
@@ -105,15 +105,15 @@ namespace AsmResolver.DotNet.Builder
                 .EncodeToken(token);
         }
 
-        private uint AddCustomAttributeType(ICustomAttributeType? constructor)
+        private uint AddCustomAttributeType(ICustomAttributeType? constructor, object? diagnosticSource = null)
         {
-            if (!AssertIsImported(constructor))
+            if (!AssertIsImported(constructor, diagnosticSource))
                 return 0;
 
             var token = constructor.MetadataToken.Table switch
             {
-                TableIndex.Method => GetMethodDefinitionToken(constructor as MethodDefinition),
-                TableIndex.MemberRef => GetMemberReferenceToken(constructor as MemberReference),
+                TableIndex.Method => GetMethodDefinitionToken(constructor as MethodDefinition, diagnosticSource),
+                TableIndex.MemberRef => GetMemberReferenceToken(constructor as MemberReference, diagnosticSource),
                 _ => throw new ArgumentOutOfRangeException(nameof(constructor))
             };
 
@@ -133,7 +133,7 @@ namespace AsmResolver.DotNet.Builder
             var row = new ConstantRow(
                 constant.Type,
                 encoder.EncodeToken(ownerToken),
-                Metadata.BlobStream.GetBlobIndex(this, constant.Value, ErrorListener));
+                Metadata.BlobStream.GetBlobIndex(this, constant.Value, ErrorListener, constant));
 
             table.Add(constant, row);
         }
@@ -150,21 +150,21 @@ namespace AsmResolver.DotNet.Builder
                 implementationMap.Attributes,
                 encoder.EncodeToken(ownerToken),
                 Metadata.StringsStream.GetStringIndex(implementationMap.Name),
-                GetModuleReferenceToken(implementationMap.Scope).Rid);
+                GetModuleReferenceToken(implementationMap.Scope, implementationMap).Rid);
 
             table.Add(implementationMap, row);
         }
 
-        private uint AddImplementation(IImplementation? implementation)
+        private uint AddImplementation(IImplementation? implementation, object? diagnosticSource = null)
         {
-            if (implementation is null)
+            if (implementation is null || !AssertIsImported(implementation, diagnosticSource))
                 return 0;
 
             var token = implementation switch
             {
-                AssemblyReference assemblyReference => GetAssemblyReferenceToken(assemblyReference),
-                ExportedType exportedType => AddExportedType(exportedType),
-                FileReference fileReference => AddFileReference(fileReference),
+                AssemblyReference assemblyReference => GetAssemblyReferenceToken(assemblyReference, diagnosticSource),
+                ExportedType exportedType => AddExportedType(exportedType, diagnosticSource),
+                FileReference fileReference => AddFileReference(fileReference, diagnosticSource),
                 _ => throw new ArgumentOutOfRangeException(nameof(implementation))
             };
 
@@ -184,7 +184,7 @@ namespace AsmResolver.DotNet.Builder
                 var row = new SecurityDeclarationRow(
                     declaration.Action,
                     encoder.EncodeToken(ownerToken),
-                    Metadata.BlobStream.GetBlobIndex(this, declaration.PermissionSet, ErrorListener));
+                    Metadata.BlobStream.GetBlobIndex(this, declaration.PermissionSet, ErrorListener, declaration));
                 table.Add(declaration, row);
             }
         }
@@ -199,7 +199,7 @@ namespace AsmResolver.DotNet.Builder
 
             var row = new FieldMarshalRow(
                 encoder.EncodeToken(ownerToken),
-                Metadata.BlobStream.GetBlobIndex(this, owner.MarshalDescriptor, ErrorListener));
+                Metadata.BlobStream.GetBlobIndex(this, owner.MarshalDescriptor, ErrorListener, owner));
             table.Add(owner, row);
         }
 

--- a/src/AsmResolver.DotNet/Builder/DotNetDirectoryBuffer.TokenProvider.cs
+++ b/src/AsmResolver.DotNet/Builder/DotNetDirectoryBuffer.TokenProvider.cs
@@ -9,9 +9,9 @@ namespace AsmResolver.DotNet.Builder
         public uint GetUserStringIndex(string value) => Metadata.UserStringsStream.GetStringIndex(value);
 
         /// <inheritdoc />
-        public MetadataToken GetTypeReferenceToken(TypeReference? type)
+        public MetadataToken GetTypeReferenceToken(TypeReference? type, object? diagnosticSource = null)
         {
-            return AddTypeReference(type, false, false);
+            return AddTypeReference(type, false, false, diagnosticSource);
         }
 
         /// <summary>
@@ -25,15 +25,16 @@ namespace AsmResolver.DotNet.Builder
         /// <param name="preserveRid">
         /// <c>true</c> if the metadata token of the type should be preserved, <c>false</c> otherwise.
         /// </param>
+        /// <param name="diagnosticSource">The object that referenced the type.</param>
         /// <returns>The newly assigned metadata token.</returns>
-        public MetadataToken AddTypeReference(TypeReference? type, bool allowDuplicates, bool preserveRid)
+        public MetadataToken AddTypeReference(TypeReference? type, bool allowDuplicates, bool preserveRid, object? diagnosticSource = null)
         {
-            if (!AssertIsImported(type))
+            if (!AssertIsImported(type, diagnosticSource))
                 return MetadataToken.Zero;
 
             var table = Metadata.TablesStream.GetDistinctTable<TypeReferenceRow>(TableIndex.TypeRef);
             var row = new TypeReferenceRow(
-                AddResolutionScope(type.Scope, allowDuplicates, preserveRid),
+                AddResolutionScope(type.Scope, allowDuplicates, preserveRid, type),
                 Metadata.StringsStream.GetStringIndex(type.Name),
                 Metadata.StringsStream.GetStringIndex(type.Namespace));
 
@@ -47,25 +48,25 @@ namespace AsmResolver.DotNet.Builder
         }
 
         /// <inheritdoc />
-        public MetadataToken GetTypeDefinitionToken(TypeDefinition? type)
+        public MetadataToken GetTypeDefinitionToken(TypeDefinition? type, object? diagnosticSource = null)
         {
-            return AssertIsImported(type)
+            return AssertIsImported(type, diagnosticSource)
                 ? _tokenMapping[type]
                 : MetadataToken.Zero;
         }
 
         /// <inheritdoc />
-        public MetadataToken GetFieldDefinitionToken(FieldDefinition? field)
+        public MetadataToken GetFieldDefinitionToken(FieldDefinition? field, object? diagnosticSource = null)
         {
-            return AssertIsImported(field)
+            return AssertIsImported(field, diagnosticSource)
                 ? _tokenMapping[field]
                 : MetadataToken.Zero;
         }
 
         /// <inheritdoc />
-        public MetadataToken GetMethodDefinitionToken(MethodDefinition? method)
+        public MetadataToken GetMethodDefinitionToken(MethodDefinition? method, object? diagnosticSource = null)
         {
-            return AssertIsImported(method)
+            return AssertIsImported(method, diagnosticSource)
                 ? _tokenMapping[method]
                 : MetadataToken.Zero;
         }
@@ -78,7 +79,7 @@ namespace AsmResolver.DotNet.Builder
         /// <returns>The metadata token of the added parameter definition.</returns>
         public MetadataToken GetParameterDefinitionToken(ParameterDefinition? parameter)
         {
-            return AssertIsImported(parameter)
+            return AssertIsImported(parameter, parameter?.Method)
                 ? _tokenMapping[parameter]
                 : MetadataToken.Zero;
         }
@@ -90,7 +91,7 @@ namespace AsmResolver.DotNet.Builder
         /// <returns>The metadata token of the added property definition.</returns>
         public MetadataToken GetPropertyDefinitionToken(PropertyDefinition? property)
         {
-            return AssertIsImported(property)
+            return AssertIsImported(property, property?.DeclaringType)
                 ? _tokenMapping[property]
                 : MetadataToken.Zero;
         }
@@ -102,15 +103,15 @@ namespace AsmResolver.DotNet.Builder
         /// <returns>The metadata token of the added event definition.</returns>
         public MetadataToken GetEventDefinitionToken(EventDefinition? @event)
         {
-            return AssertIsImported(@event)
+            return AssertIsImported(@event, @event?.DeclaringType)
                 ? _tokenMapping[@event]
                 : MetadataToken.Zero;
         }
 
         /// <inheritdoc />
-        public MetadataToken GetMemberReferenceToken(MemberReference? member)
+        public MetadataToken GetMemberReferenceToken(MemberReference? member, object? diagnosticSource = null)
         {
-            return AddMemberReference(member, false);
+            return AddMemberReference(member, false, diagnosticSource);
         }
 
         /// <summary>
@@ -121,17 +122,18 @@ namespace AsmResolver.DotNet.Builder
         /// <c>true</c> if the row is always to be added to the end of the buffer, <c>false</c> if a duplicated row
         /// is supposed to be removed and the token of the original should be returned instead.
         /// </param>
+        /// <param name="diagnosticSource">The object that referenced the member.</param>
         /// <returns>The newly assigned metadata token.</returns>
-        public MetadataToken AddMemberReference(MemberReference? member, bool allowDuplicates)
+        public MetadataToken AddMemberReference(MemberReference? member, bool allowDuplicates, object? diagnosticSource = null)
         {
-            if (!AssertIsImported(member))
+            if (!AssertIsImported(member, diagnosticSource))
                 return MetadataToken.Zero;
 
             var table = Metadata.TablesStream.GetDistinctTable<MemberReferenceRow>(TableIndex.MemberRef);
             var row = new MemberReferenceRow(
-                AddMemberRefParent(member.Parent),
+                AddMemberRefParent(member.Parent, member),
                 Metadata.StringsStream.GetStringIndex(member.Name),
-                Metadata.BlobStream.GetBlobIndex(this, member.Signature, ErrorListener));
+                Metadata.BlobStream.GetBlobIndex(this, member.Signature, ErrorListener, diagnosticSource));
 
             var token = table.Add(row, allowDuplicates);
             _tokenMapping.Register(member, token);
@@ -140,9 +142,9 @@ namespace AsmResolver.DotNet.Builder
         }
 
         /// <inheritdoc />
-        public MetadataToken GetStandAloneSignatureToken(StandAloneSignature? signature)
+        public MetadataToken GetStandAloneSignatureToken(StandAloneSignature? signature, object? diagnosticSource = null)
         {
-            return AddStandAloneSignature(signature, false);
+            return AddStandAloneSignature(signature, false, diagnosticSource);
         }
 
         /// <summary>
@@ -153,15 +155,16 @@ namespace AsmResolver.DotNet.Builder
         /// <c>true</c> if the row is always to be added to the end of the buffer, <c>false</c> if a duplicated row
         /// is supposed to be removed and the token of the original should be returned instead.
         /// </param>
+        /// <param name="diagnosticSource">The object that referenced the standalone signature.</param>
         /// <returns>The newly assigned metadata token.</returns>
-        public MetadataToken AddStandAloneSignature(StandAloneSignature? signature, bool allowDuplicates)
+        public MetadataToken AddStandAloneSignature(StandAloneSignature? signature, bool allowDuplicates, object? diagnosticSource = null)
         {
             if (signature is null)
                 return MetadataToken.Zero;
 
             var table = Metadata.TablesStream.GetDistinctTable<StandAloneSignatureRow>(TableIndex.StandAloneSig);
             var row = new StandAloneSignatureRow(
-                Metadata.BlobStream.GetBlobIndex(this, signature.Signature, ErrorListener));
+                Metadata.BlobStream.GetBlobIndex(this, signature.Signature, ErrorListener, diagnosticSource));
 
             var token = table.Add(row, allowDuplicates);
             _tokenMapping.Register(signature, token);
@@ -170,9 +173,9 @@ namespace AsmResolver.DotNet.Builder
         }
 
         /// <inheritdoc />
-        public MetadataToken GetAssemblyReferenceToken(AssemblyReference? assembly)
+        public MetadataToken GetAssemblyReferenceToken(AssemblyReference? assembly, object? diagnosticSource = null)
         {
-            return AddAssemblyReference(assembly, false, false);
+            return AddAssemblyReference(assembly, false, false, diagnosticSource);
         }
 
         /// <summary>
@@ -186,10 +189,11 @@ namespace AsmResolver.DotNet.Builder
         /// <param name="preserveRid">
         /// <c>true</c> if the metadata token of the assembly should be preserved, <c>false</c> otherwise.
         /// </param>
+        /// <param name="diagnosticSource">The object that referenced the assembly.</param>
         /// <returns>The newly assigned metadata token.</returns>
-        public MetadataToken AddAssemblyReference(AssemblyReference? assembly, bool allowDuplicates, bool preserveRid)
+        public MetadataToken AddAssemblyReference(AssemblyReference? assembly, bool allowDuplicates, bool preserveRid, object? diagnosticSource = null)
         {
-            if (assembly is null || !AssertIsImported(assembly))
+            if (assembly is null || !AssertIsImported(assembly, diagnosticSource))
                 return MetadataToken.Zero;
 
             var table = Metadata.TablesStream.GetDistinctTable<AssemblyReferenceRow>(TableIndex.AssemblyRef);
@@ -216,10 +220,11 @@ namespace AsmResolver.DotNet.Builder
         /// Adds a single module reference to the buffer.
         /// </summary>
         /// <param name="reference">The reference to add.</param>
+        /// <param name="diagnosticSource">The object that referenced the module.</param>
         /// <returns>The new metadata token assigned to the module reference.</returns>
-        public MetadataToken GetModuleReferenceToken(ModuleReference? reference)
+        public MetadataToken GetModuleReferenceToken(ModuleReference? reference, object? diagnosticSource = null)
         {
-            return AddModuleReference(reference, false, false);
+            return AddModuleReference(reference, false, false, diagnosticSource);
         }
 
         /// <summary>
@@ -233,10 +238,11 @@ namespace AsmResolver.DotNet.Builder
         /// <param name="preserveRid">
         /// <c>true</c> if the metadata token of the module should be preserved, <c>false</c> otherwise.
         /// </param>
+        /// <param name="diagnosticSource">The object that referenced the module.</param>
         /// <returns>The newly assigned metadata token.</returns>
-        public MetadataToken AddModuleReference(ModuleReference? reference, bool allowDuplicates, bool preserveRid)
+        public MetadataToken AddModuleReference(ModuleReference? reference, bool allowDuplicates, bool preserveRid, object? diagnosticSource = null)
         {
-            if (!AssertIsImported(reference))
+            if (!AssertIsImported(reference, diagnosticSource))
                 return MetadataToken.Zero;
 
             var table = Metadata.TablesStream.GetDistinctTable<ModuleReferenceRow>(TableIndex.ModuleRef);
@@ -251,9 +257,9 @@ namespace AsmResolver.DotNet.Builder
         }
 
         /// <inheritdoc />
-        public MetadataToken GetTypeSpecificationToken(TypeSpecification? type)
+        public MetadataToken GetTypeSpecificationToken(TypeSpecification? type, object? diagnosticSource = null)
         {
-            return AddTypeSpecification(type, false);
+            return AddTypeSpecification(type, false, diagnosticSource);
         }
 
         /// <summary>
@@ -264,14 +270,17 @@ namespace AsmResolver.DotNet.Builder
         /// <c>true</c> if the row is always to be added to the end of the buffer, <c>false</c> if a duplicated row
         /// is supposed to be removed and the token of the original should be returned instead.
         /// </param>
+        /// <param name="diagnosticSource">The object that referenced the type specification.</param>
         /// <returns>The newly assigned metadata token.</returns>
-        public MetadataToken AddTypeSpecification(TypeSpecification? type, bool allowDuplicates)
+        public MetadataToken AddTypeSpecification(TypeSpecification? type, bool allowDuplicates, object? diagnosticSource = null)
         {
-            if (!AssertIsImported(type))
+            if (!AssertIsImported(type, diagnosticSource))
                 return MetadataToken.Zero;
 
             var table = Metadata.TablesStream.GetDistinctTable<TypeSpecificationRow>(TableIndex.TypeSpec);
-            var row = new TypeSpecificationRow(Metadata.BlobStream.GetBlobIndex(this, type.Signature, ErrorListener));
+            var row = new TypeSpecificationRow(
+                Metadata.BlobStream.GetBlobIndex(this, type.Signature, ErrorListener, diagnosticSource)
+            );
 
             var token = table.Add(row, allowDuplicates);
             _tokenMapping.Register(type, token);
@@ -280,9 +289,9 @@ namespace AsmResolver.DotNet.Builder
         }
 
         /// <inheritdoc />
-        public MetadataToken GetMethodSpecificationToken(MethodSpecification? method)
+        public MetadataToken GetMethodSpecificationToken(MethodSpecification? method, object? diagnosticSource = null)
         {
-            return AddMethodSpecification(method, false);
+            return AddMethodSpecification(method, false, diagnosticSource);
         }
 
         /// <summary>
@@ -293,16 +302,18 @@ namespace AsmResolver.DotNet.Builder
         /// <c>true</c> if the row is always to be added to the end of the buffer, <c>false</c> if a duplicated row
         /// is supposed to be removed and the token of the original should be returned instead.
         /// </param>
+        /// <param name="diagnosticSource">The object that referenced the method specification.</param>
         /// <returns>The newly assigned metadata token.</returns>
-        public MetadataToken AddMethodSpecification(MethodSpecification? method, bool allowDuplicates)
+        public MetadataToken AddMethodSpecification(MethodSpecification? method, bool allowDuplicates, object? diagnosticSource = null)
         {
-            if (!AssertIsImported(method))
+            if (!AssertIsImported(method, diagnosticSource))
                 return MetadataToken.Zero;
 
             var table = Metadata.TablesStream.GetDistinctTable<MethodSpecificationRow>(TableIndex.MethodSpec);
             var row = new MethodSpecificationRow(
-                AddMethodDefOrRef(method.Method),
-                Metadata.BlobStream.GetBlobIndex(this, method.Signature, ErrorListener));
+                AddMethodDefOrRef(method.Method, method),
+                Metadata.BlobStream.GetBlobIndex(this, method.Signature, ErrorListener, diagnosticSource)
+            );
 
             var token = table.Add(row, allowDuplicates);
             _tokenMapping.Register(method, token);

--- a/src/AsmResolver.DotNet/Builder/DotNetDirectoryBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/DotNetDirectoryBuffer.cs
@@ -110,14 +110,14 @@ namespace AsmResolver.DotNet.Builder
             get;
         }
 
-        private bool AssertIsImported([NotNullWhen(true)] IModuleProvider? member)
+        private bool AssertIsImported([NotNullWhen(true)] IModuleProvider? member, object? diagnosticSource)
         {
             if (member is null)
                 return false;
 
             if (member.Module != Module)
             {
-                ErrorListener.RegisterException(new MemberNotImportedException((IMetadataMember) member));
+                ErrorListener.RegisterException(new MemberNotImportedException((IMetadataMember) member, diagnosticSource));
                 return false;
             }
 
@@ -160,11 +160,11 @@ namespace AsmResolver.DotNet.Builder
             switch (Module.ManagedEntryPoint.MetadataToken.Table)
             {
                 case TableIndex.Method:
-                    entryPointToken = GetMethodDefinitionToken(Module.ManagedEntryPointMethod!);
+                    entryPointToken = GetMethodDefinitionToken(Module.ManagedEntryPointMethod!, Module);
                     break;
 
                 case TableIndex.File:
-                    entryPointToken = AddFileReference((FileReference) Module.ManagedEntryPoint);
+                    entryPointToken = AddFileReference((FileReference) Module.ManagedEntryPoint, Module);
                     break;
 
                 default:
@@ -188,7 +188,7 @@ namespace AsmResolver.DotNet.Builder
 
             var row = new MethodSemanticsRow(
                 semantics.Attributes,
-                GetMethodDefinitionToken(semantics.Method).Rid,
+                GetMethodDefinitionToken(semantics.Method, semantics).Rid,
                 encoder.EncodeToken(ownerToken)
             );
 
@@ -204,7 +204,7 @@ namespace AsmResolver.DotNet.Builder
                 var implementation = interfaces[i];
                 var row = new InterfaceImplementationRow(
                     ownerToken.Rid,
-                    GetTypeDefOrRefIndex(implementation.Interface));
+                    GetTypeDefOrRefIndex(implementation.Interface, implementation));
 
                 table.Add(implementation, row);
             }
@@ -233,7 +233,7 @@ namespace AsmResolver.DotNet.Builder
 
         private void DefineGenericParameter(MetadataToken ownerToken, GenericParameter parameter)
         {
-            if (!AssertIsImported(parameter))
+            if (!AssertIsImported(parameter, parameter.Owner))
                 return;
 
             var table = Metadata.TablesStream.GetSortedTable<GenericParameter, GenericParameterRow>(TableIndex.GenericParam);
@@ -277,7 +277,7 @@ namespace AsmResolver.DotNet.Builder
 
             var row = new GenericParameterConstraintRow(
                 ownerToken.Rid,
-                GetTypeDefOrRefIndex(constraint.Constraint));
+                GetTypeDefOrRefIndex(constraint.Constraint, constraint));
 
             var token = table.Add(row);
             _tokenMapping.Register(constraint, token);

--- a/src/AsmResolver.DotNet/Builder/Metadata/BlobStreamBuffer.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/BlobStreamBuffer.cs
@@ -110,8 +110,9 @@ namespace AsmResolver.DotNet.Builder.Metadata
         /// <param name="provider">The object to use for obtaining metadata tokens for members in the tables stream.</param>
         /// <param name="signature">The signature to lookup or add.</param>
         /// <param name="errorListener">The object responsible for collecting diagnostic information.</param>
+        /// <param name="diagnosticSource">The object that is reported back when serialization of the blob fails.</param>
         /// <returns>The index of the signature.</returns>
-        public uint GetBlobIndex(ITypeCodedIndexProvider provider, BlobSignature? signature, IErrorListener errorListener)
+        public uint GetBlobIndex(ITypeCodedIndexProvider provider, BlobSignature? signature, IErrorListener errorListener, object? diagnosticSource = null)
         {
             if (signature is null)
                 return 0u;
@@ -119,7 +120,7 @@ namespace AsmResolver.DotNet.Builder.Metadata
             // Serialize blob.
 
             using var rentedWriter = _blobWriterPool.Rent();
-            signature.Write(new BlobSerializationContext(rentedWriter.Writer, provider, errorListener));
+            signature.Write(new BlobSerializationContext(rentedWriter.Writer, provider, errorListener, diagnosticSource));
 
             return GetBlobIndex(rentedWriter.GetData());
         }

--- a/src/AsmResolver.DotNet/Builder/Metadata/MemberNotImportedException.cs
+++ b/src/AsmResolver.DotNet/Builder/Metadata/MemberNotImportedException.cs
@@ -6,22 +6,44 @@ namespace AsmResolver.DotNet.Builder.Metadata
     /// Represents the exception that occurs when an external metadata member was used in a .NET module, but was not
     /// imported in said module.
     /// </summary>
-    public class MemberNotImportedException : Exception
+    public class MemberNotImportedException : MetadataBuilderException
     {
         /// <summary>
         /// Creates a new instance of the <see cref="MemberNotImportedException"/>.
         /// </summary>
         /// <param name="member">The member that was not imported.</param>
         public MemberNotImportedException(IMetadataMember member)
-            : base($"Member {member.SafeToString()} was not imported into the module.")
+            : this(member, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="MemberNotImportedException"/>.
+        /// </summary>
+        /// <param name="member">The member that was not imported.</param>
+        /// <param name="diagnosticSource">The source object that references the member.</param>
+        public MemberNotImportedException(IMetadataMember member, object? diagnosticSource)
+            : base(diagnosticSource is not null
+                ? $"[In {diagnosticSource.SafeToString()}]: Member {member.SafeToString()} was not imported into the module."
+                : $"Member {member.SafeToString()} was not imported into the module."
+            )
         {
             Member = member;
+            DiagnosticSource = diagnosticSource;
         }
 
         /// <summary>
         /// Gets the member that was not imported.
         /// </summary>
         public IMetadataMember Member
+        {
+            get;
+        }
+
+        /// <summary>
+        /// When available, gets the source object that references the member.
+        /// </summary>
+        public object? DiagnosticSource
         {
             get;
         }

--- a/src/AsmResolver.DotNet/Code/Cil/CilOperandBuilder.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilOperandBuilder.cs
@@ -13,78 +13,84 @@ namespace AsmResolver.DotNet.Code.Cil
     {
         private readonly IMetadataTokenProvider _provider;
         private readonly IErrorListener _errorListener;
+        private readonly object? _diagnosticSource;
+        private string? _diagnosticPrefix;
 
         /// <summary>
         /// Creates a new CIL operand builder that pulls metadata tokens from a mutable metadata buffer.
         /// </summary>
         public CilOperandBuilder(IMetadataTokenProvider provider, IErrorListener errorListener)
+            : this(provider, errorListener, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new CIL operand builder that pulls metadata tokens from a mutable metadata buffer.
+        /// </summary>
+        public CilOperandBuilder(IMetadataTokenProvider provider, IErrorListener errorListener, object? diagnosticSource)
         {
             _provider = provider ?? throw new ArgumentNullException(nameof(provider));
             _errorListener = errorListener ?? throw new ArgumentNullException(nameof(errorListener));
+            _diagnosticSource = diagnosticSource;
+        }
+
+        private string? DiagnosticPrefix
+        {
+            get
+            {
+                if (_diagnosticPrefix is null && _diagnosticSource is not null)
+                    _diagnosticPrefix = $"[In {_diagnosticSource.SafeToString()}]: ";
+                return _diagnosticPrefix;
+            }
         }
 
         /// <inheritdoc />
-        public int GetVariableIndex(object? operand)
+        public int GetVariableIndex(object? operand) => operand switch
         {
-            return operand switch
-            {
-                CilLocalVariable localVariable => localVariable.Index,
-                byte raw => raw,
-                ushort raw => raw,
-                _ => _errorListener.NotSupportedAndReturn<int>($"Invalid or unsupported variable operand ({operand.SafeToString()}).")
-            };
-        }
+            CilLocalVariable localVariable => localVariable.Index,
+            byte raw => raw,
+            ushort raw => raw,
+            _ => _errorListener.NotSupportedAndReturn<int>($"{DiagnosticPrefix}Invalid or unsupported variable operand ({operand.SafeToString()}).")
+        };
 
         /// <inheritdoc />
-        public int GetArgumentIndex(object? operand)
+        public int GetArgumentIndex(object? operand) => operand switch
         {
-            return operand switch
-            {
-                Parameter parameter => parameter.MethodSignatureIndex,
-                byte raw => raw,
-                ushort raw => raw,
-                _ => _errorListener.NotSupportedAndReturn<int>($"Invalid or unsupported argument operand ({operand.SafeToString()}).")
-            };
-        }
+            Parameter parameter => parameter.MethodSignatureIndex,
+            byte raw => raw,
+            ushort raw => raw,
+            _ => _errorListener.NotSupportedAndReturn<int>($"{DiagnosticPrefix}Invalid or unsupported argument operand ({operand.SafeToString()}).")
+        };
 
         /// <inheritdoc />
-        public uint GetStringToken(object? operand)
+        public uint GetStringToken(object? operand) => operand switch
         {
-            return operand switch
-            {
-                string value => 0x70000000 | _provider.GetUserStringIndex(value),
-                MetadataToken token => token.ToUInt32(),
-                uint raw => raw,
-                _ => _errorListener.NotSupportedAndReturn<uint>($"Invalid or unsupported string operand ({operand.SafeToString()}).")
-            };
-        }
+            string value => 0x70000000 | _provider.GetUserStringIndex(value),
+            MetadataToken token => token.ToUInt32(),
+            uint raw => raw,
+            _ => _errorListener.NotSupportedAndReturn<uint>($"{DiagnosticPrefix}Invalid or unsupported string operand ({operand.SafeToString()}).")
+        };
 
         /// <inheritdoc />
-        public MetadataToken GetMemberToken(object? operand)
+        public MetadataToken GetMemberToken(object? operand) => operand switch
         {
-            return operand switch
-            {
-                IMetadataMember member => GetMemberToken(member),
-                MetadataToken token => token,
-                uint raw => raw,
-                _ => _errorListener.NotSupportedAndReturn<uint>($"Invalid or unsupported member operand ({operand.SafeToString()}).")
-            };
-        }
+            IMetadataMember member => GetMemberToken(member),
+            MetadataToken token => token,
+            uint raw => raw,
+            _ => _errorListener.NotSupportedAndReturn<uint>($"{DiagnosticPrefix}Invalid or unsupported member operand ({operand.SafeToString()}).")
+        };
 
-        private MetadataToken GetMemberToken(IMetadataMember member)
+        private MetadataToken GetMemberToken(IMetadataMember member) => member.MetadataToken.Table switch
         {
-            return member.MetadataToken.Table switch
-            {
-                TableIndex.TypeRef => _provider.GetTypeReferenceToken((TypeReference) member),
-                TableIndex.TypeDef => _provider.GetTypeDefinitionToken((TypeDefinition) member),
-                TableIndex.TypeSpec => _provider.GetTypeSpecificationToken((TypeSpecification) member),
-                TableIndex.Field => _provider.GetFieldDefinitionToken((FieldDefinition) member),
-                TableIndex.Method => _provider.GetMethodDefinitionToken((MethodDefinition) member),
-                TableIndex.MethodSpec => _provider.GetMethodSpecificationToken((MethodSpecification) member),
-                TableIndex.MemberRef => _provider.GetMemberReferenceToken((MemberReference) member),
-                TableIndex.StandAloneSig => _provider.GetStandAloneSignatureToken((StandAloneSignature) member),
-                _ => throw new ArgumentOutOfRangeException(nameof(member))
-            };
-        }
+            TableIndex.TypeRef => _provider.GetTypeReferenceToken((TypeReference) member, _diagnosticSource),
+            TableIndex.TypeDef => _provider.GetTypeDefinitionToken((TypeDefinition) member, _diagnosticSource),
+            TableIndex.TypeSpec => _provider.GetTypeSpecificationToken((TypeSpecification) member, _diagnosticSource),
+            TableIndex.Field => _provider.GetFieldDefinitionToken((FieldDefinition) member, _diagnosticSource),
+            TableIndex.Method => _provider.GetMethodDefinitionToken((MethodDefinition) member, _diagnosticSource),
+            TableIndex.MethodSpec => _provider.GetMethodSpecificationToken((MethodSpecification) member, _diagnosticSource),
+            TableIndex.MemberRef => _provider.GetMemberReferenceToken((MemberReference) member, _diagnosticSource),
+            TableIndex.StandAloneSig => _provider.GetStandAloneSignatureToken((StandAloneSignature) member, _diagnosticSource),
+            _ => throw new ArgumentOutOfRangeException(nameof(member))
+        };
     }
 }

--- a/src/AsmResolver.DotNet/Code/Cil/IMetadataTokenProvider.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/IMetadataTokenProvider.cs
@@ -1,80 +1,88 @@
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
-namespace AsmResolver.DotNet.Code.Cil
+namespace AsmResolver.DotNet.Code.Cil;
+
+/// <summary>
+/// Provides members for retrieving newly assigned metadata tokens to metadata members.
+/// </summary>
+public interface IMetadataTokenProvider
 {
     /// <summary>
-    /// Provides members for retrieving newly assigned metadata tokens to metadata members.
+    /// Gets the newly assigned metadata token of a type reference stored in a tables stream or tables stream buffer.
     /// </summary>
-    public interface IMetadataTokenProvider
-    {
-        /// <summary>
-        /// Gets the newly assigned metadata token of a type reference stored in a tables stream or tables stream buffer. 
-        /// </summary>
-        /// <param name="type">The reference to the type to add.</param>
-        /// <returns>The metadata token of the added type reference.</returns>
-        MetadataToken GetTypeReferenceToken(TypeReference type);
+    /// <param name="type">The reference to the type to add.</param>
+    /// <param name="diagnosticSource">When available, the object that is reported in diagnostics when obtaining the token fails.</param>
+    /// <returns>The metadata token of the added type reference.</returns>
+    MetadataToken GetTypeReferenceToken(TypeReference type, object? diagnosticSource = null);
 
-        /// <summary>
-        /// Gets the newly assigned metadata token of a type definition stored in a tables stream or tables stream buffer. 
-        /// </summary>
-        /// <param name="type">The reference to the type to add.</param>
-        /// <returns>The metadata token of the added type definition.</returns>
-        MetadataToken GetTypeDefinitionToken(TypeDefinition type);
+    /// <summary>
+    /// Gets the newly assigned metadata token of a type definition stored in a tables stream or tables stream buffer.
+    /// </summary>
+    /// <param name="type">The reference to the type to add.</param>
+    /// <param name="diagnosticSource">When available, the object that is reported in diagnostics when obtaining the token fails.</param>
+    /// <returns>The metadata token of the added type definition.</returns>
+    MetadataToken GetTypeDefinitionToken(TypeDefinition type, object? diagnosticSource = null);
 
-        /// <summary>
-        /// Gets the newly assigned metadata token of a type definition stored in a tables stream or tables stream buffer. 
-        /// </summary>
-        /// <param name="field">The reference to the field to add.</param>
-        /// <returns>The metadata token of the added field definition.</returns>
-        MetadataToken GetFieldDefinitionToken(FieldDefinition field);
+    /// <summary>
+    /// Gets the newly assigned metadata token of a type definition stored in a tables stream or tables stream buffer.
+    /// </summary>
+    /// <param name="field">The reference to the field to add.</param>
+    /// <param name="diagnosticSource">When available, the object that is reported in diagnostics when obtaining the token fails.</param>
+    /// <returns>The metadata token of the added field definition.</returns>
+    MetadataToken GetFieldDefinitionToken(FieldDefinition field, object? diagnosticSource = null);
 
-        /// <summary>
-        /// Gets the newly assigned metadata token of a method definition stored in a tables stream or tables stream buffer. 
-        /// </summary>
-        /// <param name="method">The reference to the method to add.</param>
-        /// <returns>The metadata token of the added method definition.</returns>
-        MetadataToken GetMethodDefinitionToken(MethodDefinition method);
+    /// <summary>
+    /// Gets the newly assigned metadata token of a method definition stored in a tables stream or tables stream buffer.
+    /// </summary>
+    /// <param name="method">The reference to the method to add.</param>
+    /// <param name="diagnosticSource">When available, the object that is reported in diagnostics when obtaining the token fails.</param>
+    /// <returns>The metadata token of the added method definition.</returns>
+    MetadataToken GetMethodDefinitionToken(MethodDefinition method, object? diagnosticSource = null);
 
-        /// <summary>
-        /// Gets the newly assigned metadata token of a member reference stored in a tables stream or tables stream buffer. 
-        /// </summary>
-        /// <param name="member">The reference to the member to add.</param>
-        /// <returns>The metadata token of the added member reference.</returns>
-        MetadataToken GetMemberReferenceToken(MemberReference member);
+    /// <summary>
+    /// Gets the newly assigned metadata token of a member reference stored in a tables stream or tables stream buffer.
+    /// </summary>
+    /// <param name="member">The reference to the member to add.</param>
+    /// <param name="diagnosticSource">When available, the object that is reported in diagnostics when obtaining the token fails.</param>
+    /// <returns>The metadata token of the added member reference.</returns>
+    MetadataToken GetMemberReferenceToken(MemberReference member, object? diagnosticSource = null);
 
-        /// <summary>
-        /// Gets the newly assigned metadata token of a stand-alone signature stored in a tables stream or tables stream buffer. 
-        /// </summary>
-        /// <param name="signature">The reference to the signature to add.</param>
-        /// <returns>The metadata token of the added signature.</returns>
-        MetadataToken GetStandAloneSignatureToken(StandAloneSignature signature);
+    /// <summary>
+    /// Gets the newly assigned metadata token of a stand-alone signature stored in a tables stream or tables stream buffer.
+    /// </summary>
+    /// <param name="signature">The reference to the signature to add.</param>
+    /// <param name="diagnosticSource">When available, the object that is reported in diagnostics when obtaining the token fails.</param>
+    /// <returns>The metadata token of the added signature.</returns>
+    MetadataToken GetStandAloneSignatureToken(StandAloneSignature signature, object? diagnosticSource = null);
 
-        /// <summary>
-        /// Gets the newly assigned metadata token of a assembly reference stored in a tables stream or tables stream buffer. 
-        /// </summary>
-        /// <param name="assembly">The reference to the assembly to add.</param>
-        /// <returns>The metadata token of the added assembly reference.</returns>
-        MetadataToken GetAssemblyReferenceToken(AssemblyReference assembly);
+    /// <summary>
+    /// Gets the newly assigned metadata token of a assembly reference stored in a tables stream or tables stream buffer.
+    /// </summary>
+    /// <param name="assembly">The reference to the assembly to add.</param>
+    /// <param name="diagnosticSource">When available, the object that is reported in diagnostics when obtaining the token fails.</param>
+    /// <returns>The metadata token of the added assembly reference.</returns>
+    MetadataToken GetAssemblyReferenceToken(AssemblyReference assembly, object? diagnosticSource = null);
 
-        /// <summary>
-        /// Gets the newly assigned metadata token of a type specification. stored in a tables stream or tables stream buffer. 
-        /// </summary>
-        /// <param name="type">The reference to the type to add.</param>
-        /// <returns>The metadata token of the added type specification.</returns>
-        MetadataToken GetTypeSpecificationToken(TypeSpecification type);
+    /// <summary>
+    /// Gets the newly assigned metadata token of a type specification. stored in a tables stream or tables stream buffer.
+    /// </summary>
+    /// <param name="type">The reference to the type to add.</param>
+    /// <param name="diagnosticSource">When available, the object that is reported in diagnostics when obtaining the token fails.</param>
+    /// <returns>The metadata token of the added type specification.</returns>
+    MetadataToken GetTypeSpecificationToken(TypeSpecification type, object? diagnosticSource = null);
 
-        /// <summary>
-        /// Gets the newly assigned metadata token of a method specification stored in a tables stream or tables stream buffer. 
-        /// </summary>
-        /// <param name="method">The reference to the method to add.</param>
-        /// <returns>The metadata token of the added method specification.</returns>
-        MetadataToken GetMethodSpecificationToken(MethodSpecification method);
+    /// <summary>
+    /// Gets the newly assigned metadata token of a method specification stored in a tables stream or tables stream buffer.
+    /// </summary>
+    /// <param name="method">The reference to the method to add.</param>
+    /// <param name="diagnosticSource">When available, the object that is reported in diagnostics when obtaining the token fails.</param>
+    /// <returns>The metadata token of the added method specification.</returns>
+    MetadataToken GetMethodSpecificationToken(MethodSpecification method, object? diagnosticSource = null);
 
-        /// <summary>
-        /// Gets the index to a user-string referenced in a CIL method body.
-        /// </summary>
-        /// <param name="value">The string value.</param>
-        /// <returns>The index.</returns>
-        uint GetUserStringIndex(string value);
-    }
+    /// <summary>
+    /// Gets the index to a user-string referenced in a CIL method body.
+    /// </summary>
+    /// <param name="value">The string value.</param>
+    /// <returns>The index.</returns>
+    uint GetUserStringIndex(string value);
 }

--- a/src/AsmResolver.DotNet/Code/Cil/OriginalMetadataTokenProvider.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/OriginalMetadataTokenProvider.cs
@@ -2,73 +2,81 @@ using AsmResolver.DotNet.Builder.Metadata;
 using AsmResolver.PE.DotNet.Metadata;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
-namespace AsmResolver.DotNet.Code.Cil
+namespace AsmResolver.DotNet.Code.Cil;
+
+/// <summary>
+/// Provides an implementation for the <see cref="IMetadataTokenProvider"/> interface that always returns the
+/// original metadata token that was assigned to the provided metadata member or string.
+/// </summary>
+public class OriginalMetadataTokenProvider : IMetadataTokenProvider
 {
+    private readonly ModuleDefinition? _module;
+
     /// <summary>
-    /// Provides an implementation for the <see cref="IMetadataTokenProvider"/> interface that always returns the
-    /// original metadata token that was assigned to the provided metadata member or string.
+    /// Creates a new token provider.
     /// </summary>
-    public class OriginalMetadataTokenProvider : IMetadataTokenProvider
+    /// <param name="module">
+    /// The module to pull the original tokens from, or <c>null</c> if no verification should be done on the
+    /// declaring module.
+    /// </param>
+    public OriginalMetadataTokenProvider(ModuleDefinition? module)
     {
-        private readonly ModuleDefinition? _module;
+        _module = module;
+    }
 
-        /// <summary>
-        /// Creates a new token provider.
-        /// </summary>
-        /// <param name="module">
-        /// The module to pull the original tokens from, or <c>null</c> if no verification should be done on the
-        /// declaring module.
-        /// </param>
-        public OriginalMetadataTokenProvider(ModuleDefinition? module)
+    private MetadataToken GetToken(IMetadataMember member, object? diagnosticSource)
+    {
+        if (_module is not null && member is IModuleProvider provider && provider.Module != _module)
+            throw new MemberNotImportedException(member, diagnosticSource);
+
+        return member.MetadataToken;
+    }
+
+    /// <inheritdoc />
+    public MetadataToken GetTypeReferenceToken(TypeReference type, object? diagnosticSource = null)
+        => GetToken(type, diagnosticSource);
+
+    /// <inheritdoc />
+    public MetadataToken GetTypeDefinitionToken(TypeDefinition type, object? diagnosticSource = null)
+        => GetToken(type, diagnosticSource);
+
+    /// <inheritdoc />
+    public MetadataToken GetFieldDefinitionToken(FieldDefinition field, object? diagnosticSource = null)
+        => GetToken(field, diagnosticSource);
+
+    /// <inheritdoc />
+    public MetadataToken GetMethodDefinitionToken(MethodDefinition method, object? diagnosticSource = null)
+        => GetToken(method, diagnosticSource);
+
+    /// <inheritdoc />
+    public MetadataToken GetMemberReferenceToken(MemberReference member, object? diagnosticSource = null)
+        => GetToken(member, diagnosticSource);
+
+    /// <inheritdoc />
+    public MetadataToken GetStandAloneSignatureToken(StandAloneSignature signature, object? diagnosticSource = null)
+        => GetToken(signature, diagnosticSource);
+
+    /// <inheritdoc />
+    public MetadataToken GetAssemblyReferenceToken(AssemblyReference assembly, object? diagnosticSource = null)
+        => GetToken(assembly, diagnosticSource);
+
+    /// <inheritdoc />
+    public MetadataToken GetTypeSpecificationToken(TypeSpecification type, object? diagnosticSource = null)
+        => GetToken(type, diagnosticSource);
+
+    /// <inheritdoc />
+    public MetadataToken GetMethodSpecificationToken(MethodSpecification method, object? diagnosticSource = null)
+        => GetToken(method, diagnosticSource);
+
+    /// <inheritdoc />
+    public uint GetUserStringIndex(string value)
+    {
+        if (_module?.DotNetDirectory?.Metadata?.TryGetStream(out UserStringsStream? stream) ?? false)
         {
-            _module = module;
+            if (stream.TryFindStringIndex(value, out uint offset))
+                return offset;
         }
 
-        private MetadataToken GetToken(IMetadataMember member)
-        {
-            if (_module is not null && member is IModuleProvider provider && provider.Module != _module)
-                throw new MemberNotImportedException(member);
-
-            return member.MetadataToken;
-        }
-
-        /// <inheritdoc />
-        public MetadataToken GetTypeReferenceToken(TypeReference type) => GetToken(type);
-
-        /// <inheritdoc />
-        public MetadataToken GetTypeDefinitionToken(TypeDefinition type) => GetToken(type);
-
-        /// <inheritdoc />
-        public MetadataToken GetFieldDefinitionToken(FieldDefinition field) => GetToken(field);
-
-        /// <inheritdoc />
-        public MetadataToken GetMethodDefinitionToken(MethodDefinition method) => GetToken(method);
-
-        /// <inheritdoc />
-        public MetadataToken GetMemberReferenceToken(MemberReference member) => GetToken(member);
-
-        /// <inheritdoc />
-        public MetadataToken GetStandAloneSignatureToken(StandAloneSignature signature) => GetToken(signature);
-
-        /// <inheritdoc />
-        public MetadataToken GetAssemblyReferenceToken(AssemblyReference assembly) => GetToken(assembly);
-
-        /// <inheritdoc />
-        public MetadataToken GetTypeSpecificationToken(TypeSpecification type) => GetToken(type);
-
-        /// <inheritdoc />
-        public MetadataToken GetMethodSpecificationToken(MethodSpecification method) => GetToken(method);
-
-        /// <inheritdoc />
-        public uint GetUserStringIndex(string value)
-        {
-            if (_module?.DotNetDirectory?.Metadata?.TryGetStream(out UserStringsStream? stream) ?? false)
-            {
-                if (stream.TryFindStringIndex(value, out uint offset))
-                    return offset;
-            }
-
-            return 0;
-        }
+        return 0;
     }
 }

--- a/src/AsmResolver.DotNet/Signatures/BlobSerializationContext.cs
+++ b/src/AsmResolver.DotNet/Signatures/BlobSerializationContext.cs
@@ -14,11 +14,17 @@ namespace AsmResolver.DotNet.Signatures
         /// <param name="writer">The output stream to write the raw data to.</param>
         /// <param name="indexProvider">The object responsible for obtaining coded indices to types.</param>
         /// <param name="errorListener">The object responsible for collecting diagnostic information during the serialization process.</param>
-        public BlobSerializationContext(BinaryStreamWriter writer, ITypeCodedIndexProvider indexProvider, IErrorListener errorListener)
+        /// <param name="diagnosticSource">When available, the object that is reported in diagnostics when serialization of the blob fails.</param>
+        public BlobSerializationContext(
+            BinaryStreamWriter writer,
+            ITypeCodedIndexProvider indexProvider,
+            IErrorListener errorListener,
+            object? diagnosticSource)
         {
             Writer = writer ?? throw new ArgumentNullException(nameof(writer));
             IndexProvider = indexProvider ?? throw new ArgumentNullException(nameof(indexProvider));
             ErrorListener = errorListener ?? throw new ArgumentNullException(nameof(errorListener));
+            DiagnosticSource = diagnosticSource;
         }
 
         /// <summary>
@@ -41,6 +47,14 @@ namespace AsmResolver.DotNet.Signatures
         /// Gets the bag used to collect diagnostic information during the serialization process.
         /// </summary>
         public IErrorListener ErrorListener
+        {
+            get;
+        }
+
+        /// <summary>
+        /// When available, gets the object that is reported in diagnostics when serialization of the blob fails.
+        /// </summary>
+        public object? DiagnosticSource
         {
             get;
         }

--- a/src/AsmResolver.DotNet/Signatures/ITypeCodedIndexProvider.cs
+++ b/src/AsmResolver.DotNet/Signatures/ITypeCodedIndexProvider.cs
@@ -9,7 +9,8 @@
         /// Obtains a coded index to the provided type reference.
         /// </summary>
         /// <param name="type">The type.</param>
+        /// /// <param name="diagnosticSource">When available, the object that is reported in diagnostics when index encoding of the type fails.</param>
         /// <returns>The coded index.</returns>
-        uint GetTypeDefOrRefIndex(ITypeDefOrRef type);
+        uint GetTypeDefOrRefIndex(ITypeDefOrRef type, object? diagnosticSource = null);
     }
 }

--- a/src/AsmResolver.DotNet/Signatures/SecurityAttribute.cs
+++ b/src/AsmResolver.DotNet/Signatures/SecurityAttribute.cs
@@ -91,7 +91,9 @@ namespace AsmResolver.DotNet.Signatures
                 var subContext = new BlobSerializationContext(
                     new BinaryStreamWriter(subBlob),
                     context.IndexProvider,
-                    context.ErrorListener);
+                    context.ErrorListener,
+                    context.DiagnosticSource
+                );
 
                 subContext.Writer.WriteCompressedUInt32((uint) NamedArguments.Count);
                 foreach (var argument in NamedArguments)

--- a/src/AsmResolver.DotNet/Signatures/TypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/TypeSignature.cs
@@ -200,7 +200,7 @@ namespace AsmResolver.DotNet.Signatures
             }
             else
             {
-                index = context.IndexProvider.GetTypeDefOrRefIndex(type);
+                index = context.IndexProvider.GetTypeDefOrRefIndex(type, context.DiagnosticSource);
             }
 
             context.Writer.WriteCompressedUInt32(index);


### PR DESCRIPTION
## Problem 
A common pitfall in building metadata is to reference metadata that is not imported yet. In such a case, `MemberNotImportedException` would be thrown during rebuild, with a message similar to the one below:
```
Member SomeNamespace.SomeType was not imported into the module.
```

However, while this explains the member that was left unimported, it does not describe which object referenced the unimported reference, making it hard to pinpoint where the error originated from.

## Solution

This PR fills this gap by adding extra diagnostic tracking, containing the object that was responsible for the inclusion of this unimported reference. New error messages are now prefixed by this diagnostic source:
```
[In SomeNamespace.SomeType <Module>::SomeField]: Member SomeNamespace.SomeType was not imported into the module.
```

## Changes

- Add `MemberNotImportedException::DiagnosticSource`, and human-readable message is adjusted to include it if not `null`.
- Add `object? diagnosticSource = null` optional parameters in various places:
   - `CilOperandBuilder` constructor.
   - `IMetadataTokenProvider::GetXXX` methods and their derivatives.
   - `DotNetDirectoryBuffer`'s `AddXXX` methods.
   - `BlobStreamBuffer::GetBlobIndex` method.
   - `BlobSerializationContext` constructor.

These are breaking changes, but given that the introduced parameters are optional, impact should be minimal.