### PR TITLE
Use case insensitive compare when looking for JTD stream in ENC metadata

### DIFF
--- a/src/AsmResolver.PE/DotNet/Metadata/SerializedMetadataDirectory.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/SerializedMetadataDirectory.cs
@@ -91,8 +91,19 @@ namespace AsmResolver.PE.DotNet.Metadata
                 }
                 if (name == TablesStream.UncompressedStreamName)
                     isEncMetadata = true;
-                else if (name == TablesStream.MinimalStreamName)
+            }
+
+            // The CLR performs a case-insensitive comparison for the names of the streams when ENC metadata is present.
+            var comparisonKind = isEncMetadata.GetValueOrDefault()
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+            for (int i = 0; i < numberOfStreams; i++)
+            {
+                if (string.Equals(_streamHeaders[i].Name, TablesStream.MinimalStreamName, comparisonKind))
+                {
                     _hasJtdStream = true;
+                    break;
+                }
             }
 
             IsEncMetadata = _isEncMetadata = isEncMetadata ?? false;


### PR DESCRIPTION
Addresses an oversight I made in https://github.com/Washi1337/AsmResolver/pull/557.
It appears that CLR also uses case-insensitive comparison for the `#JTD` stream in ENC metadata.