### PR TITLE
Add parentheses to not..or pattern

### DIFF
--- a/src/AsmResolver.PE/DotNet/DotNetEntryPoint.cs
+++ b/src/AsmResolver.PE/DotNet/DotNetEntryPoint.cs
@@ -18,7 +18,7 @@ namespace AsmResolver.PE.DotNet
         /// </param>
         public DotNetEntryPoint(MetadataToken token)
         {
-            if (token != MetadataToken.Zero && token.Table is not TableIndex.Method or TableIndex.File)
+            if (token != MetadataToken.Zero && token.Table is not (TableIndex.Method or TableIndex.File))
                 throw new ArgumentException("Managed entry points can only be metadata tokens referencing a method or a file.");
 
             MetadataToken = token;


### PR DESCRIPTION
I'm failing to build the master branch with the .NET 10.0.203 SDK because of the CS9336 error reported here. I assume from the exception message below it, the condition is missing parentheses after `not` which I have added