### PR TITLE
BUGFIX: Add MarshalTypeName and consider more escaping characters.

### DIFF
--- a/src/AsmResolver.DotNet/Signatures/CustomMarshalDescriptor.cs
+++ b/src/AsmResolver.DotNet/Signatures/CustomMarshalDescriptor.cs
@@ -21,21 +21,73 @@ namespace AsmResolver.DotNet.Signatures
             string? marshalTypeName = reader.ReadSerString();
             var cookie = reader.ReadSerString();
 
-            return new CustomMarshalDescriptor(guid, nativeTypeName,
-                marshalTypeName is null ? null : TypeNameParser.Parse(parentModule, marshalTypeName), cookie);
+            TypeSignature? marshalType;
+            try
+            {
+                marshalType = !Utf8String.IsNullOrEmpty(marshalTypeName)
+                    ? TypeNameParser.Parse(parentModule, marshalTypeName)
+                    : null;
+            }
+            catch
+            {
+                // Note: we must swallow any exception here. Technically it is possible to have strings in here
+                // that do not decode to actual proper type refs.  We cannot report it to a parent IErrorListener,
+                // because it may actually throw the exception and thus cancel the parsing all together.
+                marshalType = null;
+            }
+
+            return new CustomMarshalDescriptor(
+                guid,
+                nativeTypeName,
+                marshalTypeName,
+                marshalType,
+                cookie
+            );
         }
 
         /// <summary>
         /// Creates a new instance of the <see cref="CustomMarshalDescriptor"/> class.
         /// </summary>
-        /// <param name="guid"></param>
-        /// <param name="nativeTypeName"></param>
-        /// <param name="marshalType"></param>
-        /// <param name="cookie"></param>
+        /// <param name="guid">The unique identifier of the type library that contains the marshaller.</param>
+        /// <param name="nativeTypeName">The name of the native type of the marshaller.</param>
+        /// <param name="marshalTypeName">The name of the marshal type.</param>
+        /// <param name="cookie">An additional value to be passed onto the custom marshaller.</param>
+        public CustomMarshalDescriptor(string? guid, Utf8String? nativeTypeName, Utf8String? marshalTypeName, Utf8String? cookie)
+        {
+            Guid = guid;
+            NativeTypeName = nativeTypeName;
+            MarshalTypeName = marshalTypeName;
+            Cookie = cookie;
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="CustomMarshalDescriptor"/> class.
+        /// </summary>
+        /// <param name="guid">The unique identifier of the type library that contains the marshaller.</param>
+        /// <param name="nativeTypeName">The name of the native type of the marshaller.</param>
+        /// <param name="marshalType">The type used to marshal the value.</param>
+        /// <param name="cookie">An additional value to be passed onto the custom marshaller.</param>
         public CustomMarshalDescriptor(string? guid, Utf8String? nativeTypeName, TypeSignature? marshalType, Utf8String? cookie)
         {
             Guid = guid;
             NativeTypeName = nativeTypeName;
+            MarshalType = marshalType;
+            Cookie = cookie;
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="CustomMarshalDescriptor"/> class.
+        /// </summary>
+        /// <param name="guid">The unique identifier of the type library that contains the marshaller.</param>
+        /// <param name="nativeTypeName">The name of the native type of the marshaller.</param>
+        /// <param name="marshalTypeName">The name of the marshal type.</param>
+        /// <param name="marshalType">The type used to marshal the value.</param>
+        /// <param name="cookie">An additional value to be passed onto the custom marshaller.</param>
+        public CustomMarshalDescriptor(string? guid, Utf8String? nativeTypeName, Utf8String? marshalTypeName, TypeSignature? marshalType, Utf8String? cookie)
+        {
+            Guid = guid;
+            NativeTypeName = nativeTypeName;
+            MarshalTypeName = marshalTypeName;
             MarshalType = marshalType;
             Cookie = cookie;
         }
@@ -68,8 +120,23 @@ namespace AsmResolver.DotNet.Signatures
         }
 
         /// <summary>
+        /// Gets or sets the name of the type used to marshal the value.
+        /// </summary>
+        /// <remarks>
+        /// This value is ignored by the builder when <see cref="MarshalType"/> is not <c>null</c>.
+        /// </remarks>
+        public Utf8String? MarshalTypeName
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Gets or sets the type used to marshal the value.
         /// </summary>
+        /// <remarks>
+        /// This value supersedes <see cref="MarshalTypeName"/> when set to a non-<c>null</c> value.
+        /// </remarks>
         public TypeSignature? MarshalType
         {
             get;
@@ -93,7 +160,12 @@ namespace AsmResolver.DotNet.Signatures
             writer.WriteByte((byte) NativeType);
             writer.WriteSerString(Guid ?? string.Empty);
             writer.WriteSerString(NativeTypeName ?? Utf8String.Empty);
-            writer.WriteSerString(MarshalType is null ? string.Empty : TypeNameBuilder.GetAssemblyQualifiedName(MarshalType, context.ContextModule));
+
+            if (MarshalType is null)
+                writer.WriteSerString(MarshalTypeName);
+            else
+                writer.WriteSerString(TypeNameBuilder.GetAssemblyQualifiedName(MarshalType, context.ContextModule));
+
             writer.WriteSerString(Cookie ?? Utf8String.Empty);
         }
     }

--- a/src/AsmResolver.DotNet/Signatures/Parsing/TypeNameLexer.cs
+++ b/src/AsmResolver.DotNet/Signatures/Parsing/TypeNameLexer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using AsmResolver.Shims;
@@ -9,6 +10,25 @@ namespace AsmResolver.DotNet.Signatures.Parsing
     {
         internal static readonly char[] ReservedChars = "*+.,&[]…".ToCharArray();
         private static readonly char[] TrimCharacters = " ".ToCharArray();
+
+        private static readonly Dictionary<char, char> EscapeChars = new()
+        {
+            ['e'] = '\e',
+            ['b'] = '\b',
+            ['r'] = '\r',
+            ['n'] = '\n',
+            ['t'] = '\t',
+            ['*'] = '*',
+            ['+'] = '+',
+            ['.'] = '.',
+            [','] = ',',
+            ['&'] = '&',
+            ['['] = '[',
+            [']'] = ']',
+            ['…'] = '…',
+            ['\\'] = '\\',
+            [' '] = ' ',
+        };
 
         private readonly TextReader _reader;
         private readonly StringBuilder _buffer = new();
@@ -94,12 +114,19 @@ namespace AsmResolver.DotNet.Signatures.Parsing
             {
                 int c = _reader.Peek();
                 if (c == -1)
+                {
+                    if (escape)
+                        throw new EndOfStreamException("Escape sequence ended unexpectedly.");
                     break;
+                }
 
                 char currentChar = (char) c;
 
                 if (escape)
                 {
+                    if (!EscapeChars.TryGetValue(currentChar, out char mappedChar))
+                        throw new FormatException($"Invalid escape sequence '\\{currentChar}'.");
+                    currentChar = mappedChar;
                     escape = false;
                 }
                 else
@@ -137,12 +164,19 @@ namespace AsmResolver.DotNet.Signatures.Parsing
             {
                 int c = _reader.Peek();
                 if (c == -1)
+                {
+                    if (escape)
+                        throw new EndOfStreamException("Escape sequence ended unexpectedly.");
                     break;
+                }
 
                 char currentChar = (char) c;
 
                 if (escape)
                 {
+                    if (!EscapeChars.TryGetValue(currentChar, out char mappedChar))
+                        throw new FormatException($"Invalid escape sequence '\\{currentChar}'.");
+                    currentChar = mappedChar;
                     escape = false;
                 }
                 else

--- a/test/AsmResolver.DotNet.Tests/Signatures/MarshalDescriptorTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Signatures/MarshalDescriptorTest.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Linq;
+using System.Runtime.InteropServices;
 using AsmResolver.DotNet.Builder;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.DotNet.TestCases.Fields;
 using AsmResolver.DotNet.TestCases.Methods;
+using AsmResolver.PE.DotNet.Metadata.Tables;
 using Xunit;
 
 namespace AsmResolver.DotNet.Tests.Signatures
@@ -275,6 +277,31 @@ namespace AsmResolver.DotNet.Tests.Signatures
             var field = LookupField(nameof(Marshalling.CustomMarshallerWithCustomType));
             var customMarshaller = Assert.IsType<CustomMarshalDescriptor>(field.MarshalDescriptor, exactMatch: false);
             Assert.Equal(nameof(Marshalling), customMarshaller.MarshalType?.Name);
+        }
+
+        [Fact]
+        public void ReadCustomMarshallerTypeName()
+        {
+            var field = LookupField(nameof(Marshalling.CustomMarshallerWithCustomTypeName));
+            var customMarshaller = Assert.IsType<CustomMarshalDescriptor>(field.MarshalDescriptor, exactMatch: false);
+            Assert.Equal("NonExistingType", customMarshaller.MarshalType?.Name);
+        }
+
+        [Fact]
+        public void ReadCustomMarshallerEmptyTypeName()
+        {
+            var field = LookupField(nameof(Marshalling.CustomMarshallerWithEmptyCustomTypeName));
+            var customMarshaller = Assert.IsType<CustomMarshalDescriptor>(field.MarshalDescriptor, exactMatch: false);
+            Assert.Null(customMarshaller.MarshalType);
+        }
+
+        [Fact]
+        public void ReadCustomMarshallerInvalidTypeName()
+        {
+            var field = LookupField(nameof(Marshalling.CustomMarshallerWithInvalidCustomTypeName));
+            var customMarshaller = Assert.IsType<CustomMarshalDescriptor>(field.MarshalDescriptor, exactMatch: false);
+            Assert.Null(customMarshaller.MarshalType);
+            Assert.Equal("\\", customMarshaller.MarshalTypeName);
         }
 
         [Fact]

--- a/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Fields/Marshalling.cs
+++ b/test/TestBinaries/DotNet/AsmResolver.DotNet.TestCases.Fields/Marshalling.cs
@@ -18,6 +18,15 @@ namespace AsmResolver.DotNet.TestCases.Fields
         [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Marshalling))]
         public static byte[] CustomMarshallerWithCustomType;
 
+        [MarshalAs(UnmanagedType.CustomMarshaler, MarshalType = "NonExistingNamespace.NonExistingType, NonExistingAssembly, Version=1.0.0.0")]
+        public static byte[] CustomMarshallerWithCustomTypeName;
+
+        [MarshalAs(UnmanagedType.CustomMarshaler, MarshalType = "")]
+        public static byte[] CustomMarshallerWithEmptyCustomTypeName;
+
+        [MarshalAs(UnmanagedType.CustomMarshaler, MarshalType = "\\")]
+        public static byte[] CustomMarshallerWithInvalidCustomTypeName;
+
         [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Marshalling), MarshalCookie = "abc")]
         public static byte[] CustomMarshallerWithCustomTypeAndCookie;
 


### PR DESCRIPTION
Addresses more edge cases w.r.t. type name parsing within custom attributes and marshal descriptors.