### PR TITLE
Handle zero instruction method bodies in CilMethodBodySerializer

### DIFF
--- a/src/AsmResolver.DotNet/Code/Cil/CilMethodBodySerializer.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilMethodBodySerializer.cs
@@ -1,9 +1,10 @@
-﻿using System;
+using System;
 using System.Linq;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.IO;
 using AsmResolver.PE.DotNet.Cil;
 using AsmResolver.PE.DotNet.Metadata.Tables;
+using AsmResolver.Shims;
 
 namespace AsmResolver.DotNet.Code.Cil
 {
@@ -328,6 +329,9 @@ namespace AsmResolver.DotNet.Code.Cil
             }
 
             var bag = context.ErrorListener;
+
+            if (body.Instructions.Count == 0)
+                return ArrayShim.Empty<byte>();
 
             var lastInstruction = body.Instructions[body.Instructions.Count - 1];
             using var rentedWriter = _writerPool.Rent(lastInstruction.Offset + lastInstruction.Size);

--- a/test/AsmResolver.DotNet.Tests/Builder/CilMethodBodySerializerTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Builder/CilMethodBodySerializerTest.cs
@@ -50,5 +50,27 @@ namespace AsmResolver.DotNet.Tests.Builder
 
             Assert.Equal(expectedMaxStack, newModule.ManagedEntryPointMethod!.CilMethodBody!.MaxStack);
         }
+
+        [Fact]
+        public void SerializingZeroInstructionMethodBodyDoesNotThrow()
+        {
+            var module = new ModuleDefinition("SomeModule", KnownCorLibs.SystemPrivateCoreLib_v4_0_0_0);
+
+            module.GetOrCreateModuleType().Methods.Add(new MethodDefinition(
+                "Method",
+                MethodAttributes.Public | MethodAttributes.Static,
+                MethodSignature.CreateStatic(module.CorLibTypeFactory.Void))
+            {
+                CilMethodBody = new CilMethodBody()
+            });
+
+            var factory = new DotNetDirectoryFactory
+            {
+                MethodBodySerializer = new CilMethodBodySerializer()
+            };
+            var builder = new ManagedPEImageBuilder(factory, ThrowErrorListener.Instance);
+
+            builder.CreateImage(module);
+        }
     }
 }


### PR DESCRIPTION
This fixes a regression from https://github.com/Washi1337/AsmResolver/commit/8291e500a0eb4a372b747b9f91dfbdddea19782c