### PR TITLE
Fix fast patching potentially corrupting EH catch type in memory 

### DIFF
--- a/src/AsmResolver.DotNet/Code/Cil/CilMethodBodySerializer.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilMethodBodySerializer.cs
@@ -195,6 +195,7 @@ namespace AsmResolver.DotNet.Code.Cil
                     try
                     {
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+                        sectionData = (byte[])sectionData.Clone();
                         FastCilReassembler.PatchExceptionHandlerSection(sectionData, tokenRewriter, section.IsFat);
 #else
                         var reader = new BinaryStreamReader(sectionData);

--- a/test/AsmResolver.DotNet.Tests/Code/Cil/CilMethodBodyTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Code/Cil/CilMethodBodyTest.cs
@@ -166,6 +166,23 @@ namespace AsmResolver.DotNet.Tests.Code.Cil
             Assert.Equal(newBody.ExceptionHandlers[1].ExceptionType!.FullName, newBody.ExceptionHandlers[1].ExceptionType!.FullName);
         }
 
+        [Fact]
+        public void FastPatchingShouldNotCorruptOriginalExceptionHandlerCatchType()
+        {
+            // https://github.com/Washi1337/AsmResolver/pull/747
+
+            var module = ModuleDefinition.FromFile(typeof(MethodBodyTypes).Assembly.Location, TestReaderParameters);
+            var method = module.TopLevelTypes
+                .First(t => t.Name == nameof(MethodBodyTypes))
+                .Methods.First(m => m.Name == nameof(MethodBodyTypes.FatMethodWithCatch));
+
+            module.Write(new MemoryStream());
+
+            Assert.Equal(
+                ["System.IO.IOException", "System.Net.WebException"],
+                method.CilMethodBody!.ExceptionHandlers.Select(eh => eh.ExceptionType!.FullName));
+        }
+
         [Theory]
         [InlineData(false)]
         [InlineData(true)]


### PR DESCRIPTION
When fast patching method bodies, the EH catch type token is rewritten directly into the original raw body's section data
https://github.com/Washi1337/AsmResolver/blob/08fa5cd1e40207a004265c7576f8b991cb62b4b9/src/AsmResolver.DotNet/Code/Cil/CilMethodBodySerializer.cs#L188-L199

Since `sectionData` is ultimately owned by the `sourceBody.OriginalRawBody`, patching the catch type token in place mutates the original body itself in memory. So for example if you write a module twice, the first module will be fine while the second module may have the wrong token for the catch type.

repro case:
```cs
void test()
{
    try
    {
        throw new Exception();
    }
    catch (Exception)
    {
        return;
    }
}

var module = ModuleDefinition.FromModule(typeof(Program).Module);
module.Write(new MemoryStream());

var method = module.TopLevelTypes.SelectMany(t => t.Methods).First(m => m.Name.Contains("test"));

// should print System.Exception, but it doesn't
Console.WriteLine(method.CilMethodBody!.ExceptionHandlers[0].ExceptionType); 
```

To fix it, I just Clone the sectionData before patching it.