### PR TITLE
Make System.Enum a reference type. Fixes #635

### DIFF
--- a/src/AsmResolver.DotNet/TypeDefinition.cs
+++ b/src/AsmResolver.DotNet/TypeDefinition.cs
@@ -473,7 +473,7 @@ namespace AsmResolver.DotNet
 
         /// <inheritdoc />
         [MemberNotNullWhen(true, nameof(BaseType))]
-        public bool IsValueType => BaseType is {} && (BaseType.IsTypeOf("System", nameof(ValueType)) || IsEnum);
+        public bool IsValueType => !this.IsTypeOf("System", nameof(Enum)) && BaseType is { } && (BaseType.IsTypeOf("System", nameof(ValueType)) || IsEnum);
 
         /// <summary>
         /// Gets a value indicating whether the type defines an enumeration of discrete values.

--- a/test/AsmResolver.DotNet.Tests/TypeDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/TypeDefinitionTest.cs
@@ -725,6 +725,15 @@ namespace AsmResolver.DotNet.Tests
         }
 
         [Fact]
+        public void SystemEnumShouldNotBeValueType()
+        {
+            var module = ModuleDefinition.FromFile(typeof(Enum).Assembly.Location, TestReaderParameters);
+            var type = module.LookupMember<TypeDefinition>(typeof(Enum).MetadataToken);
+
+            Assert.False(type.IsValueType);
+        }
+
+        [Fact]
         public void AddTypeToModuleShouldSetOwner()
         {
             var module = new ModuleDefinition("Dummy");


### PR DESCRIPTION
`IsValueType` for `System.Enum` currently returns `true`. This PR changes it so it will return `false`. This fixes #635.