### PR TITLE
Constant Improvements

### DIFF
--- a/src/AsmResolver.DotNet/Constant.cs
+++ b/src/AsmResolver.DotNet/Constant.cs
@@ -82,6 +82,15 @@ namespace AsmResolver.DotNet
         protected virtual DataBlobSignature? GetValue() => null;
 
         /// <summary>
+        /// Interprets the raw data stored in the <see cref="Value"/> property as a literal.
+        /// </summary>
+        /// <returns>The deserialized literal.</returns>
+        public object? InterpretData()
+        {
+            return Value?.InterpretData(Type);
+        }
+
+        /// <summary>
         /// Create a <see cref="Constant"/> from a value
         /// </summary>
         /// <param name="value">The value to be assigned to the constant</param>
@@ -184,6 +193,30 @@ namespace AsmResolver.DotNet
         /// <returns>
         /// A new <see cref="Constant"/> with the correct <see cref="Type"/> and <see cref="Value"/>
         /// </returns>
+        public static Constant FromValue(nuint value)
+        {
+            return FromValue((uint)value);
+        }
+
+        /// <summary>
+        /// Create a <see cref="Constant"/> from a value
+        /// </summary>
+        /// <param name="value">The value to be assigned to the constant</param>
+        /// <returns>
+        /// A new <see cref="Constant"/> with the correct <see cref="Type"/> and <see cref="Value"/>
+        /// </returns>
+        public static Constant FromValue(nint value)
+        {
+            return FromValue((int)value);
+        }
+
+        /// <summary>
+        /// Create a <see cref="Constant"/> from a value
+        /// </summary>
+        /// <param name="value">The value to be assigned to the constant</param>
+        /// <returns>
+        /// A new <see cref="Constant"/> with the correct <see cref="Type"/> and <see cref="Value"/>
+        /// </returns>
         public static Constant FromValue(ulong value)
         {
             return new Constant(ElementType.U8, DataBlobSignature.FromValue(value));
@@ -232,9 +265,61 @@ namespace AsmResolver.DotNet
         /// <returns>
         /// A new <see cref="Constant"/> with the correct <see cref="Type"/> and <see cref="Value"/>
         /// </returns>
-        public static Constant FromValue(string value)
+        public static Constant FromValue(string? value)
         {
-            return new Constant(ElementType.String, DataBlobSignature.FromValue(value));
+            return new Constant(value is null ? ElementType.Class : ElementType.String, DataBlobSignature.FromValue(value));
+        }
+
+        /// <summary>
+        /// Create a <see cref="Constant"/> representing a null reference
+        /// </summary>
+        /// <remarks>
+        /// This can be used for any non-primitive default value.
+        /// </remarks>
+        /// <returns>
+        /// A new <see cref="Constant"/> with the correct <see cref="Type"/> and <see cref="Value"/>
+        /// </returns>
+        public static Constant FromNull()
+        {
+            return new Constant(ElementType.Class, DataBlobSignature.FromNull());
+        }
+
+        /// <summary>
+        /// Create a <see cref="Constant"/> representing a default value
+        /// </summary>
+        /// <param name="elementType">The type of the new constant.</param>
+        /// <returns>
+        /// A new <see cref="Constant"/> with the correct <see cref="Type"/> and <see cref="Value"/>
+        /// </returns>
+        public static Constant FromDefault(ElementType elementType) => elementType switch
+        {
+            ElementType.Boolean => FromValue(false),
+            ElementType.Char => FromValue('\0'),
+            ElementType.I1 => FromValue((sbyte)0),
+            ElementType.U1 => FromValue((byte)0),
+            ElementType.I2 => FromValue((short)0),
+            ElementType.U2 => FromValue((ushort)0),
+            ElementType.I4 => FromValue(0),
+            ElementType.U4 => FromValue(0u),
+            ElementType.I => FromValue((nint)0),
+            ElementType.U => FromValue((nuint)0),
+            ElementType.I8 => FromValue(0L),
+            ElementType.U8 => FromValue(0UL),
+            ElementType.R4 => FromValue(0f),
+            ElementType.R8 => FromValue(0d),
+            _ => FromNull(),
+        };
+
+        /// <summary>
+        /// Create a <see cref="Constant"/> representing a default value
+        /// </summary>
+        /// <param name="type">The type of the new constant.</param>
+        /// <returns>
+        /// A new <see cref="Constant"/> with the correct <see cref="Type"/> and <see cref="Value"/>
+        /// </returns>
+        public static Constant FromDefault(TypeSignature type)
+        {
+            return FromDefault(type.ElementType);
         }
     }
 }

--- a/test/AsmResolver.DotNet.Tests/ConstantTest.FromValue.cs
+++ b/test/AsmResolver.DotNet.Tests/ConstantTest.FromValue.cs
@@ -9,91 +9,98 @@ namespace AsmResolver.DotNet.Tests
         public void ReadingAndWritingGiveTheSameValueBoolean()
         {
             var constant = Constant.FromValue(Constants.Boolean);
-            Assert.Equal(Constants.Boolean, constant.Value.InterpretData(constant.Type));
+            Assert.Equal(Constants.Boolean, constant.InterpretData());
         }
 
         [Fact]
         public void ReadingAndWritingGiveTheSameValueChar()
         {
             var constant = Constant.FromValue(Constants.Char);
-            Assert.Equal(Constants.Char, constant.Value.InterpretData(constant.Type));
+            Assert.Equal(Constants.Char, constant.InterpretData());
         }
 
         [Fact]
         public void ReadingAndWritingGiveTheSameValueByte()
         {
             var constant = Constant.FromValue(Constants.Byte);
-            Assert.Equal(Constants.Byte, constant.Value.InterpretData(constant.Type));
+            Assert.Equal(Constants.Byte, constant.InterpretData());
         }
 
         [Fact]
         public void ReadingAndWritingGiveTheSameValueSByte()
         {
             var constant = Constant.FromValue(Constants.SByte);
-            Assert.Equal(Constants.SByte, constant.Value.InterpretData(constant.Type));
+            Assert.Equal(Constants.SByte, constant.InterpretData());
         }
 
         [Fact]
         public void ReadingAndWritingGiveTheSameValueUInt16()
         {
             var constant = Constant.FromValue(Constants.UInt16);
-            Assert.Equal(Constants.UInt16, constant.Value.InterpretData(constant.Type));
+            Assert.Equal(Constants.UInt16, constant.InterpretData());
         }
 
         [Fact]
         public void ReadingAndWritingGiveTheSameValueInt16()
         {
             var constant = Constant.FromValue(Constants.Int16);
-            Assert.Equal(Constants.Int16, constant.Value.InterpretData(constant.Type));
+            Assert.Equal(Constants.Int16, constant.InterpretData());
         }
 
         [Fact]
         public void ReadingAndWritingGiveTheSameValueUInt32()
         {
             var constant = Constant.FromValue(Constants.UInt32);
-            Assert.Equal(Constants.UInt32, constant.Value.InterpretData(constant.Type));
+            Assert.Equal(Constants.UInt32, constant.InterpretData());
         }
 
         [Fact]
         public void ReadingAndWritingGiveTheSameValueInt32()
         {
             var constant = Constant.FromValue(Constants.Int32);
-            Assert.Equal(Constants.Int32, constant.Value.InterpretData(constant.Type));
+            Assert.Equal(Constants.Int32, constant.InterpretData());
         }
 
         [Fact]
         public void ReadingAndWritingGiveTheSameValueUInt64()
         {
             var constant = Constant.FromValue(Constants.UInt64);
-            Assert.Equal(Constants.UInt64, constant.Value.InterpretData(constant.Type));
+            Assert.Equal(Constants.UInt64, constant.InterpretData());
         }
 
         [Fact]
         public void ReadingAndWritingGiveTheSameValueInt64()
         {
             var constant = Constant.FromValue(Constants.Int64);
-            Assert.Equal(Constants.Int64, constant.Value.InterpretData(constant.Type));
+            Assert.Equal(Constants.Int64, constant.InterpretData());
         }
 
         [Fact]
         public void ReadingAndWritingGiveTheSameValueSingle()
         {
             var constant = Constant.FromValue(Constants.Single);
-            Assert.Equal(Constants.Single, constant.Value.InterpretData(constant.Type));
+            Assert.Equal(Constants.Single, constant.InterpretData());
         }
 
         [Fact]
         public void ReadingAndWritingGiveTheSameValueDouble()
         {
             var constant = Constant.FromValue(Constants.Double);
-            Assert.Equal(Constants.Double, constant.Value.InterpretData(constant.Type));
+            Assert.Equal(Constants.Double, constant.InterpretData());
         }
 
         [Fact]
         public void ReadingAndWritingGiveTheSameValueString()
         {
             var constant = Constant.FromValue(Constants.String);
-            Assert.Equal(Constants.String, constant.Value.InterpretData(constant.Type));
+            Assert.Equal(Constants.String, constant.InterpretData());
+        }
+
+        [Fact]
+        public void ReadingAndWritingGiveTheSameValueNullString()
+        {
+            var constant = Constant.FromValue(Constants.NullString);
+            Assert.Equal(Constants.NullString, constant.InterpretData());
         }
     }
 }

--- a/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Fields/Constants.cs
+++ b/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Fields/Constants.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace AsmResolver.DotNet.TestCases.Fields
 {
     public class Constants
@@ -17,5 +15,6 @@ namespace AsmResolver.DotNet.TestCases.Fields
         public const double Double = 2.0d;
         public const char Char = 'a';
         public const string String = "Hello, world!";
+        public const string NullString = null;
     }
 }


### PR DESCRIPTION
* Support null constants
* Add `DataBlobSignature::FromNull`
* Add `Constant::InterpretData`
* Add `Constant::FromNull`
* Add `Constant::FromDefault`
* Add `Constant::FromValue` overloads for `nint` and `nuint`