### PR TITLE
Parameterless MethodBody Constructors

### DIFF
--- a/docs/guides/dotnet/dynamic-methods.md
+++ b/docs/guides/dotnet/dynamic-methods.md
@@ -22,7 +22,7 @@ using AsmResolver.DotNet.Dynamic;
 ## Reading dynamic methods
 
 The following example demonstrates how to transform an instance of
-`DynamicMethod` into a `DynamicMethodDefinition`:
+`System.Reflection.Emit.DynamicMethod` into a `DynamicMethodDefinition`:
 
 ``` csharp
 DynamicMethod dynamicMethod = ...

--- a/docs/guides/dotnet/managed-method-bodies.md
+++ b/docs/guides/dotnet/managed-method-bodies.md
@@ -15,20 +15,21 @@ using AsmResolver.DotNet.Code.Cil;  // High level and easy to use models related
 
 ## The CilMethodBody class
 
-The `MethodDefinition` class defines a property called `CilMethodBody`,
-which exposes the managed implementation of the method, written in the
-Common Intermediate Language, or CIL for short.
-
-Each `CilMethodBody` is assigned to exactly one `MethodDefinition`. Upon
-instantiation of such a method body, it is therefore required to specify
-the owner of the body:
+Each `MethodDefinition` class defines a property `CilMethodBody`,
+which exposes the managed implementation of the method, written in the Common Intermediate Language (CIL).
 
 ``` csharp
 MethodDefinition method = ...
 
-CilMethodBody body = new CilMethodBody(method);
+var body = new CilMethodBody();
 method.CilMethodBody = body;
 ```
+
+> [!NOTE]
+> Each method body can be assigned to exactly one method, and every method can only have one method body.
+> Assigning a method body to another method will result in an exception to be thrown.
+> To swap method bodies, you will first have to remove it from the existing method (e.g., by setting `MethodDefinition::CilMethodBody` property to `null`).
+
 
 The `CilMethodBody` class consists of the following basic building
 blocks:
@@ -210,8 +211,8 @@ Below an example on how to use the `ReferenceImporter` to emit a call to
 var importer = new ReferenceImporter(targetModule);
 var writeLine = importer.ImportMethod(typeof(Console).GetMethod("WriteLine", new[] { typeof(string) } );
 
-body.Instructions.Add(new CilInstruction(CilOpCodes.Ldstr, "Hello, world!"));
-body.Instructions.Add(new CilInstruction(CilOpCodes.Call, writeLine));
+body.Instructions.Add(CilOpCodes.Ldstr, "Hello, world!");
+body.Instructions.Add(CilOpCodes.Call, writeLine);
 ```
 
 More information on the capabilities and limitations of the
@@ -235,7 +236,7 @@ body.Instructions.Add(instruction);
 
 body.Instructions.OptimizeMacros();
 
-// instruction is now optimized to "ldc.i4.1".
+// `instruction` is now optimized to "ldc.i4.1".
 ```
 
 ``` csharp
@@ -244,7 +245,7 @@ body.Instructions.Add(instruction);
 
 body.Instructions.ExpandMacros();
 
-// instruction is now expanded to "ldc.i4 1".
+// `instruction` is now expanded to "ldc.i4 1".
 ```
 
 ### Pretty printing CIL Instructions

--- a/docs/guides/dotnet/unmanaged-method-bodies.md
+++ b/docs/guides/dotnet/unmanaged-method-bodies.md
@@ -69,29 +69,27 @@ method.ImpleAttributes |= MethodImplAttributes.Native | MethodImplAttributes.Unm
 
 ## The NativeMethodBody class
 
-The `MethodDefinition` class defines a property called
-`NativeMethodBody`, which exposes the unmanaged implementation of the
-method.
-
-Each `NativeMethodBody` is assigned to exactly one `MethodDefinition`.
-Upon instantiation of such a method body, it is therefore required to
-specify the owner of the body:
+The `MethodDefinition` class defines a property `NativeMethodBody`, which exposes the unmanaged implementation of the method.
 
 ``` csharp
 MethodDefinition method = ...
 
-var body = new NativeMethodBody(method);
+var body = new NativeMethodBody();
 method.NativeMethodBody = body;
 ```
 
-The `NativeMethodBody` class consists of the following basic building
-blocks:
+> [!NOTE]
+> Each method body can be assigned to exactly one method, and every method can only have one method body.
+> Assigning a method body to another method will result in an exception to be thrown.
+> To swap method bodies, you will first have to remove it from the existing method (e.g., by setting `MethodDefinition::NativeMethodBody` property to `null`).
+
+
+The `NativeMethodBody` class consists of the following basic building blocks:
 
 -   `Code`: The raw code stream to be executed.
 -   `AddressFixups`: A collection of fixups that need to be applied
     within the code upon writing the code to the disk.
 
-In the following sections, we will briefly go over each of them.
 
 ## Writing native code
 

--- a/src/AsmResolver.DotNet.Dynamic/DynamicCilOperandResolver.cs
+++ b/src/AsmResolver.DotNet.Dynamic/DynamicCilOperandResolver.cs
@@ -21,8 +21,12 @@ namespace AsmResolver.DotNet.Dynamic
         private readonly ReferenceImporter _importer;
 
         /// <inheritdoc />
-        public DynamicCilOperandResolver(SerializedModuleDefinition contextModule, CilMethodBody methodBody, IList<object?> tokens)
-            : base(contextModule, methodBody)
+        public DynamicCilOperandResolver(
+            SerializedModuleDefinition contextModule,
+            DynamicMethodDefinition method,
+            CilMethodBody methodBody,
+            IList<object?> tokens)
+            : base(contextModule, method, methodBody)
         {
             _tokens = tokens ?? throw new ArgumentNullException(nameof(tokens));
             _readerContext = contextModule.ReaderContext;

--- a/src/AsmResolver.DotNet.Dynamic/DynamicMethodDefinition.cs
+++ b/src/AsmResolver.DotNet.Dynamic/DynamicMethodDefinition.cs
@@ -71,12 +71,12 @@ namespace AsmResolver.DotNet.Dynamic
         /// <param name="method">The method that owns the method body.</param>
         /// <param name="dynamicMethodObj">The Dynamic Method/Delegate/DynamicResolver.</param>
         /// <returns>The method body.</returns>
-        private static CilMethodBody CreateDynamicMethodBody(MethodDefinition method, object dynamicMethodObj)
+        private static CilMethodBody CreateDynamicMethodBody(DynamicMethodDefinition method, object dynamicMethodObj)
         {
             if (method.Module is not SerializedModuleDefinition module)
                 throw new ArgumentException("Method body should reference a serialized module.");
 
-            var result = new CilMethodBody(method);
+            var result = new CilMethodBody();
             object resolver = DynamicMethodHelper.ResolveDynamicResolver(dynamicMethodObj);
 
             // We prefer to extract the information from DynamicILInfo if it is there, as it has more accurate info
@@ -125,7 +125,7 @@ namespace AsmResolver.DotNet.Dynamic
             if (code is not null)
             {
                 var reader = new BinaryStreamReader(code);
-                var operandResolver = new DynamicCilOperandResolver(module, result, tokenList);
+                var operandResolver = new DynamicCilOperandResolver(module, method, result, tokenList);
                 var disassembler = new CilDisassembler(reader, operandResolver);
                 result.Instructions.AddRange(disassembler.ReadInstructions());
             }

--- a/src/AsmResolver.DotNet/Cloning/MemberCloner.Methods.cs
+++ b/src/AsmResolver.DotNet/Cloning/MemberCloner.Methods.cs
@@ -69,7 +69,7 @@ namespace AsmResolver.DotNet.Cloning
             CloneParameterDefinitionsInMethod(context, method, clonedMethod);
 
             if (method.CilMethodBody is not null)
-                clonedMethod.CilMethodBody = CloneCilMethodBody(context, method);
+                CloneCilMethodBody(context, method);
 
             CloneCustomAttributes(context, method, clonedMethod);
             CloneGenericParameters(context, method, clonedMethod);
@@ -84,23 +84,23 @@ namespace AsmResolver.DotNet.Cloning
                 clonedMethod.ParameterDefinitions.Add(CloneParameterDefinition(context, parameterDef));
         }
 
-        private static CilMethodBody CloneCilMethodBody(MemberCloneContext context, MethodDefinition method)
+        private static void CloneCilMethodBody(MemberCloneContext context, MethodDefinition method)
         {
             var body = method.CilMethodBody!;
 
             var clonedMethod = (MethodDefinition) context.ClonedMembers[method];
 
             // Clone method body header.
-            var clonedBody = new CilMethodBody(clonedMethod);
-            clonedBody.InitializeLocals = body.InitializeLocals;
-            clonedBody.MaxStack = body.MaxStack;
+            var clonedBody = clonedMethod.CilMethodBody = new CilMethodBody
+            {
+                InitializeLocals = body.InitializeLocals,
+                MaxStack = body.MaxStack
+            };
 
             // Clone contents.
             CloneLocalVariables(context, body, clonedBody);
             CloneCilInstructions(context, body, clonedBody);
             CloneExceptionHandlers(context, body, clonedBody);
-
-            return clonedBody;
         }
 
         private static void CloneLocalVariables(MemberCloneContext context, CilMethodBody body, CilMethodBody clonedBody)
@@ -208,7 +208,7 @@ namespace AsmResolver.DotNet.Cloning
                 case CilOperandType.InlineArgument:
                 case CilOperandType.ShortInlineArgument:
                     clonedInstruction.Operand = instruction.Operand is Parameter parameter
-                        ? clonedBody.Owner.Parameters.GetBySignatureIndex(parameter.MethodSignatureIndex)
+                        ? clonedBody.Owner!.Parameters.GetBySignatureIndex(parameter.MethodSignatureIndex)
                         : instruction.Operand;
                     break;
 

--- a/src/AsmResolver.DotNet/Code/Cil/CilExceptionHandler.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilExceptionHandler.cs
@@ -22,11 +22,13 @@ namespace AsmResolver.DotNet.Code.Cil
         /// <summary>
         /// Reads a single exception handler from the provided input stream.
         /// </summary>
+        /// <param name="module">The module the exception handler is defined in.</param>
         /// <param name="body">The method body containing the exception handler.</param>
         /// <param name="reader">The input stream.</param>
         /// <param name="isFat"><c>true</c> if the fat format should be used, <c>false</c> otherwise.</param>
         /// <returns>The exception handler.</returns>
-        public static CilExceptionHandler FromReader(CilMethodBody body, ref BinaryStreamReader reader, bool isFat)
+        public static CilExceptionHandler FromReader(ModuleDefinition module, CilMethodBody body,
+            ref BinaryStreamReader reader, bool isFat)
         {
             CilExceptionHandlerType handlerType;
             int tryStartOffset;
@@ -67,7 +69,7 @@ namespace AsmResolver.DotNet.Code.Cil
             // Interpret last field.
             switch (handler.HandlerType)
             {
-                case CilExceptionHandlerType.Exception when body.Owner.Module!.TryLookupMember(exceptionTokenOrFilterStart, out var member):
+                case CilExceptionHandlerType.Exception when module.TryLookupMember(exceptionTokenOrFilterStart, out var member):
                     handler.ExceptionType = member as ITypeDefOrRef;
                     break;
                 case CilExceptionHandlerType.Filter:

--- a/src/AsmResolver.DotNet/Code/Cil/CilMethodBody.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilMethodBody.cs
@@ -17,9 +17,7 @@ namespace AsmResolver.DotNet.Code.Cil
         /// <summary>
         /// Creates a new method body.
         /// </summary>
-        /// <param name="owner">The method that owns the method body.</param>
-        public CilMethodBody(MethodDefinition owner)
-            : base(owner)
+        public CilMethodBody()
         {
             Instructions = new CilInstructionCollection(this);
         }
@@ -145,7 +143,7 @@ namespace AsmResolver.DotNet.Code.Cil
             CilRawMethodBody rawBody,
             ICilOperandResolver? operandResolver = null)
         {
-            var result = new CilMethodBody(method);
+            var result = new CilMethodBody();
 
             // Interpret body header.
             var fatBody = rawBody as CilRawFatMethodBody;
@@ -162,12 +160,12 @@ namespace AsmResolver.DotNet.Code.Cil
             }
 
             // Parse instructions.
-            operandResolver ??= new PhysicalCilOperandResolver(context.ParentModule, result);
+            operandResolver ??= new PhysicalCilOperandResolver(context.ParentModule, method, result);
             ReadInstructions(context, result, operandResolver, rawBody);
 
             // Read exception handlers.
             if (fatBody is not null)
-                ReadExceptionHandlers(context, fatBody, result);
+                ReadExceptionHandlers(context, fatBody, method, result);
 
             return result;
         }
@@ -218,6 +216,7 @@ namespace AsmResolver.DotNet.Code.Cil
         private static void ReadExceptionHandlers(
             ModuleReaderContext context,
             CilRawFatMethodBody fatBody,
+            MethodDefinition method,
             CilMethodBody result)
         {
             try
@@ -234,7 +233,7 @@ namespace AsmResolver.DotNet.Code.Cil
 
                         while (reader.CanRead(size))
                         {
-                            var handler = CilExceptionHandler.FromReader(result, ref reader, section.IsFat);
+                            var handler = CilExceptionHandler.FromReader(method.Module!, result, ref reader, section.IsFat);
                             result.ExceptionHandlers.Add(handler);
                         }
                     }

--- a/src/AsmResolver.DotNet/Code/Cil/PhysicalCilOperandResolver.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/PhysicalCilOperandResolver.cs
@@ -12,16 +12,19 @@ namespace AsmResolver.DotNet.Code.Cil
     public class PhysicalCilOperandResolver : ICilOperandResolver
     {
         private readonly ModuleDefinition _contextModule;
+        private readonly MethodDefinition _method;
         private readonly CilMethodBody _methodBody;
 
         /// <summary>
         /// Creates a new instance of the <see cref="PhysicalCilOperandResolver"/> class.
         /// </summary>
         /// <param name="contextModule">The context module.</param>
+        /// <param name="method">The method that will own the method body.</param>
         /// <param name="methodBody">The method body that references the operands.</param>
-        public PhysicalCilOperandResolver(ModuleDefinition contextModule, CilMethodBody methodBody)
+        public PhysicalCilOperandResolver(ModuleDefinition contextModule, MethodDefinition method, CilMethodBody methodBody)
         {
             _contextModule = contextModule ?? throw new ArgumentNullException(nameof(contextModule));
+            _method = method;
             _methodBody = methodBody ?? throw new ArgumentNullException(nameof(methodBody));
         }
 
@@ -49,7 +52,7 @@ namespace AsmResolver.DotNet.Code.Cil
         /// <inheritdoc />
         public virtual object? ResolveParameter(int index)
         {
-            var parameters = _methodBody.Owner.Parameters;
+            var parameters = _method.Parameters;
             return parameters.ContainsSignatureIndex(index) ? parameters.GetBySignatureIndex(index) : null;
         }
     }

--- a/src/AsmResolver.DotNet/Code/MethodBody.cs
+++ b/src/AsmResolver.DotNet/Code/MethodBody.cs
@@ -10,18 +10,17 @@ namespace AsmResolver.DotNet.Code
         /// <summary>
         /// Initializes a new empty method body.
         /// </summary>
-        /// <param name="owner">The owner of the method body.</param>
-        protected MethodBody(MethodDefinition owner)
+        protected MethodBody()
         {
-            Owner = owner ?? throw new ArgumentNullException(nameof(owner));
         }
 
         /// <summary>
         /// Gets the method that owns the method body.
         /// </summary>
-        public MethodDefinition Owner
+        public MethodDefinition? Owner
         {
             get;
+            internal set;
         }
 
         /// <summary>

--- a/src/AsmResolver.DotNet/Code/Native/NativeMethodBody.cs
+++ b/src/AsmResolver.DotNet/Code/Native/NativeMethodBody.cs
@@ -15,9 +15,7 @@ namespace AsmResolver.DotNet.Code.Native
         /// <summary>
         /// Creates a new empty native method body.
         /// </summary>
-        /// <param name="owner">The method that owns the body.</param>
-        public NativeMethodBody(MethodDefinition owner)
-            : base(owner)
+        public NativeMethodBody()
         {
             Code = ArrayShim.Empty<byte>();
         }
@@ -25,10 +23,8 @@ namespace AsmResolver.DotNet.Code.Native
         /// <summary>
         /// Creates a new native method body with the provided raw code stream.
         /// </summary>
-        /// <param name="owner">The method that owns the body.</param>
         /// <param name="code">The raw code stream.</param>
-        public NativeMethodBody(MethodDefinition owner, byte[] code)
-            : base(owner)
+        public NativeMethodBody(byte[] code)
         {
             Code = code;
         }

--- a/src/AsmResolver.DotNet/Code/UnresolvedMethodBody.cs
+++ b/src/AsmResolver.DotNet/Code/UnresolvedMethodBody.cs
@@ -9,10 +9,8 @@ namespace AsmResolver.DotNet.Code
         /// <summary>
         /// Creates a new unresolved method body stub.
         /// </summary>
-        /// <param name="owner">The owner of the method body.</param>
         /// <param name="address">The reference to the start of the method body.</param>
-        public UnresolvedMethodBody(MethodDefinition owner, ISegmentReference address)
-            : base(owner)
+        public UnresolvedMethodBody(ISegmentReference address)
         {
             Address = address;
         }

--- a/src/AsmResolver.DotNet/Serialized/DefaultMethodBodyReader.cs
+++ b/src/AsmResolver.DotNet/Serialized/DefaultMethodBodyReader.cs
@@ -53,7 +53,7 @@ namespace AsmResolver.DotNet.Serialized
                 return result;
             }
 
-            return new UnresolvedMethodBody(owner, bodyReference);
+            return new UnresolvedMethodBody(bodyReference);
         }
     }
 }

--- a/test/AsmResolver.DotNet.Tests/Builder/CilMethodBodySerializerTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Builder/CilMethodBodySerializerTest.cs
@@ -26,7 +26,7 @@ namespace AsmResolver.DotNet.Tests.Builder
                 MethodAttributes.Public | MethodAttributes.Static,
                 MethodSignature.CreateStatic(module.CorLibTypeFactory.Void));
 
-            main.CilMethodBody = new CilMethodBody(main)
+            main.CilMethodBody = new CilMethodBody()
             {
                 ComputeMaxStackOnBuild = computeMaxStack,
                 MaxStack = maxStack,
@@ -46,9 +46,9 @@ namespace AsmResolver.DotNet.Tests.Builder
             });
 
             var newImage = builder.CreateImage(module).ConstructedImage;
-            var newModule = ModuleDefinition.FromImage(newImage, TestReaderParameters);
+            var newModule = ModuleDefinition.FromImage(newImage!, TestReaderParameters);
 
-            Assert.Equal(expectedMaxStack, newModule.ManagedEntryPointMethod.CilMethodBody.MaxStack);
+            Assert.Equal(expectedMaxStack, newModule.ManagedEntryPointMethod!.CilMethodBody!.MaxStack);
         }
     }
 }

--- a/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/EventTokenPreservationTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/EventTokenPreservationTest.cs
@@ -45,7 +45,7 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
 
             // Create signature for add/remove methods.
             var signature = MethodSignature.CreateStatic(
-                eventHandlerTypeRef.Module.CorLibTypeFactory.Void,
+                eventHandlerTypeRef.Module!.CorLibTypeFactory.Void,
                 eventHandlerTypeRef.Module.CorLibTypeFactory.Object,
                 eventHandlerTypeSig);
 
@@ -53,17 +53,21 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
                                    | MethodAttributes.HideBySig;
 
             // Define add.
-            var addMethod = new MethodDefinition($"add_{@event.Name}", methodAttributes, signature);
-            addMethod.CilMethodBody = new CilMethodBody(addMethod)
+            var addMethod = new MethodDefinition($"add_{@event.Name}", methodAttributes, signature)
             {
-                Instructions = {new CilInstruction(CilOpCodes.Ret)}
+                CilMethodBody = new CilMethodBody
+                {
+                    Instructions = { CilOpCodes.Ret }
+                }
             };
 
             // Define remove.
-            var removeMethod = new MethodDefinition($"remove_{@event.Name}", methodAttributes, signature);
-            removeMethod.CilMethodBody = new CilMethodBody(removeMethod)
+            var removeMethod = new MethodDefinition($"remove_{@event.Name}", methodAttributes, signature)
             {
-                Instructions = {new CilInstruction(CilOpCodes.Ret)}
+                CilMethodBody = new CilMethodBody
+                {
+                    Instructions = { CilOpCodes.Ret }
+                }
             };
 
             // Add members.

--- a/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/ParameterTokenPreservationTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/ParameterTokenPreservationTest.cs
@@ -59,16 +59,18 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
 
         private static MethodDefinition CreateDummyMethod(ModuleDefinition module, string name, int parameterCount)
         {
-            var method = new MethodDefinition(name,
+            var method = new MethodDefinition(
+                name,
                 MethodAttributes.Public | MethodAttributes.Static,
-                MethodSignature.CreateStatic(module.CorLibTypeFactory.Void));
+                MethodSignature.CreateStatic(module.CorLibTypeFactory.Void)
+            );
 
-            method.CilMethodBody = new CilMethodBody(method);
+            method.CilMethodBody = new CilMethodBody();
             method.CilMethodBody.Instructions.Add(CilOpCodes.Ret);
 
             for (int i = 0; i < parameterCount; i++)
             {
-                method.Signature.ParameterTypes.Add(module.CorLibTypeFactory.Object);
+                method.Signature!.ParameterTypes.Add(module.CorLibTypeFactory.Object);
                 method.ParameterDefinitions.Add(new ParameterDefinition((ushort) (i + 1), $"arg_{i}", 0));
             }
 

--- a/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/PropertyTokenPreservationTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Builder/TokenPreservation/PropertyTokenPreservationTest.cs
@@ -28,14 +28,25 @@ namespace AsmResolver.DotNet.Tests.Builder.TokenPreservation
 
         private static PropertyDefinition CreateDummyProperty(TypeDefinition dummyType, string name)
         {
-            var property = new PropertyDefinition(name, 0,
-                PropertySignature.CreateStatic(dummyType.Module.CorLibTypeFactory.Object));
+            var property = new PropertyDefinition(
+                name,
+                PropertyAttributes.None,
+                PropertySignature.CreateStatic(dummyType.Module!.CorLibTypeFactory.Object)
+            );
 
-            var getMethod = new MethodDefinition($"get_{property.Name}", MethodAttributes.Public | MethodAttributes.Static,
-                MethodSignature.CreateStatic(dummyType.Module.CorLibTypeFactory.Object));
-            getMethod.CilMethodBody = new CilMethodBody(getMethod)
+            var getMethod = new MethodDefinition(
+                $"get_{property.Name}",
+                MethodAttributes.Public | MethodAttributes.Static,
+                MethodSignature.CreateStatic(dummyType.Module.CorLibTypeFactory.Object)
+            );
+
+            getMethod.CilMethodBody = new CilMethodBody
             {
-                Instructions = {new CilInstruction(CilOpCodes.Ldnull), new CilInstruction(CilOpCodes.Ret)}
+                Instructions =
+                {
+                    CilOpCodes.Ldnull,
+                    CilOpCodes.Ret
+                }
             };
 
             dummyType.Methods.Add(getMethod);

--- a/test/AsmResolver.DotNet.Tests/Code/Cil/CilInstructionCollectionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Code/Cil/CilInstructionCollectionTest.cs
@@ -31,7 +31,7 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
 
             var method = new MethodDefinition("Dummy", flags, signature);
 
-            var body = new CilMethodBody(method);
+            var body = new CilMethodBody();
             for (int i = 0; i < localCount; i++)
                 body.LocalVariables.Add(new CilLocalVariable(_module.CorLibTypeFactory.Object));
 

--- a/test/AsmResolver.DotNet.Tests/Code/Cil/CilInstructionExtensionsTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Code/Cil/CilInstructionExtensionsTest.cs
@@ -16,7 +16,7 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
         {
             var method = new MethodDefinition("Method", MethodAttributes.Static,
                 MethodSignature.CreateStatic(_module.CorLibTypeFactory.Void));
-            method.CilMethodBody = new CilMethodBody(method);
+            method.CilMethodBody = new CilMethodBody();
 
             var instruction = new CilInstruction(CilOpCodes.Nop);
             Assert.Equal(0, instruction.GetStackPopCount(method.CilMethodBody));
@@ -27,7 +27,7 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
         {
             var method = new MethodDefinition("Method", MethodAttributes.Static,
                 MethodSignature.CreateStatic(_module.CorLibTypeFactory.Void));
-            method.CilMethodBody = new CilMethodBody(method);
+            method.CilMethodBody = new CilMethodBody();
 
             var instruction = new CilInstruction(CilOpCodes.Ret);
             Assert.Equal(0, instruction.GetStackPopCount(method.CilMethodBody));
@@ -38,7 +38,7 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
         {
             var method = new MethodDefinition("Method", MethodAttributes.Static,
                 MethodSignature.CreateStatic(_module.CorLibTypeFactory.Int32));
-            method.CilMethodBody = new CilMethodBody(method);
+            method.CilMethodBody = new CilMethodBody();
 
             var instruction = new CilInstruction(CilOpCodes.Ret);
             Assert.Equal(1, instruction.GetStackPopCount(method.CilMethodBody));
@@ -49,7 +49,7 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
         {
             var method = new MethodDefinition("Method", MethodAttributes.Static,
                 MethodSignature.CreateStatic(_module.CorLibTypeFactory.Int32));
-            method.CilMethodBody = new CilMethodBody(method);
+            method.CilMethodBody = new CilMethodBody();
 
             var type = new TypeReference(_module, null, "SomeType");
             var member = new MemberReference(type, "SomeMethod",
@@ -64,7 +64,7 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
         {
             var method = new MethodDefinition("Method", MethodAttributes.Static,
                 MethodSignature.CreateStatic(_module.CorLibTypeFactory.Int32));
-            method.CilMethodBody = new CilMethodBody(method);
+            method.CilMethodBody = new CilMethodBody();
 
             var type = new TypeReference(_module, null, "SomeType");
             var member = new MemberReference(type, "SomeMethod",
@@ -80,7 +80,7 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
         {
             var method = new MethodDefinition("Method", MethodAttributes.Static,
                 MethodSignature.CreateStatic(_module.CorLibTypeFactory.Int32));
-            method.CilMethodBody = new CilMethodBody(method);
+            method.CilMethodBody = new CilMethodBody();
 
             var type = new TypeReference(_module, null, "SomeType");
             var member = new MemberReference(type, "SomeMethod",
@@ -95,7 +95,7 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
         {
             var method = new MethodDefinition("Method", MethodAttributes.Static,
                 MethodSignature.CreateStatic(_module.CorLibTypeFactory.Int32));
-            method.CilMethodBody = new CilMethodBody(method);
+            method.CilMethodBody = new CilMethodBody();
 
             var type = new TypeReference(_module, null, "SomeType");
             var member = new MemberReference(type, "SomeMethod",
@@ -144,19 +144,11 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
         {
             var module = ModuleDefinition.FromFile(typeof(TestClass).Assembly.Location, TestReaderParameters);
             var type = module.TopLevelTypes.Single(t => t.MetadataToken == typeof(TestClass).MetadataToken);
-            var property = type.Properties[0];
-            var setter = property.SetMethod;
-            var body = setter.CilMethodBody;
-            var ret = body.Instructions[^1];
+            var body = type.Properties[0].SetMethod!.CilMethodBody!;
+            Assert.Equal(0, body.Instructions[^1].GetStackPopCount(body));
 
-            Assert.Equal(0, ret.GetStackPopCount(body));
-
-            property = type.Properties[1];
-            setter = property.SetMethod;
-            body = setter.CilMethodBody;
-            ret = body.Instructions[^1];
-
-            Assert.Equal(0, ret.GetStackPopCount(body));
+            body = type.Properties[1].SetMethod!.CilMethodBody!;
+            Assert.Equal(0, body.Instructions[^1].GetStackPopCount(body));
         }
     }
 

--- a/test/AsmResolver.DotNet.Tests/Code/Cil/CilMethodBodyTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Code/Cil/CilMethodBodyTest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Reflection.Emit;
 using AsmResolver.DotNet.Builder;
 using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Serialized;
@@ -127,7 +126,7 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
                 MethodSignature.CreateStatic(isVoid ? module.CorLibTypeFactory.Void : module.CorLibTypeFactory.Int32));
 
             module.GetOrCreateModuleType().Methods.Add(method);
-            return method.CilMethodBody = new CilMethodBody(method);
+            return method.CilMethodBody = new CilMethodBody();
         }
 
         [Fact]
@@ -623,7 +622,7 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
             module.GetOrCreateModuleType().Methods.Add(method);
 
             // Give it a method body.
-            var body = new CilMethodBody(method);
+            var body = new CilMethodBody();
             method.MethodBody = body;
 
             // Add some random local variables.

--- a/test/AsmResolver.DotNet.Tests/Code/Native/NativeMethodBodyTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Code/Native/NativeMethodBodyTest.cs
@@ -57,7 +57,7 @@ namespace AsmResolver.DotNet.Tests.Code.Native
             method.DeclaringType!.Methods.Remove(method);
             module.GetOrCreateModuleType().Methods.Add(method);
 
-            return method.NativeMethodBody = new NativeMethodBody(method);
+            return method.NativeMethodBody = new NativeMethodBody();
         }
 
         private static IReadableSegment GetNewCodeSegment(PEImage image)

--- a/test/AsmResolver.DotNet.Tests/MethodDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/MethodDefinitionTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -13,7 +12,6 @@ using AsmResolver.PE.DotNet;
 using AsmResolver.PE.DotNet.Cil;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.VTableFixups;
-using AsmResolver.PE.Exports;
 using AsmResolver.PE.File;
 using AsmResolver.Tests.Runners;
 using Xunit;
@@ -50,7 +48,7 @@ namespace AsmResolver.DotNet.Tests
             var module = ModuleDefinition.FromFile(typeof(MultipleMethods).Assembly.Location, TestReaderParameters);
             var type = module.TopLevelTypes.First(t => t.Name == nameof(MultipleMethods));
             var method = type.Methods.First(m => m.Name == methodName);
-            Assert.Equal(expectedReturnType, method.Signature.ReturnType.FullName);
+            Assert.Equal(expectedReturnType, method.Signature!.ReturnType.FullName);
         }
 
         [Fact]
@@ -58,7 +56,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(SingleMethod).Assembly.Location, TestReaderParameters);
             var method = (MethodDefinition) module.LookupMember(
-                typeof(SingleMethod).GetMethod(nameof(SingleMethod.VoidParameterlessMethod)).MetadataToken);
+                typeof(SingleMethod).GetMethod(nameof(SingleMethod.VoidParameterlessMethod))!.MetadataToken);
             Assert.NotNull(method.DeclaringType);
             Assert.Equal(nameof(SingleMethod), method.DeclaringType.Name);
         }
@@ -68,7 +66,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(MultipleMethods).Assembly.Location, TestReaderParameters);
             var method = (MethodDefinition) module.LookupMember(
-                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.VoidParameterlessMethod)).MetadataToken);
+                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.VoidParameterlessMethod))!.MetadataToken);
             Assert.Empty(method.ParameterDefinitions);
         }
 
@@ -77,7 +75,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(MultipleMethods).Assembly.Location, TestReaderParameters);
             var method = (MethodDefinition) module.LookupMember(
-                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.SingleParameterMethod)).MetadataToken);
+                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.SingleParameterMethod))!.MetadataToken);
             Assert.Single(method.ParameterDefinitions);
         }
 
@@ -86,7 +84,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(MultipleMethods).Assembly.Location, TestReaderParameters);
             var method = (MethodDefinition) module.LookupMember(
-                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.MultipleParameterMethod)).MetadataToken);
+                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.MultipleParameterMethod))!.MetadataToken);
             Assert.Equal(3, method.ParameterDefinitions.Count);
         }
 
@@ -95,7 +93,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(MultipleMethods).Assembly.Location, TestReaderParameters);
             var method = (MethodDefinition) module.LookupMember(
-                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.VoidParameterlessMethod)).MetadataToken);
+                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.VoidParameterlessMethod))!.MetadataToken);
             Assert.Empty(method.Parameters);
         }
 
@@ -104,7 +102,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(MultipleMethods).Assembly.Location, TestReaderParameters);
             var method = (MethodDefinition) module.LookupMember(
-                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.SingleParameterMethod)).MetadataToken);
+                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.SingleParameterMethod))!.MetadataToken);
             Assert.Single(method.Parameters);
             Assert.Equal("intParameter", method.Parameters[0].Name);
             Assert.True(method.Parameters[0].ParameterType.IsTypeOf("System", "Int32"));
@@ -115,7 +113,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(MultipleMethods).Assembly.Location, TestReaderParameters);
             var method = (MethodDefinition) module.LookupMember(
-                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.MultipleParameterMethod)).MetadataToken);
+                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.MultipleParameterMethod))!.MetadataToken);
             Assert.Equal(3, method.Parameters.Count);
 
             Assert.Equal("intParameter", method.Parameters[0].Name);
@@ -136,7 +134,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(MultipleMethods).Assembly.Location, TestReaderParameters);
             var method = (MethodDefinition) module.LookupMember(
-                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.IntParameterlessMethod)).MetadataToken);
+                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.IntParameterlessMethod))!.MetadataToken);
 
             Assert.Equal(
                 "System.Int32 AsmResolver.DotNet.TestCases.Methods.MultipleMethods::IntParameterlessMethod()",
@@ -148,7 +146,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(MultipleMethods).Assembly.Location, TestReaderParameters);
             var method = (MethodDefinition) module.LookupMember(
-                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.VoidParameterlessMethod)).MetadataToken);
+                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.VoidParameterlessMethod))!.MetadataToken);
 
             Assert.Equal(
                 "System.Void AsmResolver.DotNet.TestCases.Methods.MultipleMethods::VoidParameterlessMethod()",
@@ -160,7 +158,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(MultipleMethods).Assembly.Location, TestReaderParameters);
             var method = (MethodDefinition) module.LookupMember(
-                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.SingleParameterMethod)).MetadataToken);
+                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.SingleParameterMethod))!.MetadataToken);
 
             Assert.Equal(
                 "System.Void AsmResolver.DotNet.TestCases.Methods.MultipleMethods::SingleParameterMethod(System.Int32)",
@@ -172,7 +170,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(MultipleMethods).Assembly.Location, TestReaderParameters);
             var method = (MethodDefinition) module.LookupMember(
-                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.MultipleParameterMethod)).MetadataToken);
+                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.MultipleParameterMethod))!.MetadataToken);
 
             Assert.Equal(
                 "System.Void AsmResolver.DotNet.TestCases.Methods.MultipleMethods::MultipleParameterMethod(System.Int32, System.String, AsmResolver.DotNet.TestCases.Methods.MultipleMethods)",
@@ -184,7 +182,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(SingleMethod).Assembly.Location, TestReaderParameters);
             var method = (MethodDefinition) module.LookupMember(
-                typeof(SingleMethod).GetMethod(nameof(SingleMethod.VoidParameterlessMethod)).MetadataToken);
+                typeof(SingleMethod).GetMethod(nameof(SingleMethod.VoidParameterlessMethod))!.MetadataToken);
 
             Assert.False(method.IsGetMethod);
             Assert.False(method.IsSetMethod);
@@ -198,7 +196,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(SingleProperty).Assembly.Location, TestReaderParameters);
             var method = (MethodDefinition) module.LookupMember(
-                typeof(SingleProperty).GetMethod("get_" + nameof(SingleProperty.IntProperty)).MetadataToken);
+                typeof(SingleProperty).GetMethod("get_" + nameof(SingleProperty.IntProperty))!.MetadataToken);
 
             Assert.True(method.IsGetMethod);
         }
@@ -208,7 +206,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(SingleProperty).Assembly.Location, TestReaderParameters);
             var method = (MethodDefinition) module.LookupMember(
-                typeof(SingleProperty).GetMethod("set_" + nameof(SingleProperty.IntProperty)).MetadataToken);
+                typeof(SingleProperty).GetMethod("set_" + nameof(SingleProperty.IntProperty))!.MetadataToken);
 
             Assert.True(method.IsSetMethod);
         }
@@ -218,7 +216,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(SingleEvent).Assembly.Location, TestReaderParameters);
             var method = (MethodDefinition) module.LookupMember(
-                typeof(SingleEvent).GetMethod("add_" + nameof(SingleEvent.SimpleEvent)).MetadataToken);
+                typeof(SingleEvent).GetMethod("add_" + nameof(SingleEvent.SimpleEvent))!.MetadataToken);
 
             Assert.True(method.IsAddMethod);
         }
@@ -228,7 +226,7 @@ namespace AsmResolver.DotNet.Tests
         {
             var module = ModuleDefinition.FromFile(typeof(SingleEvent).Assembly.Location, TestReaderParameters);
             var method = (MethodDefinition) module.LookupMember(
-                typeof(SingleEvent).GetMethod("remove_" + nameof(SingleEvent.SimpleEvent)).MetadataToken);
+                typeof(SingleEvent).GetMethod("remove_" + nameof(SingleEvent.SimpleEvent))!.MetadataToken);
 
             Assert.True(method.IsRemoveMethod);
         }
@@ -240,7 +238,7 @@ namespace AsmResolver.DotNet.Tests
             var method = module.TopLevelTypes
                 .First(t => t.Name == nameof(MultipleMethods)).Methods
                 .First(m => m.Name == nameof(MultipleMethods.IntParameterlessMethod));
-            Assert.True(method.Signature.ReturnsValue);
+            Assert.True(method.Signature!.ReturnsValue);
         }
 
         [Fact]
@@ -250,7 +248,7 @@ namespace AsmResolver.DotNet.Tests
             var method = module.TopLevelTypes
                 .First(t => t.Name == nameof(MultipleMethods)).Methods
                 .First(m => m.Name == nameof(MultipleMethods.VoidParameterlessMethod));
-            Assert.False(method.Signature.ReturnsValue);
+            Assert.False(method.Signature!.ReturnsValue);
         }
 
         private static AssemblyDefinition CreateDummyLibraryWithExport(int methodCount, bool is32Bit)
@@ -298,7 +296,7 @@ namespace AsmResolver.DotNet.Tests
                     MethodSignature.CreateStatic(module.CorLibTypeFactory.Void));
 
                 // Add a Console.WriteLine call
-                var body = new CilMethodBody(method);
+                var body = new CilMethodBody();
                 method.MethodBody = body;
                 body.Instructions.Add(CilOpCodes.Ldstr, $"Hello from {methodName}.");
                 body.Instructions.Add(CilOpCodes.Call, writeLine);
@@ -590,6 +588,67 @@ namespace AsmResolver.DotNet.Tests
 
             Assert.True(ctor.IsConstructor);
             Assert.Equal(new[] {factory.Int32, factory.Double}, ctor.Parameters.Select(x => x.ParameterType));
+        }
+
+        [Fact]
+        public void BodyHasOwner()
+        {
+            var module = ModuleDefinition.FromFile(typeof(SingleMethod).Assembly.Location, TestReaderParameters);
+            var method = module.LookupMember<MethodDefinition>(
+                typeof(SingleMethod).GetMethod(nameof(SingleMethod.VoidParameterlessMethod))!.MetadataToken
+            );
+
+            var body = method.MethodBody;
+            Assert.NotNull(body);
+            Assert.Same(method, body.Owner);
+        }
+
+        [Fact]
+        public void RemovingBodyShouldClearOwner()
+        {
+            var module = ModuleDefinition.FromFile(typeof(SingleMethod).Assembly.Location, TestReaderParameters);
+            var method = module.LookupMember<MethodDefinition>(
+                typeof(SingleMethod).GetMethod(nameof(SingleMethod.VoidParameterlessMethod))!.MetadataToken
+            );
+
+            var body = method.MethodBody!;
+            Assert.Same(method, body.Owner);
+            method.MethodBody = null;
+            Assert.Null(body.Owner);
+        }
+
+        [Fact]
+        public void AssigningNewBodyShouldUpdateOwner()
+        {
+            var module = ModuleDefinition.FromFile(typeof(SingleMethod).Assembly.Location, TestReaderParameters);
+            var method = module.LookupMember<MethodDefinition>(
+                typeof(SingleMethod).GetMethod(nameof(SingleMethod.VoidParameterlessMethod))!.MetadataToken
+            );
+
+            var originalBody = method.MethodBody!;
+            var newBody = new CilMethodBody();
+
+            Assert.Same(method, originalBody.Owner);
+            Assert.Null(newBody.Owner);
+
+            method.MethodBody = newBody;
+
+            Assert.Null(originalBody.Owner);
+            Assert.Same(method, newBody.Owner);
+        }
+
+        [Fact]
+        public void AssignBodyOfOtherMethodShouldThrow()
+        {
+            var module = ModuleDefinition.FromFile(typeof(MultipleMethods).Assembly.Location, TestReaderParameters);
+            var method1 = module.LookupMember<MethodDefinition>(
+                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.VoidParameterlessMethod))!.MetadataToken
+            );
+            var method2 = module.LookupMember<MethodDefinition>(
+                typeof(MultipleMethods).GetMethod(nameof(MultipleMethods.IntParameterlessMethod))!.MetadataToken
+            );
+
+            Assert.ThrowsAny<ArgumentException>(() => method1.MethodBody = method2.MethodBody);
         }
     }
 }

--- a/test/AsmResolver.DotNet.Tests/TokenAllocatorTest.cs
+++ b/test/AsmResolver.DotNet.Tests/TokenAllocatorTest.cs
@@ -122,14 +122,20 @@ namespace AsmResolver.DotNet.Tests
 
             var targetModule = ModuleDefinition.FromBytes(Properties.Resources.HelloWorld, TestReaderParameters);
 
-            var method = new MethodDefinition("test",
+            var method = new MethodDefinition(
+                "test",
                 MethodAttributes.Public | MethodAttributes.Static,
-                MethodSignature.CreateStatic(targetModule.CorLibTypeFactory.Boolean));
+                MethodSignature.CreateStatic(targetModule.CorLibTypeFactory.Boolean)
+            );
 
-            var body = new CilMethodBody(method);
-            body.Instructions.Add(CilOpCodes.Ldc_I4, 0);
-            body.Instructions.Add(CilOpCodes.Ret);
-            method.CilMethodBody = body;
+            method.CilMethodBody = new CilMethodBody
+            {
+                Instructions =
+                {
+                    {CilOpCodes.Ldc_I4, 0},
+                    CilOpCodes.Ret
+                }
+            };
 
             targetModule.TopLevelTypes.First().Methods.Add(method);
 


### PR DESCRIPTION
Removes `owner` parameters from  `CilMethodBody`, `NativeMethodBody` and `UnresolvedMethodBody`, allowing them to be used in C# object initializer syntax. Assigning to `MethodDefinition::MethodBody` may now throw an `ArgumentException` when the body was already assigned to another method body.