### PR TITLE
SignatureComparer ITypeDescriptor and TypeSignature changes

### DIFF
--- a/src/AsmResolver.DotNet/Signatures/SignatureComparer.TypeDefOrRef.cs
+++ b/src/AsmResolver.DotNet/Signatures/SignatureComparer.TypeDefOrRef.cs
@@ -20,13 +20,26 @@ namespace AsmResolver.DotNet.Signatures
             if (x is null || y is null)
                 return false;
 
-            return x switch
+            x = Reduce(x);
+            y = Reduce(y);
+
+            return (x, y) switch
             {
-                InvalidTypeDefOrRef invalidType => Equals(invalidType, y as InvalidTypeDefOrRef),
-                TypeSpecification specification => Equals(specification, y as TypeSpecification),
-                TypeSignature signature => Equals(signature, y as TypeSignature),
-                _ => SimpleTypeEquals(x, y)
+                (null, null) => true,
+                (TypeSignature ts1, TypeSignature ts2) => SignatureEquals(ts1, ts2),
+                (InvalidTypeDefOrRef i1, InvalidTypeDefOrRef i2) => i1.Error == i2.Error,
+                (ITypeDefOrRef or ExportedType, ITypeDefOrRef or ExportedType) => SimpleTypeEquals(x, y),
+                _ => false,
             };
+
+            static ITypeDescriptor? Reduce(ITypeDescriptor? desc)
+            {
+                if (desc is TypeDefOrRefSignature tdors)
+                    desc = tdors.Type;
+                if (desc is TypeSpecification ts)
+                    desc = ts.Signature;
+                return desc;
+            }
         }
 
         /// <inheritdoc />
@@ -94,7 +107,7 @@ namespace AsmResolver.DotNet.Signatures
             if (x is null || y is null)
                 return false;
 
-            return Equals(x.Signature, y.Signature);
+            return SignatureEquals(x.Signature, y.Signature);
         }
 
         /// <inheritdoc />

--- a/src/AsmResolver.DotNet/Signatures/SignatureComparer.TypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/SignatureComparer.TypeSignature.cs
@@ -24,7 +24,9 @@ namespace AsmResolver.DotNet.Signatures
         IEqualityComparer<IEnumerable<TypeSignature>>
     {
         /// <inheritdoc />
-        public bool Equals(TypeSignature? x, TypeSignature? y)
+        public bool Equals(TypeSignature? x, TypeSignature? y) => Equals((ITypeDescriptor?)x, y);
+
+        private bool SignatureEquals(TypeSignature? x, TypeSignature? y)
         {
             if (ReferenceEquals(x, y))
                 return true;
@@ -179,14 +181,7 @@ namespace AsmResolver.DotNet.Signatures
             GetHashCode(obj as TypeSpecificationSignature);
 
         /// <inheritdoc />
-        public bool Equals(TypeDefOrRefSignature? x, TypeDefOrRefSignature? y)
-        {
-            if (ReferenceEquals(x, y))
-                return true;
-            if (x is null || y is null)
-                return false;
-            return SimpleTypeEquals(x.Type, y.Type);
-        }
+        public bool Equals(TypeDefOrRefSignature? x, TypeDefOrRefSignature? y) => Equals(x?.Type, y?.Type);
 
         /// <inheritdoc />
         public int GetHashCode(TypeDefOrRefSignature obj) => SimpleTypeHashCode(obj);

--- a/test/AsmResolver.DotNet.Tests/Signatures/SignatureComparerTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Signatures/SignatureComparerTest.cs
@@ -247,6 +247,15 @@ namespace AsmResolver.DotNet.Tests.Signatures
             Assert.Equal(_comparer.GetHashCode(definition), _comparer.GetHashCode(signature));
         }
 
+        [Fact]
+        public void TypeSigOfTypeRefShouldCompareEqualToTypeRef()
+        {
+            var typeRef = new TypeReference(KnownCorLibs.NetStandard_v2_0_0_0, "System", "Action");
+
+            Assert.Equal((ITypeDescriptor)typeRef, typeRef.ToTypeSignature(false), _comparer);
+            Assert.Equal((ITypeDescriptor)typeRef.ToTypeSignature(false), typeRef, _comparer);
+        }
+
         private class NestedTypes
         {
             public class FirstType


### PR DESCRIPTION
Namely fixes `Equals(typeSig, typeRef)`, but also generally makes an effort to use SimpleTypeEquals only when it makes sense. Leaves all of the hash code logic, since it already did this kind of deep searching via the Name/Namespace/Scope properties which are just forwarders to inner signatures.