### PR TITLE
Avoid unnecessary string allocations in CorLibTypeFactory.FromType

### DIFF
--- a/src/AsmResolver.DotNet/Signatures/CorLibTypeFactory.cs
+++ b/src/AsmResolver.DotNet/Signatures/CorLibTypeFactory.cs
@@ -153,9 +153,17 @@ namespace AsmResolver.DotNet.Signatures
         /// <returns>The corlib type, or <c>null</c> if none was found.</returns>
         public CorLibTypeSignature? FromType(ITypeDescriptor type)
         {
-            return type is CorLibTypeSignature typeSig
-                ? FromElementType(typeSig.ElementType)
-                : FromName(type.Namespace, type.Name);
+            if (type is CorLibTypeSignature typeSig)
+                return FromElementType(typeSig.ElementType);
+
+            // Corlib types are always encoded as TypeDefOrRefSignature (ValueType/Class).
+            // Other TypeSignatures are structural types (arrays, pointers, byrefs, etc.) that can
+            // never match. Skip them to avoid allocating a string from their Name property
+            // (e.g. $"{BaseType.Name}[]") when it's unnecessary.
+            if (type is TypeSignature { ElementType: not (ElementType.ValueType or ElementType.Class) })
+                return null;
+
+            return FromName(type.Namespace, type.Name);
         }
 
         /// <summary>


### PR DESCRIPTION
Before:
<img width="1312" height="161" alt="image" src="https://github.com/user-attachments/assets/825ee864-6a08-40e2-85f4-4f999ab8597c" />
After:
<img width="833" height="27" alt="image" src="https://github.com/user-attachments/assets/ce186209-c151-4eb0-9208-e0da4c19f885" />

Some type signatures (e.g. SzArray) aren't corlib types, and accessing their `Name` property can allocate a string. This PR ensures a type can actually be a corlib type before matching its name.

I believe the logic is correct for this. I would welcome a second set of eyes though.