### PR TITLE
Optimize `BinaryStreamWriter`

### DIFF
--- a/src/AsmResolver/IO/BinaryStreamWriter.cs
+++ b/src/AsmResolver/IO/BinaryStreamWriter.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+using System.Buffers;
 using System.Buffers.Binary;
 #endif
 
@@ -455,6 +456,9 @@ namespace AsmResolver.IO
         /// Writes an UTF8 string to the stream.
         /// </summary>
         /// <param name="value">The string to write.</param>
+#if NET10_0_OR_GREATER
+        [SkipLocalsInit]
+#endif
         public void WriteSerString(string? value)
         {
             if (value is null)
@@ -463,9 +467,26 @@ namespace AsmResolver.IO
                 return;
             }
 
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+            int maxByteCount = Encoding.UTF8.GetMaxByteCount(value.Length);
+            byte[]? utf8Array = null;
+            Span<byte> utf8Span = maxByteCount <= 256
+                ? stackalloc byte[maxByteCount]
+                : (utf8Array = ArrayPool<byte>.Shared.Rent(maxByteCount));
+            int bytesWritten = Encoding.UTF8.GetBytes(value, utf8Span);
+
+            WriteCompressedUInt32((uint)bytesWritten);
+            WriteBytes(utf8Span[..bytesWritten]);
+
+            if (utf8Array is not null)
+            {
+                ArrayPool<byte>.Shared.Return(utf8Array);
+            }
+#else
             byte[] bytes = Encoding.UTF8.GetBytes(value);
             WriteCompressedUInt32((uint)bytes.Length);
             WriteBytes(bytes);
+#endif
         }
 
         /// <summary>
@@ -479,11 +500,31 @@ namespace AsmResolver.IO
         /// </summary>
         /// <param name="value">The string to write.</param>
         /// <param name="encoding">The encoding to use.</param>
+#if NET10_0_OR_GREATER
+        [SkipLocalsInit]
+#endif
         public void WriteBinaryFormatterString(string value, Encoding encoding)
         {
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+            int maxByteCount = encoding.GetMaxByteCount(value.Length);
+            byte[]? byteArray = null;
+            Span<byte> byteSpan = maxByteCount <= 256
+                ? stackalloc byte[maxByteCount]
+                : (byteArray = ArrayPool<byte>.Shared.Rent(maxByteCount));
+            int bytesWritten = encoding.GetBytes(value, byteSpan);
+
+            Write7BitEncodedInt32(bytesWritten);
+            WriteBytes(byteSpan[..bytesWritten]);
+
+            if (byteArray is not null)
+            {
+                ArrayPool<byte>.Shared.Return(byteArray);
+            }
+#else
             byte[] data = encoding.GetBytes(value);
             Write7BitEncodedInt32(data.Length);
             WriteBytes(data);
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
This PR includes two optimizations for `BinaryStreamWriter`:
- On .NET 10, replaces the array with an inline array, to make that write optimization zero-alloc
- On .NS2.1/NC3.1 and above, it uses `stackalloc` or pooled arrays to write strings, to avoid allocating