### PR TITLE
Fix not fully qualified type names in blobs

### DIFF
--- a/src/AsmResolver.DotNet/DotNetRuntimeInfo.cs
+++ b/src/AsmResolver.DotNet/DotNetRuntimeInfo.cs
@@ -148,12 +148,17 @@ namespace AsmResolver.DotNet
         }
 
         /// <summary>
-        /// Obtains a reference to the default core lib reference of this runtime.
+        /// Obtains a reference to the default core lib of this runtime.
         /// </summary>
         /// <returns>The reference to the default core lib.</returns>
         /// <exception cref="ArgumentException">The runtime information is invalid or unsupported.</exception>
         public AssemblyReference GetDefaultCorLib() => KnownCorLibs.FromRuntimeInfo(this);
 
+        /// <summary>
+        /// Obtains a reference to the assumed implementation core lib for this runtime.
+        /// </summary>
+        /// <returns>The reference to the assumed implementation core lib.</returns>
+        /// <exception cref="ArgumentException">The runtime information is invalid or unsupported.</exception>
         public AssemblyReference? GetAssumedImplCorLib() => KnownCorLibs.TryImplFromRuntimeInfo(this);
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/DotNetRuntimeInfo.cs
+++ b/src/AsmResolver.DotNet/DotNetRuntimeInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Runtime.Versioning;
 using System.Text.RegularExpressions;
 
@@ -152,6 +153,8 @@ namespace AsmResolver.DotNet
         /// <returns>The reference to the default core lib.</returns>
         /// <exception cref="ArgumentException">The runtime information is invalid or unsupported.</exception>
         public AssemblyReference GetDefaultCorLib() => KnownCorLibs.FromRuntimeInfo(this);
+
+        public AssemblyReference? GetAssumedImplCorLib() => KnownCorLibs.TryImplFromRuntimeInfo(this);
 
         /// <inheritdoc />
         public override string ToString() => $"{Name},Version=v{Version}";

--- a/src/AsmResolver.DotNet/KnownCorLibs.cs
+++ b/src/AsmResolver.DotNet/KnownCorLibs.cs
@@ -379,6 +379,7 @@ namespace AsmResolver.DotNet
                 (7, 0) => SystemPrivateCoreLib_v7_0_0_0,
                 (8, 0) => SystemPrivateCoreLib_v8_0_0_0,
                 (9, 0) => SystemPrivateCoreLib_v9_0_0_0,
+                (10, 0) => SystemPrivateCoreLib_v10_0_0_0,
                 _ => throw new ArgumentException($"Invalid or unsupported .NET or .NET Core version {version}.")
             };
         }

--- a/src/AsmResolver.DotNet/KnownCorLibs.cs
+++ b/src/AsmResolver.DotNet/KnownCorLibs.cs
@@ -294,7 +294,7 @@ namespace AsmResolver.DotNet
         }
 
         /// <summary>
-        /// Obtains a reference to the default core lib reference for the provided .NET target runtime.
+        /// Obtains a reference to the default core lib for the provided .NET target runtime.
         /// </summary>
         /// <param name="runtimeInfo">The runtime to target.</param>
         /// <returns>The reference to the default core lib.</returns>
@@ -314,10 +314,10 @@ namespace AsmResolver.DotNet
         }
 
         /// <summary>
-        /// Obtains a reference to the default core lib reference for the provided .NET target runtime.
+        /// Obtains a reference to the assumed implementation core lib for the provided .NET target runtime.
         /// </summary>
         /// <param name="runtimeInfo">The runtime to target.</param>
-        /// <returns>The reference to the default core lib.</returns>
+        /// <returns>The reference to the assumed implementation core lib.</returns>
         /// <exception cref="ArgumentException">The runtime information is invalid or unsupported.</exception>
         public static AssemblyReference? TryImplFromRuntimeInfo(DotNetRuntimeInfo runtimeInfo)
         {

--- a/src/AsmResolver.DotNet/KnownCorLibs.cs
+++ b/src/AsmResolver.DotNet/KnownCorLibs.cs
@@ -373,7 +373,7 @@ namespace AsmResolver.DotNet
         {
             return (version.Major, version.Minor) switch
             {
-                (1, 0 or 1) or (2, 0 or 1) or (3,0 or 1) => SystemPrivateCoreLib_v4_0_0_0,
+                (1, 0 or 1) or (2, 0 or 1 or 2) or (3,0 or 1) => SystemPrivateCoreLib_v4_0_0_0,
                 (5, 0) => SystemPrivateCoreLib_v5_0_0_0,
                 (6, 0) => SystemPrivateCoreLib_v6_0_0_0,
                 (7, 0) => SystemPrivateCoreLib_v7_0_0_0,

--- a/src/AsmResolver.DotNet/Signatures/Parsing/CustomAttributeArgumentWriter.cs
+++ b/src/AsmResolver.DotNet/Signatures/Parsing/CustomAttributeArgumentWriter.cs
@@ -91,15 +91,7 @@ namespace AsmResolver.DotNet.Signatures.Parsing
 
             if (argumentType.IsTypeOf("System", "Type"))
             {
-                // Type names must include the assembly spec for 'corelib' as well. E.g., this is what Roslyn emits:
-                //
-                // 'System.Collections.Generic.List`1[[System.Uri, System.Runtime, Version=10.0.0.0, Culture=neutral,
-                //  PublicKeyToken=b03f5f7f11d50a3a]], System.Collections, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
-                //
-                // When parsing 'Type' attribute elements, if the assembly spec is not specified, types would otherwise default to 'corlib', but that
-                // would not necessarily be correct. For instance, 'System.Uri' is not in 'System.Private.CoreLib.dll', it's in 'System.Private.Uri.dll'.
-                // Emitting the assembly spec in all cases fixes this issue, and results in the same output as Roslyn.
-                writer.WriteSerString(TypeNameBuilder.GetAssemblyQualifiedName((TypeSignature) element, omitCorLib: false));
+                writer.WriteSerString(TypeNameBuilder.GetAssemblyQualifiedName((TypeSignature) element));
                 return;
             }
 

--- a/src/AsmResolver.DotNet/Signatures/Parsing/CustomAttributeArgumentWriter.cs
+++ b/src/AsmResolver.DotNet/Signatures/Parsing/CustomAttributeArgumentWriter.cs
@@ -91,7 +91,15 @@ namespace AsmResolver.DotNet.Signatures.Parsing
 
             if (argumentType.IsTypeOf("System", "Type"))
             {
-                writer.WriteSerString(TypeNameBuilder.GetAssemblyQualifiedName((TypeSignature) element));
+                // Type names must include the assembly spec for 'corelib' as well. E.g., this is what Roslyn emits:
+                //
+                // 'System.Collections.Generic.List`1[[System.Uri, System.Runtime, Version=10.0.0.0, Culture=neutral,
+                //  PublicKeyToken=b03f5f7f11d50a3a]], System.Collections, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
+                //
+                // When parsing 'Type' attribute elements, if the assembly spec is not specified, types would otherwise default to 'corlib', but that
+                // would not necessarily be correct. For instance, 'System.Uri' is not in 'System.Private.CoreLib.dll', it's in 'System.Private.Uri.dll'.
+                // Emitting the assembly spec in all cases fixes this issue, and results in the same output as Roslyn.
+                writer.WriteSerString(TypeNameBuilder.GetAssemblyQualifiedName((TypeSignature) element, omitCorLib: false));
                 return;
             }
 

--- a/src/AsmResolver.DotNet/Signatures/Parsing/TypeName.cs
+++ b/src/AsmResolver.DotNet/Signatures/Parsing/TypeName.cs
@@ -27,9 +27,9 @@ internal readonly struct TypeName(string? ns, IList<string> names)
             {
                 // If that fails, try corlib.
                 // However, we would prefer to use the implementation corlib for the runtime targeted, not the one it was compiled against.
-                if (contextModule.OriginalTargetRuntime.GetAssumedImplCorLib() is { } implCorLib)
+                if (contextModule.RuntimeContext.RuntimeCorLib is {} runtimeCorLib)
                 {
-                    type.Scope = implCorLib;
+                    type.Scope = runtimeCorLib.ImportWith(contextModule.DefaultImporter);
                     definition = type.Resolve();
                 }
 

--- a/src/AsmResolver.DotNet/Signatures/Parsing/TypeName.cs
+++ b/src/AsmResolver.DotNet/Signatures/Parsing/TypeName.cs
@@ -26,12 +26,24 @@ internal readonly struct TypeName(string? ns, IList<string> names)
             if (definition is null)
             {
                 // If that fails, try corlib.
-                type.Scope = contextModule.CorLibTypeFactory.CorLibScope;
-                definition = type.Resolve();
+                // However, we would prefer to use the implementation corlib for the runtime targeted, not the one it was compiled against.
+                if (contextModule.OriginalTargetRuntime.GetAssumedImplCorLib() is { } implCorLib)
+                {
+                    type.Scope = implCorLib;
+                    definition = type.Resolve();
+                }
 
-                // If both lookups fail, revert to the normal module as scope as a fallback.
                 if (definition is null)
-                    type.Scope = contextModule;
+                {
+                    // fall back to the CorLibScope
+                    type.Scope = contextModule.CorLibTypeFactory.CorLibScope;
+                    definition = type.Resolve();
+                    if (definition is null)
+                    {
+                        // All lookups failed, leave no scope.
+                        type.Scope = null;
+                    }
+                }
             }
         }
 

--- a/src/AsmResolver.DotNet/Signatures/Parsing/TypeName.cs
+++ b/src/AsmResolver.DotNet/Signatures/Parsing/TypeName.cs
@@ -29,20 +29,13 @@ internal readonly struct TypeName(string? ns, IList<string> names)
                 // However, we would prefer to use the implementation corlib for the runtime targeted, not the one it was compiled against.
                 if (contextModule.RuntimeContext.RuntimeCorLib is {} runtimeCorLib)
                 {
-                    type.Scope = runtimeCorLib.ImportWith(contextModule.DefaultImporter);
+                    type.Scope = new AssemblyReference(runtimeCorLib);
                     definition = type.Resolve();
                 }
 
                 if (definition is null)
                 {
-                    // fall back to the CorLibScope
-                    type.Scope = contextModule.CorLibTypeFactory.CorLibScope;
-                    definition = type.Resolve();
-                    if (definition is null)
-                    {
-                        // All lookups failed, leave no scope.
-                        type.Scope = null;
-                    }
+                    type.Scope = null;
                 }
             }
         }

--- a/test/AsmResolver.DotNet.Tests/Signatures/TypeNameBuilderTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Signatures/TypeNameBuilderTest.cs
@@ -75,7 +75,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
             var type = _module.CorLibTypeFactory.Object;
             string name = TypeNameBuilder.GetAssemblyQualifiedName(type);
             Assert.Contains(type.FullName, name);
-            Assert.Contains(type.Scope.Name, name);
+            Assert.Contains(type.Scope!.GetAssembly().FullName, name);
         }
 
         [Fact]

--- a/test/AsmResolver.DotNet.Tests/Signatures/TypeNameBuilderTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Signatures/TypeNameBuilderTest.cs
@@ -70,19 +70,10 @@ namespace AsmResolver.DotNet.Tests.Signatures
         }
 
         [Fact]
-        public void CorLibWithoutFullScope()
-        {
-            var type = _module.CorLibTypeFactory.Object;
-            string name = TypeNameBuilder.GetAssemblyQualifiedName(type, true);
-            Assert.Contains(type.FullName, name);
-            Assert.DoesNotContain(type.Scope.Name, name);
-        }
-
-        [Fact]
         public void CorLibWithFullScope()
         {
             var type = _module.CorLibTypeFactory.Object;
-            string name = TypeNameBuilder.GetAssemblyQualifiedName(type, false);
+            string name = TypeNameBuilder.GetAssemblyQualifiedName(type);
             Assert.Contains(type.FullName, name);
             Assert.Contains(type.Scope.Name, name);
         }
@@ -92,7 +83,7 @@ namespace AsmResolver.DotNet.Tests.Signatures
         {
             // Order matters for Mono
             var type = _module.CorLibTypeFactory.Object;
-            string name = TypeNameBuilder.GetAssemblyQualifiedName(type, false);
+            string name = TypeNameBuilder.GetAssemblyQualifiedName(type);
             Assert.Equal("System.Object, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e", name);
         }
     }


### PR DESCRIPTION
This PR supersedes #646.

Created as a draft as I still need to figure out some tests and need the following question answered: upon failing to resolve from what we assume to be the implementing core library for the target runtime (or if we cannot pick one, in the case of netstandard), what do we do? The implementation I have started this PR with does a second layer of fallback to CorLibScope and attempts a third resolve there, but this means AsmResolver could succeed resolution in more cases than it should. We could do nothing, but this means non-FQ type names to corelib types in netstandard would never be able to resolve without user intervention. If there are any other ideas for how to handle these types, it would be great to hear them, but I think no matter what AsmResolver is going to end up with some odd behavior here (since I don't believe definitive correct behavior exists).