### PR TITLE
Fix DotNetEntryPoint.cs error CS9336: The pattern is redundant.

### DIFF
--- a/src/AsmResolver.PE/DotNet/DotNetEntryPoint.cs
+++ b/src/AsmResolver.PE/DotNet/DotNetEntryPoint.cs
@@ -18,7 +18,7 @@ namespace AsmResolver.PE.DotNet
         /// </param>
         public DotNetEntryPoint(MetadataToken token)
         {
-            if (token != MetadataToken.Zero && token.Table is not TableIndex.Method or TableIndex.File)
+            if (token != MetadataToken.Zero && token.Table is not (TableIndex.Method or TableIndex.File))
                 throw new ArgumentException("Managed entry points can only be metadata tokens referencing a method or a file.");
 
             MetadataToken = token;


### PR DESCRIPTION
Fix for 
`\AsmResolver\src\AsmResolver.PE\DotNet\DotNetEntryPoint.cs`(21,88): error CS9336: The pattern is redundant.
  AsmResolver.PE net9.0 failed with 1 error(s) (3.0s)

The fix adds parentheses around the `or` pattern: `is not (TableIndex.Method or TableIndex.File)`.

What was wrong: The original `is not TableIndex.Method or TableIndex.File` was parsed by C# as `(is not TableIndex.Method) or (is TableIndex.File)` due to operator precedence. The `or TableIndex.File` arm was always redundant (if table is `File`, the first part `is not Method` is already true), hence CS9336.

The fix: `is not (TableIndex.Method or TableIndex.File)` correctly groups the pattern to mean "table is neither Method nor File", which matches the intended validation logic.