### PR TITLE
Fix double ownership of nested serialized type definitions

### DIFF
--- a/src/AsmResolver.DotNet/Serialized/SerializedTypeDefinition.cs
+++ b/src/AsmResolver.DotNet/Serialized/SerializedTypeDefinition.cs
@@ -28,7 +28,8 @@ namespace AsmResolver.DotNet.Serialized
             _row = row;
             Attributes = row.Attributes;
 
-            ((IOwnedCollectionElement<ModuleDefinition>) this).Owner = context.ParentModule;
+            if (_context.ParentModule.GetParentTypeRid(MetadataToken.Rid) == 0)
+                ((IOwnedCollectionElement<ModuleDefinition>)this).Owner = _context.ParentModule;
         }
 
         /// <inheritdoc />

--- a/test/AsmResolver.DotNet.Tests/TypeDefinitionTest.cs
+++ b/test/AsmResolver.DotNet.Tests/TypeDefinitionTest.cs
@@ -796,5 +796,16 @@ namespace AsmResolver.DotNet.Tests
             type.Namespace = string.Empty;
             Assert.Null(type.Namespace);
         }
+
+        [Fact]
+        public void NestedTypeRemovedFromOwnerShouldHaveNoModule()
+        {
+            var module = ModuleDefinition.FromFile(typeof(TopLevelClass1).Assembly.Location, TestReaderParameters);
+            var nestedType = module.LookupMember<TypeDefinition>(typeof(TopLevelClass1.Nested1).MetadataToken);
+
+            nestedType.DeclaringType!.NestedTypes.Remove(nestedType);
+
+            Assert.Null(nestedType.Module);
+        }
     }
 }


### PR DESCRIPTION
Currently, code that does something like:
```cs
var module = ModuleDefinition.FromFile(@"C:\Users\user\RiderProjects\ConsoleApp1\Test\bin\Debug\net9.0\Test.dll");
var type = module.TopLevelTypes.Single(it => it.Name == "Class1");
var nestedType = type.NestedTypes[0];
type.NestedTypes.Remove(nestedType);
module.TopLevelTypes.Add(nestedType);
```
would throw an exception because the constructor for SerializedTypeDefintion would set _module (through IOwnedCollectionElement) even when the type definition is not "owned" by the module, but instead by its declaring type. Changing it to only do so when no parent type exists fixes the issue.