### PR TITLE
Include assembly spec for 'corelib' in attributes

### DIFF
--- a/src/AsmResolver.DotNet/Signatures/Parsing/CustomAttributeArgumentWriter.cs
+++ b/src/AsmResolver.DotNet/Signatures/Parsing/CustomAttributeArgumentWriter.cs
@@ -91,7 +91,15 @@ namespace AsmResolver.DotNet.Signatures.Parsing
 
             if (argumentType.IsTypeOf("System", "Type"))
             {
-                writer.WriteSerString(TypeNameBuilder.GetAssemblyQualifiedName((TypeSignature) element));
+                // Type names must include the assembly spec for 'corelib' as well. E.g., this is what Roslyn emits:
+                //
+                // 'System.Collections.Generic.List`1[[System.Uri, System.Runtime, Version=10.0.0.0, Culture=neutral,
+                //  PublicKeyToken=b03f5f7f11d50a3a]], System.Collections, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
+                //
+                // When parsing 'Type' attribute elements, if the assembly spec is not specified, types would otherwise default to 'corlib', but that
+                // would not necessarily be correct. For instance, 'System.Uri' is not in 'System.Private.CoreLib.dll', it's in 'System.Private.Uri.dll'.
+                // Emitting the assembly spec in all cases fixes this issue, and results in the same output as Roslyn.
+                writer.WriteSerString(TypeNameBuilder.GetAssemblyQualifiedName((TypeSignature) element, omitCorLib: false));
                 return;
             }
 


### PR DESCRIPTION
This fixes the custom attribute serialization logic to emit FQNs with assembly specs in all cases.

Context:

![image](https://github.com/user-attachments/assets/9ff8572d-d084-4a8c-87ac-4f422cb54fe0)

![image](https://github.com/user-attachments/assets/d80da2cb-3374-4aeb-b29d-a9e7b4950599)