### PR TITLE
Add WindowsRuntime attribute and property

### DIFF
--- a/src/AsmResolver.DotNet/TypeDefinition.cs
+++ b/src/AsmResolver.DotNet/TypeDefinition.cs
@@ -416,6 +416,16 @@ namespace AsmResolver.DotNet
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the current type is a Windows Runtime type.
+        /// </summary>
+        public bool IsWindowsRuntime
+        {
+            get => (Attributes & TypeAttributes.WindowsRuntime) != 0;
+            set => Attributes = (Attributes & ~TypeAttributes.WindowsRuntime)
+                                | (value ? TypeAttributes.WindowsRuntime : 0);
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating the runtime should initialize the class before any time before the first
         /// static field access.
         /// </summary>

--- a/src/AsmResolver.PE/DotNet/Metadata/Tables/TypeAttributes.cs
+++ b/src/AsmResolver.PE/DotNet/Metadata/Tables/TypeAttributes.cs
@@ -123,6 +123,11 @@ namespace AsmResolver.PE.DotNet.Metadata.Tables
         CustomFormatClass = 0x00030000,
 
         /// <summary>
+        /// The type is a Windows Runtime type.
+        /// </summary>
+        WindowsRuntime = 0x0004000,
+
+        /// <summary>
         /// Provides a bitmask for obtaining flag related to string format.
         /// </summary>
         StringFormatMask = 0x00030000,


### PR DESCRIPTION
Introduce a WindowsRuntime flag to the TypeAttributes enum and add an IsWindowsRuntime boolean property on TypeDefinition. The property reads and updates the Attributes bitmask using TypeAttributes.WindowsRuntime, enabling types to be marked and queried as Windows Runtime types.