### PR TITLE
Change IsTrimmable to IsAotCompatible

### DIFF
--- a/src/AsmResolver.DotNet.Dynamic/AsmResolver.DotNet.Dynamic.csproj
+++ b/src/AsmResolver.DotNet.Dynamic/AsmResolver.DotNet.Dynamic.csproj
@@ -4,7 +4,7 @@
     <Title>AsmResolver.DotNet.Dynamic</Title>
     <Description>Dynamic method support for the AsmResolver executable file inspection toolsuite.</Description>
     <PackageTags>exe pe directories imports exports resources dotnet cil inspection manipulation assembly disassembly dynamic</PackageTags>
-    <IsTrimmable>false</IsTrimmable>
+    <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0;net6.0;net462;net472;net35;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <IsTrimmable>true</IsTrimmable>
+        <IsAotCompatible>true</IsAotCompatible>
         <NoWarn>1701;1702;NU5105</NoWarn>
         <ArtifactsPath>$(MSBuildThisFileDirectory)..\artifacts\src</ArtifactsPath>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
IsAotCompatible is a stronger version of IsTrimmable.

I checked to see if any code needed additional attribute annotations due to the higher strictness, but I encountered no warnings while building.

Resolves #751