### PR TITLE
Add constructor overload for ExportedType

### DIFF
--- a/src/AsmResolver.DotNet/ExportedType.cs
+++ b/src/AsmResolver.DotNet/ExportedType.cs
@@ -38,17 +38,6 @@ namespace AsmResolver.DotNet
         /// <param name="implementation">The file containing the type.</param>
         /// <param name="ns">The namespace of the type.</param>
         /// <param name="name">The name of the type.</param>
-        public ExportedType(IImplementation? implementation, string? ns, string? name)
-            : this(implementation, (Utf8String?)ns, (Utf8String?)name)
-        {
-        }
-
-        /// <summary>
-        /// Creates a new exported type reference.
-        /// </summary>
-        /// <param name="implementation">The file containing the type.</param>
-        /// <param name="ns">The namespace of the type.</param>
-        /// <param name="name">The name of the type.</param>
         public ExportedType(IImplementation? implementation, Utf8String? ns, Utf8String? name)
             : this(new MetadataToken(TableIndex.ExportedType, 1))
         {

--- a/src/AsmResolver.DotNet/ExportedType.cs
+++ b/src/AsmResolver.DotNet/ExportedType.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading;
 using AsmResolver.Collections;
 using AsmResolver.DotNet.Signatures;
@@ -39,6 +39,17 @@ namespace AsmResolver.DotNet
         /// <param name="ns">The namespace of the type.</param>
         /// <param name="name">The name of the type.</param>
         public ExportedType(IImplementation? implementation, string? ns, string? name)
+            : this(implementation, (Utf8String?)ns, (Utf8String?)name)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new exported type reference.
+        /// </summary>
+        /// <param name="implementation">The file containing the type.</param>
+        /// <param name="ns">The namespace of the type.</param>
+        /// <param name="name">The name of the type.</param>
+        public ExportedType(IImplementation? implementation, Utf8String? ns, Utf8String? name)
             : this(new MetadataToken(TableIndex.ExportedType, 1))
         {
             Implementation = implementation;


### PR DESCRIPTION
This PR adds a constructor overload for `ExportedType` to allow passing `Utf8String` values without round-tripping.