### PR TITLE
Avoid unnecessary decoding of instructions and exception handlers

### DIFF
--- a/src/AsmResolver.DotNet/Code/Cil/CilExceptionHandler.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilExceptionHandler.cs
@@ -23,12 +23,15 @@ namespace AsmResolver.DotNet.Code.Cil
         /// Reads a single exception handler from the provided input stream.
         /// </summary>
         /// <param name="module">The module the exception handler is defined in.</param>
-        /// <param name="body">The method body containing the exception handler.</param>
+        /// <param name="instructions">The instructions containing the exception handler.</param>
         /// <param name="reader">The input stream.</param>
         /// <param name="isFat"><c>true</c> if the fat format should be used, <c>false</c> otherwise.</param>
         /// <returns>The exception handler.</returns>
-        public static CilExceptionHandler FromReader(ModuleDefinition module, CilMethodBody body,
-            ref BinaryStreamReader reader, bool isFat)
+        public static CilExceptionHandler FromReader(
+            ModuleDefinition module,
+            CilInstructionCollection instructions,
+            ref BinaryStreamReader reader,
+            bool isFat)
         {
             CilExceptionHandlerType handlerType;
             int tryStartOffset;
@@ -60,10 +63,10 @@ namespace AsmResolver.DotNet.Code.Cil
             var handler = new CilExceptionHandler
             {
                 HandlerType = handlerType,
-                TryStart = body.Instructions.GetLabel(tryStartOffset),
-                TryEnd = body.Instructions.GetLabel(tryEndOffset),
-                HandlerStart = body.Instructions.GetLabel(handlerStartOffset),
-                HandlerEnd = body.Instructions.GetLabel(handlerEndOffset),
+                TryStart = instructions.GetLabel(tryStartOffset),
+                TryEnd = instructions.GetLabel(tryEndOffset),
+                HandlerStart = instructions.GetLabel(handlerStartOffset),
+                HandlerEnd = instructions.GetLabel(handlerEndOffset),
             };
 
             // Interpret last field.
@@ -73,7 +76,7 @@ namespace AsmResolver.DotNet.Code.Cil
                     handler.ExceptionType = member as ITypeDefOrRef;
                     break;
                 case CilExceptionHandlerType.Filter:
-                    handler.FilterStart = body.Instructions.GetByOffset(exceptionTokenOrFilterStart)?.CreateLabel()
+                    handler.FilterStart = instructions.GetByOffset(exceptionTokenOrFilterStart)?.CreateLabel()
                                           ?? new CilOffsetLabel(exceptionTokenOrFilterStart);
                     break;
             }

--- a/src/AsmResolver.DotNet/Code/Cil/CilMethodBodySerializer.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilMethodBodySerializer.cs
@@ -133,7 +133,10 @@ namespace AsmResolver.DotNet.Code.Cil
             catch (Exception ex)
             {
                 context.ErrorListener.RegisterException(new BadImageFormatException(
-                    $"Method body of {sourceBody.OriginalOwner.SafeToString()} contains invalid extra sections.", ex));
+                    $"Method body of {sourceBody.OriginalOwner.SafeToString()} contains an invalid CIL code stream.",
+                    ex
+                ));
+
                 return sourceBody.OriginalRawBody.Code.ToArray();
             }
         }
@@ -167,7 +170,9 @@ namespace AsmResolver.DotNet.Code.Cil
                     catch (Exception ex)
                     {
                         context.ErrorListener.RegisterException(new BadImageFormatException(
-                            $"Method body of {sourceBody.OriginalOwner.SafeToString()} contains an invalid CIL code stream.", ex));
+                            $"Method body of {sourceBody.OriginalOwner.SafeToString()} contains invalid extra sections.",
+                            ex
+                        ));
                     }
                 }
 

--- a/src/AsmResolver.DotNet/Code/Cil/CilMethodBodySerializer.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilMethodBodySerializer.cs
@@ -59,6 +59,16 @@ namespace AsmResolver.DotNet.Code.Cil
             set;
         } = null;
 
+        /// <summary>
+        /// Gets or sets a value indicating whether all method bodies should be fully verified and reassembled,
+        /// including previously serialized method bodies that have not been modified.
+        /// </summary>
+        public bool ForceFullReassemble
+        {
+            get;
+            set;
+        }
+
         /// <inheritdoc />
         public ISegmentReference SerializeMethodBody(MethodBodySerializationContext context, MethodDefinition method)
         {
@@ -67,7 +77,8 @@ namespace AsmResolver.DotNet.Code.Cil
 
             var body = method.CilMethodBody;
 
-            if (body is SerializedCilMethodBody { IsInitialized: false } serializedBody
+            if (!ForceFullReassemble
+                && body is SerializedCilMethodBody { IsInitialized: false } serializedBody
                 && serializedBody.IsFat == serializedBody.OriginalRawBody.IsFat)
             {
                 return FastPatchMethodBody(context, serializedBody);

--- a/src/AsmResolver.DotNet/Code/Cil/SerializedCilMethodBody.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/SerializedCilMethodBody.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using AsmResolver.DotNet.Serialized;
+using AsmResolver.DotNet.Signatures;
+using AsmResolver.IO;
+using AsmResolver.PE.DotNet.Cil;
+using AsmResolver.PE.DotNet.Metadata.Tables;
+
+namespace AsmResolver.DotNet.Code.Cil;
+
+internal sealed class SerializedCilMethodBody : CilMethodBody
+{
+    private readonly ModuleReaderContext _context;
+    private readonly MethodDefinition _originalOwner;
+
+    public SerializedCilMethodBody(
+        ModuleReaderContext context,
+        MethodDefinition owner,
+        CilRawMethodBody rawBody,
+        ICilOperandResolver? operandResolver)
+    {
+        _context = context;
+        _originalOwner = owner;
+        OriginalRawBody = rawBody;
+
+        // Interpret body header.
+        if (rawBody is CilRawFatMethodBody fatBody)
+        {
+            MaxStack = fatBody.MaxStack;
+            InitializeLocals = fatBody.InitLocals;
+            ReadLocalVariables(fatBody);
+        }
+        else
+        {
+            MaxStack = 8;
+            InitializeLocals = false;
+        }
+
+        OperandResolver = operandResolver
+            ?? new PhysicalCilOperandResolver(context.ParentModule, _originalOwner, this);
+    }
+
+    public CilRawMethodBody OriginalRawBody { get; }
+
+    public ICilOperandResolver OperandResolver
+    {
+        get;
+    }
+
+    public override bool IsFat
+    {
+        get
+        {
+            // If we're fully initialized, we cannot assume anything about the original body to be still the same.
+            if (IsInitialized)
+                return base.IsFat;
+
+            // The local variables list can be modified without triggering full initialization, so we need to
+            // check this explicitly.
+            if (LocalVariables.Count > 0)
+                return true;
+
+            // Otherwise, we can safely assume the body hasn't been modified yet.
+            return OriginalRawBody.IsFat;
+        }
+    }
+
+    protected override void Initialize(CilInstructionCollection instructions, List<CilExceptionHandler> exceptionHandlers)
+    {
+        // Decode instructions.
+        ReadInstructions(instructions);
+
+        // Read exception handlers.
+        if (OriginalRawBody is CilRawFatMethodBody fatBody)
+            ReadExceptionHandlers(fatBody, instructions, exceptionHandlers);
+    }
+
+    private void ReadInstructions(CilInstructionCollection result)
+    {
+        try
+        {
+            var reader = OriginalRawBody.Code.CreateReader();
+            var disassembler = new CilDisassembler(reader, OperandResolver);
+            result.AddRange(disassembler.ReadInstructions());
+        }
+        catch (Exception ex)
+        {
+            _context.RegisterException(new BadImageFormatException(
+                $"Method body of {_originalOwner.SafeToString()} contains an invalid CIL code stream.", ex));
+        }
+    }
+
+    private void ReadLocalVariables(CilRawFatMethodBody fatBody)
+    {
+        // Method bodies can have 0 tokens if there are no locals defined.
+        if (fatBody.LocalVarSigToken == MetadataToken.Zero)
+            return;
+
+        // If there is a non-zero token however, it needs to point to a stand-alone signature with a
+        // local variable signature stored in it.
+        if (!_context.ParentModule.TryLookupMember(fatBody.LocalVarSigToken, out var member)
+            || member is not StandAloneSignature { Signature: LocalVariablesSignature localVariablesSignature })
+        {
+            _context.BadImage($"Method body of {_originalOwner.SafeToString()} contains an invalid local variable signature token.");
+            return;
+        }
+
+        // Copy over the local variable types from the signature into the method body.
+        var variableTypes = localVariablesSignature.VariableTypes;
+        for (int i = 0; i < variableTypes.Count; i++)
+            LocalVariables.Add(new CilLocalVariable(variableTypes[i]));
+    }
+
+    private void ReadExceptionHandlers(CilRawFatMethodBody fatBody, CilInstructionCollection instructions, List<CilExceptionHandler> result)
+    {
+        try
+        {
+            for (int i = 0; i < fatBody.ExtraSections.Count; i++)
+            {
+                var section = fatBody.ExtraSections[i];
+                if (section.IsEHTable)
+                {
+                    var reader = new BinaryStreamReader(section.Data);
+                    uint size = section.IsFat
+                        ? CilExceptionHandler.FatExceptionHandlerSize
+                        : CilExceptionHandler.TinyExceptionHandlerSize;
+
+                    while (reader.CanRead(size))
+                    {
+                        result.Add(CilExceptionHandler.FromReader(
+                            _originalOwner.DeclaringModule!, instructions, ref reader,
+                            section.IsFat
+                        ));
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _context.RegisterException(new BadImageFormatException(
+                $"Method body of {_originalOwner.SafeToString()} contains invalid extra sections.", ex));
+        }
+    }
+}

--- a/src/AsmResolver.PE/DotNet/Cil/FastCilReassembler.cs
+++ b/src/AsmResolver.PE/DotNet/Cil/FastCilReassembler.cs
@@ -1,0 +1,203 @@
+using System;
+using AsmResolver.IO;
+using AsmResolver.PE.DotNet.Metadata.Tables;
+
+#if !NETSTANDARD2_0
+using System.Buffers;
+#endif
+
+namespace AsmResolver.PE.DotNet.Cil;
+
+/// <summary>
+/// Provides methods for patching references to metadata in raw method bodies efficiently.
+/// </summary>
+public static class FastCilReassembler
+{
+    private const int TinyExceptionHandlerSize = 2 * sizeof(byte) + 3 * sizeof(ushort) + sizeof(uint);
+    private const int FatExceptionHandlerSize = 6 * sizeof(uint);
+    private const uint ExceptionHandlerType = 0;
+
+    /// <summary>
+    /// Patches the provided code stream.
+    /// </summary>
+    /// <param name="reader">The input code stream to patch.</param>
+    /// <param name="operandResolver">The operand resolver to use for resolving raw operands.</param>
+    /// <param name="writer">The output code stream to write to.</param>
+    /// <param name="operandBuilder">The operand builder to use for obtaining the new raw operands after they have been resolved.</param>
+    public static void RewriteCode(
+        ref BinaryStreamReader reader,
+        ICilOperandResolver operandResolver,
+        BinaryStreamWriter writer,
+        ICilOperandBuilder operandBuilder)
+    {
+#if NETSTANDARD2_0
+        byte[] operandBuffer = new byte[8];
+#else
+        byte[] operandBuffer = ArrayPool<byte>.Shared.Rent(8);
+#endif
+
+        while (reader.CanRead(sizeof(byte)))
+        {
+            var code = ReadWriteOpCode(ref reader, writer);
+
+            MetadataToken token;
+            switch (code.OperandType)
+            {
+                case CilOperandType.InlineNone:
+                    break;
+
+                case CilOperandType.ShortInlineI:
+                case CilOperandType.ShortInlineArgument:
+                case CilOperandType.ShortInlineBrTarget:
+                case CilOperandType.ShortInlineVar:
+                    writer.WriteByte(reader.ReadByte());
+                    break;
+
+                case CilOperandType.InlineVar:
+                case CilOperandType.InlineArgument:
+                    reader.ReadBytes(operandBuffer, 0, sizeof(ushort));
+                    writer.WriteBytes(operandBuffer, 0, sizeof(ushort));
+                    break;
+
+                case CilOperandType.InlineBrTarget:
+                case CilOperandType.InlineI:
+                case CilOperandType.ShortInlineR:
+                    reader.ReadBytes(operandBuffer, 0, sizeof(uint));
+                    writer.WriteBytes(operandBuffer, 0, sizeof(uint));
+                    break;
+
+                case CilOperandType.InlineI8:
+                case CilOperandType.InlineR:
+                    reader.ReadBytes(operandBuffer, 0, sizeof(ulong));
+                    writer.WriteBytes(operandBuffer, 0, sizeof(ulong));
+                    break;
+
+                case CilOperandType.InlineSwitch:
+                    int count = reader.ReadInt32();
+                    writer.WriteInt32(count);
+
+                    int labelsByteCount = count * sizeof(uint);
+                    if (operandBuffer.Length < labelsByteCount)
+                    {
+#if NETSTANDARD2_0
+                        operandBuffer = new byte[labelsByteCount];
+#else
+                        ArrayPool<byte>.Shared.Return(operandBuffer);
+                        operandBuffer = ArrayPool<byte>.Shared.Rent(labelsByteCount);
+#endif
+                    }
+
+                    reader.ReadBytes(operandBuffer, 0, labelsByteCount);
+                    writer.WriteBytes(operandBuffer, 0, labelsByteCount);
+                    break;
+
+                case CilOperandType.InlinePhi:
+                    throw new NotSupportedException();
+
+                case CilOperandType.InlineField:
+                case CilOperandType.InlineSig:
+                case CilOperandType.InlineTok:
+                case CilOperandType.InlineType:
+                case CilOperandType.InlineMethod:
+                    token = reader.ReadUInt32();
+                    if (operandResolver.ResolveMember(token) is { } member)
+                        token = operandBuilder.GetMemberToken(member);
+                    writer.WriteUInt32(token.ToUInt32());
+                    break;
+
+                case CilOperandType.InlineString:
+                    token = reader.ReadUInt32();
+                    if (operandResolver.ResolveString(token) is { } s)
+                        token = operandBuilder.GetStringToken(s);
+                    writer.WriteUInt32(token.ToUInt32());
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+#if !NETSTANDARD2_0
+        ArrayPool<byte>.Shared.Return(operandBuffer);
+#endif
+    }
+
+    private static CilOpCode ReadWriteOpCode(ref BinaryStreamReader reader, BinaryStreamWriter writer)
+    {
+        byte op = reader.ReadByte();
+        writer.WriteByte(op);
+
+        if (op == 0xFE)
+        {
+            byte op2 = reader.ReadByte();
+            writer.WriteByte(op2);
+            return CilOpCodes.MultiByteOpCodes[op2];
+        }
+
+        return CilOpCodes.SingleByteOpCodes[op];
+    }
+
+    /// <summary>
+    /// Patches the provided raw extra section containing exception handlers.
+    /// </summary>
+    /// <param name="reader">The input extra section data to patch.</param>
+    /// <param name="operandResolver">The operand resolver to use for resolving any metadata tokens referenced in the handlers.</param>
+    /// <param name="writer">The output code stream to write to.</param>
+    /// <param name="operandBuilder">The operand builder to use for obtaining the new metadata tokens after they have been resolved.</param>
+    /// <param name="fatFormat"></param>
+    public static void RewriteExceptionHandlerSection(
+        ref BinaryStreamReader reader,
+        ICilOperandResolver operandResolver,
+        BinaryStreamWriter writer,
+        ICilOperandBuilder operandBuilder,
+        bool fatFormat)
+    {
+        int entrySize = fatFormat
+            ? FatExceptionHandlerSize
+            : TinyExceptionHandlerSize;
+
+#if NETSTANDARD2_0
+        byte[] rawEntry = new byte[entrySize];
+#else
+        byte[] rawEntry = ArrayPool<byte>.Shared.Rent(entrySize);
+#endif
+
+        while (reader.CanRead((uint) entrySize))
+        {
+            // Read next handler entry.
+            reader.ReadBytes(rawEntry, 0, entrySize);
+
+            // Carve out handler type.
+            uint handlerType = fatFormat
+                ? (uint) (rawEntry[0] | rawEntry[1] << 8 | rawEntry[2] << 16 | rawEntry[3] << 24)
+                : (uint) (rawEntry[0] | rawEntry[1] << 8);
+
+            // If the handler references an exception type, then we should update the md token.
+            if (handlerType == ExceptionHandlerType)
+            {
+                uint exceptionToken = (uint) (
+                    rawEntry[entrySize - 4]
+                    | rawEntry[entrySize - 3] << 8
+                    | rawEntry[entrySize - 2] << 16
+                    | rawEntry[entrySize - 1] << 24
+                );
+
+                if (operandResolver.ResolveMember(exceptionToken) is { } resolved)
+                {
+                    exceptionToken = operandBuilder.GetMemberToken(resolved).ToUInt32();
+                    rawEntry[entrySize - 4] = (byte) ((exceptionToken) & 0xFF);
+                    rawEntry[entrySize - 3] = (byte) ((exceptionToken >> 8) & 0xFF);
+                    rawEntry[entrySize - 2] = (byte) ((exceptionToken >> 16) & 0xFF);
+                    rawEntry[entrySize - 1] = (byte) ((exceptionToken >> 24) & 0xFF);
+                }
+            }
+
+            // Write back exception handler.
+            writer.WriteBytes(rawEntry, 0, entrySize);
+        }
+
+#if !NETSTANDARD2_0
+        ArrayPool<byte>.Shared.Return(rawEntry);
+#endif
+    }
+}

--- a/src/AsmResolver.PE/DotNet/Cil/FastCilReassembler.cs
+++ b/src/AsmResolver.PE/DotNet/Cil/FastCilReassembler.cs
@@ -21,9 +21,8 @@ public static class FastCilReassembler
     /// Patches the provided code stream.
     /// </summary>
     /// <param name="reader">The input code stream to patch.</param>
-    /// <param name="operandResolver">The operand resolver to use for resolving raw operands.</param>
     /// <param name="writer">The output code stream to write to.</param>
-    /// <param name="operandBuilder">The operand builder to use for obtaining the new raw operands after they have been resolved.</param>
+    /// <param name="tokenRewriter">The function to use for translating old metadata tokens to new metadata tokens.</param>
     public static void RewriteCode(
         ref BinaryStreamReader reader,
         BinaryStreamWriter writer,
@@ -39,7 +38,6 @@ public static class FastCilReassembler
         {
             var code = ReadWriteOpCode(ref reader, writer);
 
-            MetadataToken token;
             switch (code.OperandType)
             {
                 case CilOperandType.InlineNone:
@@ -99,7 +97,7 @@ public static class FastCilReassembler
                 case CilOperandType.InlineType:
                 case CilOperandType.InlineMethod:
                 case CilOperandType.InlineString:
-                    token = reader.ReadUInt32();
+                    MetadataToken token = reader.ReadUInt32();
                     writer.WriteUInt32(tokenRewriter(token).ToUInt32());
                     break;
 
@@ -132,9 +130,8 @@ public static class FastCilReassembler
     /// Patches the provided raw extra section containing exception handlers.
     /// </summary>
     /// <param name="reader">The input extra section data to patch.</param>
-    /// <param name="operandResolver">The operand resolver to use for resolving any metadata tokens referenced in the handlers.</param>
     /// <param name="writer">The output code stream to write to.</param>
-    /// <param name="operandBuilder">The operand builder to use for obtaining the new metadata tokens after they have been resolved.</param>
+    /// <param name="tokenRewriter">The function to use for translating old metadata tokens to new metadata tokens.</param>
     /// <param name="fatFormat"></param>
     public static void RewriteExceptionHandlerSection(
         ref BinaryStreamReader reader,

--- a/test/AsmResolver.Benchmarks/ModuleReadWriteBenchmark.cs
+++ b/test/AsmResolver.Benchmarks/ModuleReadWriteBenchmark.cs
@@ -23,8 +23,8 @@ namespace AsmResolver.Benchmarks
         static ModuleReadWriteBenchmark()
         {
             string runtimePath = DotNetCorePathProvider.Default
-                .GetRuntimePathCandidates("Microsoft.NETCore.App", new Version(3, 1, 0))
-                .FirstOrDefault() ?? throw new InvalidOperationException(".NET Core 3.1 is not installed.");
+                .GetRuntimePathCandidates("Microsoft.NETCore.App", new Version(8, 0))
+                .FirstOrDefault() ?? throw new InvalidOperationException(".NET Core 8.0 is not installed.");
 
             var fs = new ByteArrayFileService();
             SystemPrivateCoreLib = fs.OpenFile(Path.Combine(runtimePath, "System.Private.CoreLib.dll"));

--- a/test/AsmResolver.DotNet.Tests/Code/Cil/CilMethodBodyTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Code/Cil/CilMethodBodyTest.cs
@@ -27,8 +27,11 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
             return type.Methods.First(m => m.Name == name).CilMethodBody;
         }
 
-        private CilMethodBody RebuildAndLookup(CilMethodBody methodBody)
+        private CilMethodBody RebuildAndLookup(CilMethodBody methodBody, bool accessBeforeBuild)
         {
+            if (accessBeforeBuild)
+                _ = methodBody.Instructions;
+
             var module = methodBody.Owner!.DeclaringModule!;
 
             var stream = new MemoryStream();
@@ -45,11 +48,13 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
             Assert.False(body.IsFat);
         }
 
-        [Fact]
-        public void PersistentTinyMethod()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void PersistentTinyMethod(bool accessBeforeBuild)
         {
             var body = ReadMethodBody(nameof(MethodBodyTypes.TinyMethod));
-            var newBody = RebuildAndLookup(body);
+            var newBody = RebuildAndLookup(body, accessBeforeBuild);
 
             Assert.False(newBody.IsFat);
             Assert.Equal(body.Instructions.Count, newBody.Instructions.Count);
@@ -62,11 +67,13 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
             Assert.True(body.IsFat);
         }
 
-        [Fact]
-        public void PersistentFatLongMethod()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void PersistentFatLongMethod(bool accessBeforeBuild)
         {
             var body = ReadMethodBody(nameof(MethodBodyTypes.FatLongMethod));
-            var newBody = RebuildAndLookup(body);
+            var newBody = RebuildAndLookup(body, accessBeforeBuild);
 
             Assert.True(newBody.IsFat);
             Assert.Equal(body.Instructions.Count, newBody.Instructions.Count);
@@ -98,11 +105,13 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
             }
         }
 
-        [Fact]
-        public void PersistentFatMethodWithLocals()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void PersistentFatMethodWithLocals(bool accessBeforeBuild)
         {
             var body = ReadMethodBody(nameof(MethodBodyTypes.FatLongMethod));
-            var newBody = RebuildAndLookup(body);
+            var newBody = RebuildAndLookup(body, accessBeforeBuild);
 
             Assert.True(newBody.IsFat);
             Assert.Equal(
@@ -111,11 +120,33 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
         }
 
         [Fact]
-        public void ReadFatMethodWithExceptionHandler()
+        public void ReadFatMethodWithFinally()
         {
-            var body = ReadMethodBody(nameof(MethodBodyTypes.FatMethodWithExceptionHandler));
+            var body = ReadMethodBody(nameof(MethodBodyTypes.FatMethodWithFinally));
             Assert.True(body.IsFat);
             Assert.Single(body.ExceptionHandlers);
+        }
+
+        [Fact]
+        public void ReadFatMethodWithCatch()
+        {
+            var body = ReadMethodBody(nameof(MethodBodyTypes.FatMethodWithCatch));
+            Assert.True(body.IsFat);
+            Assert.Equal(2, body.ExceptionHandlers.Count);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void PersistentFatMethodWithExceptionHandler(bool accessBeforeBuild)
+        {
+            var body = ReadMethodBody(nameof(MethodBodyTypes.FatMethodWithCatch));
+            var newBody = RebuildAndLookup(body, accessBeforeBuild);
+
+            Assert.True(newBody.IsFat);
+            Assert.Equal(2, newBody.ExceptionHandlers.Count);
+            Assert.Equal(newBody.ExceptionHandlers[0].ExceptionType!.FullName, newBody.ExceptionHandlers[0].ExceptionType!.FullName);
+            Assert.Equal(newBody.ExceptionHandlers[1].ExceptionType!.FullName, newBody.ExceptionHandlers[1].ExceptionType!.FullName);
         }
 
         private static CilMethodBody CreateDummyBody(bool isVoid)

--- a/test/AsmResolver.PE.Tests/DotNet/Cil/FastCilReassemblerTest.cs
+++ b/test/AsmResolver.PE.Tests/DotNet/Cil/FastCilReassemblerTest.cs
@@ -1,0 +1,310 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using AsmResolver.IO;
+using AsmResolver.PE.DotNet.Cil;
+using AsmResolver.PE.DotNet.Metadata.Tables;
+using Xunit;
+
+namespace AsmResolver.PE.Tests.DotNet.Cil;
+
+public class FastCilReassemblerTest
+{
+    private readonly MemoryStreamWriterPool _writerPool = new();
+
+    [Fact]
+    public void RewriteSingleByteOpCodeNoOperands()
+    {
+        byte[] code =
+        [
+            CilOpCodes.Nop.Byte1,
+            CilOpCodes.Nop.Byte1,
+            CilOpCodes.Nop.Byte1,
+            CilOpCodes.Ret.Byte1
+        ];
+
+        var reader = new BinaryStreamReader(code);
+        using var rentedWriter = _writerPool.Rent();
+        FastCilReassembler.RewriteCode(ref reader, new MockOperandResolver(), rentedWriter.Writer, new MockOperandBuilder());
+
+        Assert.Equal(code, rentedWriter.GetData());
+    }
+
+    [Fact]
+    public void RewriteMultiByteOpCodeNoOperands()
+    {
+        byte[] code =
+        [
+            CilOpCodes.Ldarg_0.Byte1,
+            CilOpCodes.Rethrow.Byte1, CilOpCodes.Rethrow.Byte2,
+            CilOpCodes.Ret.Byte1
+        ];
+
+        var reader = new BinaryStreamReader(code);
+        using var rentedWriter = _writerPool.Rent();
+        FastCilReassembler.RewriteCode(ref reader, new MockOperandResolver(), rentedWriter.Writer, new MockOperandBuilder());
+
+        Assert.Equal(code, rentedWriter.GetData());
+    }
+
+    [Fact]
+    public void RewriteInt8Operand()
+    {
+        byte[] code =
+        [
+            CilOpCodes.Ldc_I4_S.Byte1, 0x21,
+            CilOpCodes.Ret.Byte1
+        ];
+
+        var reader = new BinaryStreamReader(code);
+        using var rentedWriter = _writerPool.Rent();
+        FastCilReassembler.RewriteCode(ref reader, new MockOperandResolver(), rentedWriter.Writer, new MockOperandBuilder());
+
+        Assert.Equal(code, rentedWriter.GetData());
+    }
+
+    [Fact]
+    public void RewriteInt16Operand()
+    {
+        byte[] code =
+        [
+            CilOpCodes.Ldarg_S.Byte1, 0x01, 0x00,
+            CilOpCodes.Ret.Byte1
+        ];
+
+        var reader = new BinaryStreamReader(code);
+        using var rentedWriter = _writerPool.Rent();
+        FastCilReassembler.RewriteCode(ref reader, new MockOperandResolver(), rentedWriter.Writer, new MockOperandBuilder());
+
+        Assert.Equal(code, rentedWriter.GetData());
+    }
+
+    [Fact]
+    public void RewriteInt32Operand()
+    {
+        byte[] code =
+        [
+            CilOpCodes.Ldc_I4.Byte1, 0x78, 0x65, 0x43, 0x21,
+            CilOpCodes.Ret.Byte1
+        ];
+
+        var reader = new BinaryStreamReader(code);
+        using var rentedWriter = _writerPool.Rent();
+        FastCilReassembler.RewriteCode(ref reader, new MockOperandResolver(), rentedWriter.Writer, new MockOperandBuilder());
+
+        Assert.Equal(code, rentedWriter.GetData());
+    }
+
+    [Fact]
+    public void RewriteInt64Operand()
+    {
+        byte[] code =
+        [
+            CilOpCodes.Ldc_I8.Byte1, 0xf0, 0xde, 0xbc, 0x9a, 0x78, 0x65, 0x43, 0x21,
+            CilOpCodes.Ret.Byte1
+        ];
+
+        var reader = new BinaryStreamReader(code);
+        using var rentedWriter = _writerPool.Rent();
+        FastCilReassembler.RewriteCode(ref reader, new MockOperandResolver(), rentedWriter.Writer, new MockOperandBuilder());
+
+        Assert.Equal(code, rentedWriter.GetData());
+    }
+
+    [Fact]
+    public void RewriteSwitchOperand()
+    {
+        byte[] code =
+        [
+            CilOpCodes.Switch.Byte1,
+            0x03, 0x00, 0x00, 0x00, // count=3
+            0x00, 0x00, 0x00, 0x00, // +0x00
+            0x01, 0x00, 0x00, 0x00, // +0x01
+            0x02, 0x00, 0x00, 0x00, // +0x02
+            CilOpCodes.Nop.Byte1,
+            CilOpCodes.Nop.Byte1,
+            CilOpCodes.Nop.Byte1,
+            CilOpCodes.Nop.Byte1,
+            CilOpCodes.Ret.Byte1
+        ];
+
+        var reader = new BinaryStreamReader(code);
+        using var rentedWriter = _writerPool.Rent();
+        FastCilReassembler.RewriteCode(ref reader, new MockOperandResolver(), rentedWriter.Writer, new MockOperandBuilder());
+
+        Assert.Equal(code, rentedWriter.GetData());
+    }
+
+    [Fact]
+    public void RewriteTokenOperand()
+    {
+        byte[] code =
+        [
+            CilOpCodes.Ldstr.Byte1, 0x01, 0x00, 0x00, 0x70,
+            CilOpCodes.Ldstr.Byte1, 0x10, 0x00, 0x00, 0x70,
+            CilOpCodes.Ldstr.Byte1, 0x20, 0x00, 0x00, 0x70,
+            CilOpCodes.Pop.Byte1,
+            CilOpCodes.Pop.Byte1,
+            CilOpCodes.Pop.Byte1,
+            CilOpCodes.Ret.Byte1
+        ];
+
+        var reader = new BinaryStreamReader(code);
+        using var rentedWriter = _writerPool.Rent();
+        FastCilReassembler.RewriteCode(
+            ref reader,
+            new MockOperandResolver
+            {
+                { new MetadataToken(TableIndex.String, 0x01), "Hello, world!" },
+                { new MetadataToken(TableIndex.String, 0x10), "Hello, mars!" },
+                { new MetadataToken(TableIndex.String, 0x20), "Hello, jupiter!" },
+            },
+            rentedWriter.Writer,
+            new MockOperandBuilder
+            {
+                { "Hello, world!", new MetadataToken(TableIndex.String, 0x50) },
+                { "Hello, mars!", new MetadataToken(TableIndex.String, 0x80) },
+                { "Hello, jupiter!", new MetadataToken(TableIndex.String, 0xA0) },
+            }
+        );
+
+        Assert.Equal(
+            [
+                CilOpCodes.Ldstr.Byte1, 0x50, 0x00, 0x00, 0x70,
+                CilOpCodes.Ldstr.Byte1, 0x80, 0x00, 0x00, 0x70,
+                CilOpCodes.Ldstr.Byte1, 0xA0, 0x00, 0x00, 0x70,
+                CilOpCodes.Pop.Byte1,
+                CilOpCodes.Pop.Byte1,
+                CilOpCodes.Pop.Byte1,
+                CilOpCodes.Ret.Byte1
+            ],
+            rentedWriter.GetData()
+        );
+    }
+
+    [Fact]
+    public void RewriteTinyExceptionHandlerSection()
+    {
+        byte[] sectionData =
+        [
+            0x00, 0x00,             // handler type = exception
+            0x01, 0x00,             // trystart = IL_0001
+            0x20,                   // trylength = 0x20
+            0x21, 0x00,             // handlerstart = IL_0021
+            0x20,                   // handlerlength = 0x20
+            0x02, 0x00, 0x00, 0x01, // token = 0x01000002
+        ];
+
+        var reader = new BinaryStreamReader(sectionData);
+        using var rentedWriter = _writerPool.Rent();
+        FastCilReassembler.RewriteExceptionHandlerSection(
+            ref reader,
+            new MockOperandResolver
+            {
+                { new MetadataToken(TableIndex.TypeRef, 2), "SomeType" }
+            },
+            rentedWriter.Writer,
+            new MockOperandBuilder
+            {
+                { "SomeType", new MetadataToken(TableIndex.TypeRef, 0x10) }
+            },
+            false
+        );
+
+        Assert.Equal(
+            [
+                0x00, 0x00,             // handler type = exception
+                0x01, 0x00,             // trystart = IL_0001
+                0x20,                   // trylength = 0x20
+                0x21, 0x00,             // handlerstart = IL_0021
+                0x20,                   // handlerlength = 0x20
+                0x10, 0x00, 0x00, 0x01, // token = 0x01000010
+            ],
+            rentedWriter.GetData()
+        );
+    }
+
+    [Fact]
+    public void RewriteFatExceptionHandlerSection()
+    {
+        byte[] sectionData =
+        [
+            0x00, 0x00, 0x00, 0x00, // handler type = exception
+            0x01, 0x00, 0x00, 0x00, // trystart = IL_0001
+            0x20, 0x00, 0x00, 0x00, // trylength = 0x20
+            0x21, 0x00, 0x00, 0x00, // handlerstart = IL_0021
+            0x20, 0x00, 0x00, 0x00, // handlerlength = 0x20
+            0x02, 0x00, 0x00, 0x01, // token = 0x01000002
+        ];
+
+        var reader = new BinaryStreamReader(sectionData);
+        using var rentedWriter = _writerPool.Rent();
+        FastCilReassembler.RewriteExceptionHandlerSection(
+            ref reader,
+            new MockOperandResolver
+            {
+                { new MetadataToken(TableIndex.TypeRef, 2), "SomeType" }
+            },
+            rentedWriter.Writer,
+            new MockOperandBuilder
+            {
+                { "SomeType", new MetadataToken(TableIndex.TypeRef, 0x10) }
+            },
+            true
+        );
+
+        Assert.Equal(
+            [
+                0x00, 0x00, 0x00, 0x00, // handler type = exception
+                0x01, 0x00, 0x00, 0x00, // trystart = IL_0001
+                0x20, 0x00, 0x00, 0x00, // trylength = 0x20
+                0x21, 0x00, 0x00, 0x00, // handlerstart = IL_0021
+                0x20, 0x00, 0x00, 0x00, // handlerlength = 0x20
+                0x10, 0x00, 0x00, 0x01, // token = 0x01000010
+            ],
+            rentedWriter.GetData()
+        );
+    }
+
+    private sealed class MockOperandResolver : ICilOperandResolver, IEnumerable<KeyValuePair<MetadataToken, object>>
+    {
+        private readonly Dictionary<MetadataToken, object?> _operandTokens = new();
+
+        public void Add(MetadataToken token, object key) => _operandTokens.Add(token, key);
+
+        public object? ResolveMember(MetadataToken token)  => _operandTokens.GetValueOrDefault(token);
+
+        public object? ResolveString(MetadataToken token) => _operandTokens.GetValueOrDefault(token);
+
+        public object? ResolveLocalVariable(int index) => index;
+
+        public object? ResolveParameter(int index) => index;
+
+        public IEnumerator<KeyValuePair<MetadataToken, object>> GetEnumerator() => _operandTokens.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class MockOperandBuilder : ICilOperandBuilder, IEnumerable<KeyValuePair<object, MetadataToken>>
+    {
+        private readonly Dictionary<object, MetadataToken> _newTokens = new();
+
+        public void Add(object key, MetadataToken token) => _newTokens.Add(key, token);
+
+        public int GetVariableIndex(object? operand) => Convert.ToInt32(operand);
+
+        public int GetArgumentIndex(object? operand) => Convert.ToInt32(operand);
+
+        public uint GetStringToken(object? operand) => operand is not null && _newTokens.TryGetValue(operand, out var token)
+                ? token.ToUInt32()
+                : 0;
+
+        public MetadataToken GetMemberToken(object? operand) => operand is not null && _newTokens.TryGetValue(operand, out var token)
+            ? token.ToUInt32()
+            : 0;
+
+        public IEnumerator<KeyValuePair<object, MetadataToken>> GetEnumerator() => _newTokens.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable) _newTokens).GetEnumerator();
+    }
+}

--- a/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Methods/MethodBodyTypes.cs
+++ b/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Methods/MethodBodyTypes.cs
@@ -1,4 +1,6 @@
 using System;
+using System.IO;
+using System.Net;
 
 namespace AsmResolver.DotNet.TestCases.Methods
 {
@@ -11,7 +13,7 @@ namespace AsmResolver.DotNet.TestCases.Methods
         public static void FatMethodWithLocals()
         {
             int x = int.Parse(Console.ReadLine());
-            
+
             // HACK: We include some additional code to prevent Release mode optimizing away the local variable.
             if (x < 10)
                 Console.WriteLine(x);
@@ -42,7 +44,7 @@ namespace AsmResolver.DotNet.TestCases.Methods
             Console.WriteLine(v10);
         }
 
-        public static void FatMethodWithExceptionHandler()
+        public static void FatMethodWithFinally()
         {
             try
             {
@@ -51,6 +53,22 @@ namespace AsmResolver.DotNet.TestCases.Methods
             finally
             {
                 Console.WriteLine("Finally");
+            }
+        }
+
+        public static void FatMethodWithCatch()
+        {
+            try
+            {
+                Console.WriteLine("Try");
+            }
+            catch (IOException ex)
+            {
+                Console.WriteLine("IOException");
+            }
+            catch (WebException ex)
+            {
+                Console.WriteLine("WebException");
             }
         }
 

--- a/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Methods/MethodBodyTypes.cs
+++ b/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Methods/MethodBodyTypes.cs
@@ -62,11 +62,11 @@ namespace AsmResolver.DotNet.TestCases.Methods
             {
                 Console.WriteLine("Try");
             }
-            catch (IOException ex)
+            catch (IOException)
             {
                 Console.WriteLine("IOException");
             }
-            catch (WebException ex)
+            catch (WebException)
             {
                 Console.WriteLine("WebException");
             }


### PR DESCRIPTION
Currently, on .NET module build, AsmResolver always fully decodes all method bodies, including all instructions and exception handlers. However, many assembly processing workloads do not require editing every method body (if at all). For example, a symbol renamer does not ever touch any CIL instruction and only assignes new names to metadata. This results in a lot of wasted processing time and memory consumption, particularly on allocations of `CilInstruction` objects.

This PR addresses this by purposefully avoiding a full decoding of method bodies if they haven't been accessed by the user. The only thing we actually need to do to keep things consistent is patch any possible metadata tokens in a raw code stream or exception handler that may have changed after a rebuild.

## Includes:
- `FastCilReassembler`: A raw CIL code and section rewriter that can patch metadata token operands without creating and allocating `CilInstruction`s. 
- `SerializedCilMethodBody`: A lazily initialized variant of `CilMethodBody` that only decodes all instructions and exception handlers when these are accessed.
- `CilMethodBodySerializer` now uses `FastCilReassembler` on a `SerializedCilMethodBody` if it wasn't fully initialized yet, saving many allocations on `CilInstruction`

## Benchmarks

Benchmarks indicate a marginal overhead with significant performance improvements for processing larger binaries (such as roundtripping `System.Private.CoreLib.dll` with allocation reductions up to 30%):

<details>
<summary>Full Statistics</summary>

| Method                         | Job          | Mean          | Error         | StdDev        | Ratio | RatioSD | Gen0       | Gen1       | Gen2      | Allocated    | Alloc Ratio |
|------------------------------- |------------- |--------------:|--------------:|--------------:|------:|--------:|-----------:|-----------:|----------:|-------------:|------------:|
| HelloWorld_Read                | DefaultJob   |      14.89 us |      0.280 us |      0.287 us |  1.03 |    0.04 |     4.9591 |     0.5341 |         - |     40.54 KB |        1.00 |
| HelloWorld_Read                | 6.0.0-beta.4 |      14.52 us |      0.289 us |      0.514 us |  1.00 |    0.05 |     4.9591 |     0.5341 |         - |     40.54 KB |        1.00 |
|                                |              |               |               |               |       |         |            |            |           |              |             |
| HelloWorld_ReadWrite           | DefaultJob   |     229.41 us |      4.572 us |      6.842 us |  0.99 |    0.03 |    32.7148 |     7.8125 |         - |    270.12 KB |        1.00 |
| HelloWorld_ReadWrite           | 6.0.0-beta.4 |     231.94 us |      4.547 us |      4.670 us |  1.00 |    0.03 |    33.2031 |     6.8359 |         - |    271.35 KB |        1.00 |
|                                |              |               |               |               |       |         |            |            |           |              |             |
| CrackMe_Read                   | DefaultJob   |      14.94 us |      0.297 us |      0.365 us |  1.00 |    0.03 |     5.0201 |     0.5341 |         - |     41.05 KB |        1.00 |
| CrackMe_Read                   | 6.0.0-beta.4 |      14.98 us |      0.192 us |      0.180 us |  1.00 |    0.02 |     5.0201 |     0.5341 |         - |     41.05 KB |        1.00 |
|                                |              |               |               |               |       |         |            |            |           |              |             |
| CrackMe_ReadWrite              | DefaultJob   |     238.48 us |      3.866 us |      3.797 us |  0.97 |    0.02 |    34.1797 |     7.8125 |         - |     281.1 KB |        0.98 |
| CrackMe_ReadWrite              | 6.0.0-beta.4 |     244.96 us |      3.119 us |      2.918 us |  1.00 |    0.02 |    34.1797 |     8.7891 |         - |    286.21 KB |        1.00 |
|                                |              |               |               |               |       |         |            |            |           |              |             |
| ManyMethods_Read               | DefaultJob   |      14.35 us |      0.235 us |      0.220 us |  0.99 |    0.02 |     4.9591 |     0.5035 |         - |     40.55 KB |        1.00 |
| ManyMethods_Read               | 6.0.0-beta.4 |      14.55 us |      0.172 us |      0.161 us |  1.00 |    0.02 |     4.9591 |     0.5035 |         - |     40.55 KB |        1.00 |
|                                |              |               |               |               |       |         |            |            |           |              |             |
| ManyMethods_ReadWrite          | DefaultJob   |  55,540.47 us |  1,109.128 us |  1,883.383 us |  0.79 |    0.07 |  3500.0000 |  2750.0000 |  875.0000 |  28903.22 KB |        0.84 |
| ManyMethods_ReadWrite          | 6.0.0-beta.4 |  70,733.44 us |  1,991.640 us |  5,841.137 us |  1.01 |    0.12 |  4125.0000 |  2750.0000 |  875.0000 |  34297.13 KB |        1.00 |
|                                |              |               |               |               |       |         |            |            |           |              |             |
| SystemPrivateCoreLib_ReadWrite | DefaultJob   | 654,221.89 us | 12,869.726 us | 12,639.792 us |  0.84 |    0.02 | 29000.0000 | 16000.0000 | 3000.0000 | 262321.64 KB |        0.82 |
| SystemPrivateCoreLib_ReadWrite | 6.0.0-beta.4 | 776,946.15 us | 12,048.013 us | 11,269.719 us |  1.00 |    0.02 | 36000.0000 | 20000.0000 | 3000.0000 | 321854.75 KB |        1.00 |
|                                |              |               |               |               |       |         |            |            |           |              |             |
| SystemRuntimeLib_ReadWrite     | DefaultJob   |   1,226.32 us |     21.879 us |     20.466 us |  1.06 |    0.03 |   187.5000 |   181.6406 |         - |   1534.44 KB |        1.00 |
| SystemRuntimeLib_ReadWrite     | 6.0.0-beta.4 |   1,152.24 us |     22.397 us |     23.000 us |  1.00 |    0.03 |   187.5000 |   181.6406 |         - |   1534.44 KB |        1.00 |
|                                |              |               |               |               |       |         |            |            |           |              |             |
| SystemPrivateXml_ReadWrite     | DefaultJob   | 316,328.46 us |  5,015.268 us |  3,915.592 us |  0.74 |    0.01 | 12000.0000 |  8000.0000 | 2000.0000 | 115599.23 KB |        0.70 |
| SystemPrivateXml_ReadWrite     | 6.0.0-beta.4 | 425,017.10 us |  7,197.898 us |  5,619.645 us |  1.00 |    0.02 | 18000.0000 | 11000.0000 | 2000.0000 | 164482.58 KB |        1.00 |

</details>


## Drawbacks:
- Existing method bodies are now implicitly assumed "correct", as verifiers are only triggered when the method body is fully decoded. We could introduce a method body serializer flag to always force decode all method bodies fully.