### PR TITLE
BUGFIX: Address target framework detection regressions

### DIFF
--- a/src/AsmResolver.DotNet/Config/Json/RuntimeOptions.cs
+++ b/src/AsmResolver.DotNet/Config/Json/RuntimeOptions.cs
@@ -81,6 +81,19 @@ namespace AsmResolver.DotNet.Config.Json
         }
 
         /// <summary>
+        /// Gets an array (added in .NET Core 3.0) of shared frameworks when activating the application.
+        /// </summary>
+        /// <remarks>
+        /// The presence of this section (or another framework in the new "framework" section) indicates
+        /// that the application is a framework-dependent app.
+        /// </remarks>
+        public List<RuntimeFramework>? Frameworks
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Gets an optional array (added in .NET Core 3.0) that allows multiple frameworks to be specified.
         /// </summary>
         public List<RuntimeFramework>? IncludedFrameworks
@@ -130,6 +143,13 @@ namespace AsmResolver.DotNet.Config.Json
             if (node.HasKey("framework"))
                 result.Framework = RuntimeFramework.FromJsonNode(node["framework"]);
 
+            if (node.HasKey("frameworks"))
+            {
+                result.Frameworks = new List<RuntimeFramework>();
+                foreach (var item in node["frameworks"].Values)
+                    result.Frameworks.Add(RuntimeFramework.FromJsonNode(item));
+            }
+
             if (node.HasKey("includedFrameworks"))
             {
                 result.IncludedFrameworks = new List<RuntimeFramework>();
@@ -178,9 +198,15 @@ namespace AsmResolver.DotNet.Config.Json
             if (Framework is { } framework)
                 yield return framework;
 
-            if (IncludedFrameworks is { } frameworks)
+            if (Frameworks is { } frameworks)
             {
                 foreach (var includedFramework in frameworks)
+                    yield return includedFramework;
+            }
+
+            if (IncludedFrameworks is { } includedFrameworks)
+            {
+                foreach (var includedFramework in includedFrameworks)
                     yield return includedFramework;
             }
         }

--- a/src/AsmResolver.DotNet/DotNetCoreAssemblyResolver.cs
+++ b/src/AsmResolver.DotNet/DotNetCoreAssemblyResolver.cs
@@ -64,7 +64,7 @@ namespace AsmResolver.DotNet
             if (options is not null)
             {
                 // Self-contained -> prefer the source directory.
-                if (options.Framework is not null && !string.IsNullOrEmpty(sourceDirectory))
+                if (options.Framework is null && options.Frameworks is null && !string.IsNullOrEmpty(sourceDirectory))
                     _runtimeDirectories.Add(sourceDirectory!);
 
                 // Order frameworks such that .NETCore.App is last.

--- a/src/AsmResolver.DotNet/KnownCorLibs.cs
+++ b/src/AsmResolver.DotNet/KnownCorLibs.cs
@@ -45,6 +45,15 @@ namespace AsmResolver.DotNet
             ]);
 
         /// <summary>
+        /// References mscorlib.dll, Version=255.255.255.255, PublicKeyToken=B77A5C561934E089. This is used by .NET
+        /// assemblies targeting Windows Runtime (WinRT).
+        /// </summary>
+        public static readonly AssemblyReference MsCorLib_v255_255_255_255 = new("mscorlib",
+            new Version(255, 255, 255, 255), false, [
+                0xB7, 0x7A, 0x5C, 0x56, 0x19, 0x34, 0xE0, 0x89
+            ]);
+
+        /// <summary>
         /// References System.Private.CoreLib.dll, Version=4.0.0.0, PublicKeyToken=7CEC85D7BEA7798E. This is used by .NET
         /// assemblies targeting .NET Core 1.0 and later.
         /// </summary>
@@ -268,6 +277,7 @@ namespace AsmResolver.DotNet
                 NetStandard_v2_1_0_0,
                 MsCorLib_v2_0_0_0,
                 MsCorLib_v4_0_0_0,
+                MsCorLib_v255_255_255_255,
                 SystemRuntime_v4_0_0_0,
                 SystemRuntime_v4_0_10_0,
                 SystemRuntime_v4_0_20_0,

--- a/src/AsmResolver.DotNet/KnownRuntimeVersions.cs
+++ b/src/AsmResolver.DotNet/KnownRuntimeVersions.cs
@@ -1,18 +1,18 @@
 namespace AsmResolver.DotNet
 {
     /// <summary>
-    /// Provides strings of known runtime version numbers. 
+    /// Provides strings of known runtime version numbers.
     /// </summary>
     public static class KnownRuntimeVersions
     {
         // String values are taken from the original sscli (rotor) documentation files (sscli/docs/relnotes.html),
         // and from sample binaries.
-        
+
         /// <summary>
         /// Indicates the ECMA 2002 runtime version string.
         /// </summary>
         public const string Ecma2002 = "Standard CLI 2002";
-        
+
         /// <summary>
         /// Indicates the ECMA 2005 runtime version string.
         /// </summary>
@@ -22,12 +22,12 @@ namespace AsmResolver.DotNet
         /// Indicates the Microsoft .NET Framework 1.0 runtime version string.
         /// </summary>
         public const string Clr10 = "v1.0.3705";
-        
+
         /// <summary>
         /// Indicates the Microsoft .NET Framework 1.1 runtime version string.
         /// </summary>
         public const string Clr11 = "v1.1.4322";
-        
+
         /// <summary>
         /// Indicates the Microsoft .NET Framework 2.0 runtime version string.
         /// </summary>
@@ -37,5 +37,20 @@ namespace AsmResolver.DotNet
         /// Indicates the Microsoft .NET Framework 4.0 runtime version string.
         /// </summary>
         public const string Clr40 = "v4.0.30319";
+
+        /// <summary>
+        /// Indicates the Microsoft .NET Windows Runtime 1.2 (WinRT) version string.
+        /// </summary>
+        public const string WindowsRuntime12 = "WindowsRuntime 1.2";
+
+        /// <summary>
+        /// Indicates the Microsoft .NET Windows Runtime 1.3 (WinRT) version string.
+        /// </summary>
+        public const string WindowsRuntime13 = "WindowsRuntime 1.3";
+
+        /// <summary>
+        /// Indicates the Microsoft .NET Windows Runtime 1.4 (WinRT) version string.
+        /// </summary>
+        public const string WindowsRuntime14 = "WindowsRuntime 1.4";
     }
 }

--- a/src/AsmResolver.DotNet/TargetRuntimeProber.cs
+++ b/src/AsmResolver.DotNet/TargetRuntimeProber.cs
@@ -229,6 +229,12 @@ public static class TargetRuntimeProber
 
     private static DotNetRuntimeInfo ToDotNetRuntimeInfo(string name, int major, int minor, int build, int revision)
     {
+        // mscorlib v255.255.255.255 is used in WinRT (earliest supported framework is .NET FX 4.5).
+        // TODO: We may want to introduce a separate runtime info for this instead, as it will require some additional
+        //       changes to the resolver (i.e., include WinMetadata search dirs).
+        if (name == "mscorlib" && major == 255 && minor == 255 && build == 255 && revision == 255)
+            return DotNetRuntimeInfo.NetFramework(4, 5);
+
         // .NETCoreApp uses 1:1 version correspondence of corlib since .NET 5.
         if (major >= 5)
             return DotNetRuntimeInfo.NetCoreApp(major, minor);

--- a/test/AsmResolver.DotNet.Tests/AssemblyResolverTest.cs
+++ b/test/AsmResolver.DotNet.Tests/AssemblyResolverTest.cs
@@ -378,10 +378,10 @@ namespace AsmResolver.DotNet.Tests
                     {
                         "runtimeOptions": {
                             "tfm": "net10.0",
-                            "includedFrameworks": [{
+                            "framework": {
                                 "name": "Microsoft.NETCore.App",
                                 "version": "10.0.0"
-                            }]
+                            }
                         }
                     }
                     """
@@ -421,10 +421,10 @@ namespace AsmResolver.DotNet.Tests
                     {
                         "runtimeOptions": {
                             "tfm": "net10.0",
-                            "framework": {
+                            "includedFrameworks": [{
                                 "name": "Microsoft.NETCore.App",
                                 "version": "10.0.0"
-                            }
+                            }]
                         }
                     }
                     """

--- a/test/AsmResolver.DotNet.Tests/Config/Json/RuntimeConfigurationTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Config/Json/RuntimeConfigurationTest.cs
@@ -10,15 +10,19 @@ namespace AsmResolver.DotNet.Tests.Config.Json
         [Fact]
         public void ReadSingleFramework()
         {
-            var config = RuntimeConfiguration.FromJson(@"{
-    ""runtimeOptions"": {
-        ""tfm"": ""netcoreapp3.1"",
-        ""framework"": {
-            ""name"": ""Microsoft.NETCore.App"",
-            ""version"": ""3.1.0""
-        }
-    }
-}");
+            var config = RuntimeConfiguration.FromJson(
+                """
+                {
+                    "runtimeOptions": {
+                        "tfm": "netcoreapp3.1",
+                        "framework": {
+                            "name": "Microsoft.NETCore.App",
+                            "version": "3.1.0"
+                        }
+                    }
+                }
+                """
+            );
 
             Assert.NotNull(config);
             Assert.NotNull(config.RuntimeOptions);
@@ -33,21 +37,56 @@ namespace AsmResolver.DotNet.Tests.Config.Json
         [Fact]
         public void ReadMultipleFrameworks()
         {
-            var config = RuntimeConfiguration.FromJson(@"{
-    ""runtimeOptions"": {
-        ""tfm"": ""net5.0"",
-        ""includedFrameworks"": [
-            {
-                ""name"": ""Microsoft.NETCore.App"",
-                ""version"": ""5.0.0""
-            },
-            {
-                ""name"": ""Microsoft.WindowsDesktop.App"",
-                ""version"": ""5.0.0""
-            }
-        ]
-    }
-}");
+            var config = RuntimeConfiguration.FromJson(
+                """
+                {
+                    "runtimeOptions": {
+                        "tfm": "net5.0",
+                        "frameworks": [
+                            {
+                                "name": "Microsoft.NETCore.App",
+                                "version": "5.0.0"
+                            },
+                            {
+                                "name": "Microsoft.WindowsDesktop.App",
+                                "version": "5.0.0"
+                            }
+                        ]
+                    }
+                }
+                """);
+
+            Assert.NotNull(config);
+            Assert.NotNull(config.RuntimeOptions);
+            Assert.Equal("net5.0", config.RuntimeOptions.TargetFrameworkMoniker);
+
+            var frameworks = config.RuntimeOptions.Frameworks;
+            Assert.NotNull(frameworks);
+            Assert.Contains(frameworks, framework => framework is { Name: "Microsoft.NETCore.App", Version: "5.0.0" });
+            Assert.Contains(frameworks, framework => framework is { Name: "Microsoft.WindowsDesktop.App", Version: "5.0.0" });
+        }
+
+        [Fact]
+        public void ReadMultipleIncludedFrameworks()
+        {
+            var config = RuntimeConfiguration.FromJson(
+                """
+                {
+                    "runtimeOptions": {
+                        "tfm": "net5.0",
+                        "includedFrameworks": [
+                            {
+                                "name": "Microsoft.NETCore.App",
+                                "version": "5.0.0"
+                            },
+                            {
+                                "name": "Microsoft.WindowsDesktop.App",
+                                "version": "5.0.0"
+                            }
+                        ]
+                    }
+                }
+                """);
 
             Assert.NotNull(config);
             Assert.NotNull(config.RuntimeOptions);
@@ -62,19 +101,23 @@ namespace AsmResolver.DotNet.Tests.Config.Json
         [Fact]
         public void ReadConfigurationProperties()
         {
-            var config = RuntimeConfiguration.FromJson(@"{
-    ""runtimeOptions"": {
-        ""tfm"": ""netcoreapp3.1"",
-        ""framework"": {
-            ""name"": ""Microsoft.NETCore.App"",
-            ""version"": ""3.1.0""
-        },
-        ""configProperties"": {
-            ""System.GC.Concurrent"": false,
-            ""System.Threading.ThreadPool.MinThreads"": 4
-        }
-    }
-}");
+            var config = RuntimeConfiguration.FromJson(
+                """
+                {
+                    "runtimeOptions": {
+                        "tfm": "netcoreapp3.1",
+                        "framework": {
+                            "name": "Microsoft.NETCore.App",
+                            "version": "3.1.0"
+                        },
+                        "configProperties": {
+                            "System.GC.Concurrent": false,
+                            "System.Threading.ThreadPool.MinThreads": 4
+                        }
+                    }
+                }
+                """
+            );
 
             Assert.NotNull(config);
             Assert.NotNull(config.RuntimeOptions.ConfigProperties);


### PR DESCRIPTION
- Correct self-contained detection
- Add support for multiple shared target frameworks in runtimeconfig
- Add basic WinRT version detection mechanism