### PR TITLE
Docs: add a note about native method restrictions

### DIFF
--- a/docs/guides/dotnet/unmanaged-method-bodies.md
+++ b/docs/guides/dotnet/unmanaged-method-bodies.md
@@ -22,6 +22,12 @@ your mixed mode application, and might throw runtime or image format
 exceptions, even if everything else conforms to the right format. This
 section will go over these requirements briefly.
 
+> [!NOTE]
+> There are restrictions on the location of native methods in the 
+> CLR core implementation: they can only be located in the global `<Module>` class.
+> Defining a native method in a different class will result 
+> in a "Native method is not supported" exception being thrown.
+
 ### Allowing native code in modules
 
 To make the CLR treat the output file as a mixed mode application, the


### PR DESCRIPTION
While using AsmResolver, I ran into an issue where the assembly containing my created native methods (following the guide) would not load. It took me a long time to figure out the reason, which I have now documented in the commit note.
Even though the MSIL specification does not explicitly state that native methods must be defined in , the CoreCLR implementation includes code in coreclr\vm\methodtablebuilder.cpp [MethodTableBuilder::ValidateMethods] that checks for IsGlobalClass(). Because of this, I think this note is worth existing