### PR TITLE
Metadata Validation on MethodDefinition

### DIFF
--- a/src/AsmResolver.DotNet/Builder/Discovery/MemberDiscoverer.cs
+++ b/src/AsmResolver.DotNet/Builder/Discovery/MemberDiscoverer.cs
@@ -412,8 +412,9 @@ namespace AsmResolver.DotNet.Builder.Discovery
             // Define getter.
             var getMethod = new MethodDefinition(
                 $"get_{property.Name}",
-                MethodPlaceHolderAttributes | MethodAttributes.SpecialName,
-                MethodSignature.CreateStatic(_module.CorLibTypeFactory.Object));
+                MethodPlaceHolderAttributes | MethodAttributes.SpecialName | MethodAttributes.Static,
+                MethodSignature.CreateStatic(_module.CorLibTypeFactory.Object)
+            );
 
             // Add members.
             placeHolderType.Methods.Add(getMethod);
@@ -439,12 +440,14 @@ namespace AsmResolver.DotNet.Builder.Discovery
             // Define add and remove methods.
             var addMethod = new MethodDefinition(
                 $"add_{@event.Name}",
-                MethodPlaceHolderAttributes | MethodAttributes.SpecialName,
-                signature);
+                MethodPlaceHolderAttributes | MethodAttributes.SpecialName | MethodAttributes.Static,
+                signature
+            );
             var removeMethod = new MethodDefinition(
                 $"remove_{@event.Name}",
-                MethodPlaceHolderAttributes | MethodAttributes.SpecialName,
-                signature);
+                MethodPlaceHolderAttributes | MethodAttributes.SpecialName | MethodAttributes.Static,
+                signature
+            );
 
             // Add members.
             placeHolderType.Methods.Add(addMethod);

--- a/src/AsmResolver.DotNet/Builder/DotNetDirectoryBuffer.MemberTree.cs
+++ b/src/AsmResolver.DotNet/Builder/DotNetDirectoryBuffer.MemberTree.cs
@@ -189,7 +189,8 @@ namespace AsmResolver.DotNet.Builder
         /// Allocates metadata rows for the provided method definitions in the buffer.
         /// </summary>
         /// <param name="methods">The methods to define.</param>
-        public void DefineMethods(IEnumerable<MethodDefinition> methods)
+        /// <param name="validateSignatures">Set to <c>true</c> if the signatures should be validated for consistency with what is defined in metadata.</param>
+        public void DefineMethods(IEnumerable<MethodDefinition> methods, bool validateSignatures = true)
         {
             var table = Metadata.TablesStream.GetTable<MethodDefinitionRow>(TableIndex.Method);
             if (methods is ICollection<MethodDefinition> collection)
@@ -214,6 +215,9 @@ namespace AsmResolver.DotNet.Builder
                 // If the method is supposed to be exported as an unmanaged symbol, register it.
                 if (method.ExportInfo.HasValue)
                     VTableFixups.MapTokenToExport(method.ExportInfo.Value, token);
+
+                if (validateSignatures)
+                    method.VerifyMetadata(ErrorListener);
             }
         }
 

--- a/src/AsmResolver.DotNet/Builder/DotNetDirectoryFactory.cs
+++ b/src/AsmResolver.DotNet/Builder/DotNetDirectoryFactory.cs
@@ -94,7 +94,10 @@ namespace AsmResolver.DotNet.Builder
 
             // We need to define method definitions before member references, since member references can have method
             // definitions in their parent.
-            buffer.DefineMethods(discoveryResult.Methods);
+            buffer.DefineMethods(
+                discoveryResult.Methods,
+                (MetadataBuilderFlags & MetadataBuilderFlags.NoMemberSignatureVerification) == 0
+            );
             ImportMemberRefsIfSpecified(module, buffer);
 
             // Define all remaining members in the added types.

--- a/src/AsmResolver.DotNet/Builder/MetadataBuilderFlags.cs
+++ b/src/AsmResolver.DotNet/Builder/MetadataBuilderFlags.cs
@@ -17,103 +17,103 @@ namespace AsmResolver.DotNet.Builder
         /// Indicates indices into the #Blob stream should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
-        PreserveBlobIndices = 0x1,
+        PreserveBlobIndices = 1 << 0,
 
         /// <summary>
         /// Indicates indices into the #GUID stream should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
-        PreserveGuidIndices = 0x2,
+        PreserveGuidIndices = 1 << 1,
 
         /// <summary>
         /// Indicates indices into the #Strings stream should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
-        PreserveStringIndices = 0x4,
+        PreserveStringIndices = 1 << 2,
 
         /// <summary>
         /// Indicates indices into the #US stream should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
-        PreserveUserStringIndices = 0x8,
+        PreserveUserStringIndices = 1 << 3,
 
         /// <summary>
         /// Indicates indices into the type references table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
-        PreserveTypeReferenceIndices = 0x10,
+        PreserveTypeReferenceIndices = 1 << 4,
 
         /// <summary>
         /// Indicates indices into the type definition table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
-        PreserveTypeDefinitionIndices = 0x20,
+        PreserveTypeDefinitionIndices = 1 << 5,
 
         /// <summary>
         /// Indicates indices into the field definition table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
-        PreserveFieldDefinitionIndices = 0x40,
+        PreserveFieldDefinitionIndices = 1 << 6,
 
         /// <summary>
         /// Indicates indices into the method definition table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
-        PreserveMethodDefinitionIndices = 0x80,
+        PreserveMethodDefinitionIndices = 1 << 7,
 
         /// <summary>
         /// Indicates indices into the parameter definition table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
-        PreserveParameterDefinitionIndices = 0x100,
+        PreserveParameterDefinitionIndices = 1 << 8,
 
         /// <summary>
         /// Indicates indices into the member reference table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
-        PreserveMemberReferenceIndices = 0x200,
+        PreserveMemberReferenceIndices = 1 << 9,
 
         /// <summary>
         /// Indicates indices into the stand-alone signature table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
-        PreserveStandAloneSignatureIndices = 0x400,
+        PreserveStandAloneSignatureIndices = 1 << 10,
 
         /// <summary>
         /// Indicates indices into the event definition table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
-        PreserveEventDefinitionIndices = 0x800,
+        PreserveEventDefinitionIndices = 1 << 11,
 
         /// <summary>
         /// Indicates indices into the property definition table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
-        PreservePropertyDefinitionIndices = 0x1000,
+        PreservePropertyDefinitionIndices = 1 << 12,
 
         /// <summary>
         /// Indicates indices into the module reference table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
-        PreserveModuleReferenceIndices = 0x2000,
+        PreserveModuleReferenceIndices = 1 << 13,
 
         /// <summary>
         /// Indicates indices into the type specification table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
-        PreserveTypeSpecificationIndices = 0x4000,
+        PreserveTypeSpecificationIndices = 1 << 14,
 
         /// <summary>
         /// Indicates indices into the assembly reference table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
-        PreserveAssemblyReferenceIndices = 0x8000,
+        PreserveAssemblyReferenceIndices = 1 << 15,
 
         /// <summary>
         /// Indicates indices into the method specification table should be preserved whenever possible during the construction
         /// of the metadata directory.
         /// </summary>
-        PreserveMethodSpecificationIndices = 0x10000,
+        PreserveMethodSpecificationIndices = 1 << 16,
 
         /// <summary>
         /// Indicates indices into the tables stream should be preserved whenever possible during the construction
@@ -129,13 +129,13 @@ namespace AsmResolver.DotNet.Builder
         /// Indicates unconventional / spurious metadata streams present in the .NET metadata directory should be
         /// preserved when possible.
         /// </summary>
-        PreserveUnknownStreams = 0x20000,
+        PreserveUnknownStreams = 1 << 17,
 
         /// <summary>
         /// Indicates unconventional metadata stream order in the .NET metadata directory should be preserved when
         /// possible.
         /// </summary>
-        PreserveStreamOrder = 0x40000,
+        PreserveStreamOrder = 1 << 18,
 
         /// <summary>
         /// Indicates any kind of index into a blob or tables stream, as well as unknown spurious metadata streams
@@ -154,7 +154,7 @@ namespace AsmResolver.DotNet.Builder
         /// Setting this flag will disable this optimization.
         /// </para>
         /// </summary>
-        NoStringsStreamOptimization = 0x20000,
+        NoStringsStreamOptimization = 1 << 19,
 
         /// <summary>
         /// <para>
@@ -167,11 +167,24 @@ namespace AsmResolver.DotNet.Builder
         /// or depend on individual resource items to be present. Setting this flag will disable this optimization.
         /// </para>
         /// </summary>
-        NoResourceDataDeduplication = 0x40000,
+        NoResourceDataDeduplication = 1 << 20,
 
         /// <summary>
         /// Setting this flag will force the builder to emit edit-and-continue metadata, even if it is not required.
         /// </summary>
-        ForceEncMetadata = 0x80000
+        ForceEncMetadata = 1 << 21,
+
+        /// <summary>
+        /// <para>
+        /// By default, AsmResolver will validate member definitions that hold signatures for consistency with their
+        /// associated metadata. This includes e.g., testing whether static methods have the HasThis unset in their
+        /// signatures, and verifying that the number of generic parameters is consistent with what is defined in their
+        /// signature.
+        /// </para>
+        /// <para>
+        /// Setting this flag will disable this verification.
+        /// </para>
+        /// </summary>
+        NoMemberSignatureVerification = 1 << 22,
     }
 }

--- a/src/AsmResolver.DotNet/Cloning/MemberCloner.Methods.cs
+++ b/src/AsmResolver.DotNet/Cloning/MemberCloner.Methods.cs
@@ -32,10 +32,13 @@ namespace AsmResolver.DotNet.Cloning
             if (method.Signature is null)
                 throw new ArgumentException($"Method {method.SafeToString()} has no signature.");
 
-            var clonedMethod = new MethodDefinition(method.Name, method.Attributes,
-                context.Importer.ImportMethodSignature(method.Signature));
-            clonedMethod.ImplAttributes = method.ImplAttributes;
+            var clonedMethod = new MethodDefinition(
+                method.Name,
+                method.Attributes,
+                context.Importer.ImportMethodSignature(method.Signature)
+            );
 
+            clonedMethod.ImplAttributes = method.ImplAttributes;
             clonedMethod.Parameters.PullUpdatesFromMethodSignature();
 
             context.ClonedMembers[method] = clonedMethod;

--- a/src/AsmResolver.DotNet/Code/Cil/CilInstructionCollection.Add.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilInstructionCollection.Add.cs
@@ -217,7 +217,8 @@ namespace AsmResolver.DotNet.Code.Cil
         public CilInstruction Add(CilOpCode code, IMetadataMember member) => Insert(Count, code, member);
 
         /// <summary>
-        /// Verifies and adds a instruction to the end of the collection that references a standalone signature.
+        /// Verifies and adds a instruction to the end of the collection that references a standalone signature
+        /// referencing a method signature in the blob stream.
         /// </summary>
         /// <param name="code">The opcode.</param>
         /// <param name="signature">The referenced signature.</param>

--- a/src/AsmResolver.DotNet/Code/Cil/CilInstructionCollection.Insert.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilInstructionCollection.Insert.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using AsmResolver.DotNet.Collections;
+using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Cil;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 
@@ -379,7 +380,8 @@ namespace AsmResolver.DotNet.Code.Cil
         }
 
         /// <summary>
-        /// Verifies and inserts a instruction into the collection that references a standalone signature.
+        /// Verifies and inserts a instruction into the collection that references a standalone signature
+        /// referencing a method signature in the blob stream.
         /// </summary>
         /// <param name="index">The zero-based index at which the instruction should be inserted at.</param>
         /// <param name="code">The opcode.</param>
@@ -392,6 +394,9 @@ namespace AsmResolver.DotNet.Code.Cil
         {
             if (code.OperandType != CilOperandType.InlineSig)
                 throw new InvalidCilInstructionException(code);
+
+            if (code == CilOpCodes.Calli && signature.Signature is not MethodSignature)
+                throw new InvalidCilInstructionException($"Operation code calli requires a method signature wrapped in a standalone signature as operand.");
 
             return InsertAndReturn(index, code, signature);
         }

--- a/test/AsmResolver.DotNet.Tests/Code/Cil/CilInstructionCollectionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Code/Cil/CilInstructionCollectionTest.cs
@@ -431,5 +431,17 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
             instructions.CalculateOffsets();
             Assert.Equal(offsets, instructions.Select(i => i.Offset));
         }
+
+        [Fact]
+        public void InsertInlineSigInstructionShouldOnlyAcceptWrappedMethodSignatures()
+        {
+            var instructions = CreateDummyMethod(false, 0, 0);
+
+            instructions.Add(CilOpCodes.Calli, MethodSignature.CreateStatic(_module.CorLibTypeFactory.Void).MakeStandAloneSignature());
+
+            Assert.ThrowsAny<InvalidCilInstructionException>(() =>
+                instructions.Add(CilOpCodes.Calli, new DataBlobSignature(new byte[] { 1, 2, 3 }).MakeStandAloneSignature())
+            );
+        }
     }
 }

--- a/test/AsmResolver.DotNet.Tests/Signatures/GenericContextTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Signatures/GenericContextTest.cs
@@ -157,8 +157,12 @@ namespace AsmResolver.DotNet.Tests.Signatures
         public void ParseGenericFromMethodSpecification()
         {
             var genericParameter = new GenericParameterSignature(GenericParameterType.Method, 0);
-            var method = new MethodDefinition("TestMethod", MethodAttributes.Private,
-                MethodSignature.CreateStatic(genericParameter));
+            var method = new MethodDefinition(
+                "TestMethod",
+                MethodAttributes.Static,
+                MethodSignature.CreateStatic(genericParameter)
+            );
+
             var genericInstance = new GenericInstanceMethodSignature();
             genericInstance.TypeArguments.Add(_importer.ImportTypeSignature(typeof(int)));
             var methodSpecification = new MethodSpecification(method, genericInstance);
@@ -224,8 +228,11 @@ namespace AsmResolver.DotNet.Tests.Signatures
             var type = new TypeDefinition("", "Test type", TypeAttributes.Public);
             var notGenericSignature = new TypeDefOrRefSignature(type);
 
-            var method = new MethodDefinition("TestMethod", MethodAttributes.Private,
-                MethodSignature.CreateStatic(notGenericSignature));
+            var method = new MethodDefinition(
+                "TestMethod",
+                MethodAttributes.Static,
+                MethodSignature.CreateStatic(notGenericSignature)
+            );
             var methodSpecification = new MethodSpecification(method, null);
 
             var context = GenericContext.FromMethod(methodSpecification);
@@ -310,8 +317,11 @@ namespace AsmResolver.DotNet.Tests.Signatures
 
             var genericParameter = new GenericParameterSignature(GenericParameterType.Type, 0);
 
-            var method = new MethodDefinition("Method", MethodAttributes.Private,
-                MethodSignature.CreateStatic(genericParameter));
+            var method = new MethodDefinition(
+                "Method",
+                MethodAttributes.Static,
+                MethodSignature.CreateStatic(genericParameter)
+            );
 
             var member = new MemberReference(typeSpecification, method.Name, method.Signature);
 
@@ -330,8 +340,11 @@ namespace AsmResolver.DotNet.Tests.Signatures
             var type = new TypeDefinition("", "Test type", TypeAttributes.Public);
             var notGenericSignature = new TypeDefOrRefSignature(type);
 
-            var method = new MethodDefinition("Method", MethodAttributes.Private,
-                MethodSignature.CreateStatic(notGenericSignature));
+            var method = new MethodDefinition(
+                "Method",
+                MethodAttributes.Static,
+                MethodSignature.CreateStatic(notGenericSignature)
+            );
 
             var member = new MemberReference(type, method.Name, method.Signature);
 


### PR DESCRIPTION
Additions:
- Add validation of standalone signature contents in `CilInstructionCollection::Insert(CilOpCode, StandAloneSiganture)`
- Add static/instance flag checks in constructor of `MethodDefinition` and an overload to surpress this.
- Add `MethodDefinition::VerifyMetadata` that checks for (accidental) inconsistencies in metadata, including inconsistencies between static and HasThis and generic parameter counts.

Bug fixes:
- Fix conflicting constants in `MetadataBuilderFlags`.

Related #630 