### PR TITLE
Invert the relationship between IMethodDefOrRef and ICustomAttributeType

### DIFF
--- a/src/AsmResolver.DotNet/ICustomAttributeType.cs
+++ b/src/AsmResolver.DotNet/ICustomAttributeType.cs
@@ -3,7 +3,14 @@ namespace AsmResolver.DotNet
     /// <summary>
     /// Represents a member that can be referenced by a CustomAttributeType coded index,
     /// </summary>
-    public interface ICustomAttributeType : IMethodDefOrRef
+    public interface ICustomAttributeType : IMethodDescriptor, IHasCustomAttribute
     {
+        /// <summary>
+        /// When this member is defined in a type, gets the enclosing type.
+        /// </summary>
+        new ITypeDefOrRef? DeclaringType
+        {
+            get;
+        }
     }
 }

--- a/src/AsmResolver.DotNet/IMethodDefOrRef.cs
+++ b/src/AsmResolver.DotNet/IMethodDefOrRef.cs
@@ -4,14 +4,7 @@ namespace AsmResolver.DotNet
     /// Represents a member that is either a method definition or a method reference, and can be referenced by a
     /// MethodDefOrRef coded index.
     /// </summary>
-    public interface IMethodDefOrRef : IMethodDescriptor, IHasCustomAttribute
+    public interface IMethodDefOrRef : ICustomAttributeType
     {
-        /// <summary>
-        /// When this member is defined in a type, gets the enclosing type.
-        /// </summary>
-        new ITypeDefOrRef? DeclaringType
-        {
-            get;
-        }
     }
 }

--- a/src/AsmResolver.DotNet/MemberReference.cs
+++ b/src/AsmResolver.DotNet/MemberReference.cs
@@ -11,7 +11,7 @@ namespace AsmResolver.DotNet
     /// <summary>
     /// Represents a reference to a method or a field in an (external) .NET assembly.
     /// </summary>
-    public class MemberReference : MetadataMember, ICustomAttributeType, IFieldDescriptor
+    public class MemberReference : MetadataMember, IMethodDefOrRef, IFieldDescriptor
     {
         private readonly LazyVariable<MemberReference, IMemberRefParent?> _parent;
         private readonly LazyVariable<MemberReference, Utf8String?> _name;

--- a/src/AsmResolver.DotNet/MethodDefinition.cs
+++ b/src/AsmResolver.DotNet/MethodDefinition.cs
@@ -21,7 +21,7 @@ namespace AsmResolver.DotNet
         IMemberDefinition,
         IOwnedCollectionElement<TypeDefinition>,
         IMemberRefParent,
-        ICustomAttributeType,
+        IMethodDefOrRef,
         IHasGenericParameters,
         IMemberForwarded,
         IHasSecurityDeclaration,
@@ -564,7 +564,7 @@ namespace AsmResolver.DotNet
 
         ITypeDescriptor? IMemberDescriptor.DeclaringType => DeclaringType;
 
-        ITypeDefOrRef? IMethodDefOrRef.DeclaringType => DeclaringType;
+        ITypeDefOrRef? ICustomAttributeType.DeclaringType => DeclaringType;
 
         TypeDefinition? IOwnedCollectionElement<TypeDefinition>.Owner
         {


### PR DESCRIPTION
Currently ICustomAttributeType is a little annoying to interact with, since `ImportMethod` returns an IMethodDefOrRef, which is not usable as one without a cast, despite all types implementing IMethodDefOrRef also implementing ICustomAttributeType. This PR inverts their relationship to make this not be the case.