### PR TITLE
Fix lexing FQNs in generic type names

### DIFF
--- a/src/AsmResolver.DotNet/Signatures/Parsing/TypeNameLexer.cs
+++ b/src/AsmResolver.DotNet/Signatures/Parsing/TypeNameLexer.cs
@@ -112,8 +112,7 @@ namespace AsmResolver.DotNet.Signatures.Parsing
                     {
                         break;
                     }
-                    else if (terminal == TypeNameTerminal.Number
-                             && (char.IsWhiteSpace(currentChar) || ReservedChars.Contains(currentChar)))
+                    else if (char.IsWhiteSpace(currentChar) || ReservedChars.Contains(currentChar))
                     {
                         break;
                     }


### PR DESCRIPTION
When parsing a type name like:
```
Windows.Foundation.AsyncOperationCompletedHandler`1[[Windows.Storage.FileProperties.MusicProperties, Microsoft.Windows.SDK.NET, Version=10.0.26100.38, Culture=neutral, PublicKeyToken=31bf3856ad364e35]], Microsoft.Windows.SDK.NET, Version=10.0.26100.38, Culture=neutral, PublicKeyToken=31bf3856ad364e35
```
TypeNameLexer would begin lexing the ident after the first PublicKeyToken=, using ReadNumberOrIdentifierToken. ReadNumberOrIdentifierToken starts assuming it is a number, but then upon seeing `b`, it changes to parsing an identifier. However, it only checks for the whitespace and restricted characters when parsing a number, so it continues lexing until it hits an '=', giving `"31bf3856ad364e35]], Microsoft.Windows.SDK.NET, Version"` instead of the intended `31bf3856ad364e35`.