### PR TITLE
BUGFIX: Correct strong-name RSA key blob encoding

### DIFF
--- a/src/AsmResolver.PE/DotNet/StrongName/StrongNamePrivateKey.cs
+++ b/src/AsmResolver.PE/DotNet/StrongName/StrongNamePrivateKey.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Security.Cryptography;
 using AsmResolver.IO;
 
@@ -39,7 +38,7 @@ namespace AsmResolver.PE.DotNet.StrongName
             ReadBlobHeader(ref reader, StrongNameKeyStructureType.PrivateKeyBlob, 2, SignatureAlgorithm.RsaSign);
 
             // Read RSAPUBKEY
-            if ((RsaPublicKeyMagic) reader.ReadUInt32() != RsaPublicKeyMagic.Rsa2)
+            if ((RsaPublicKeyMagic)reader.ReadUInt32() != RsaPublicKeyMagic.Rsa2)
                 throw new FormatException("Input stream does not contain a valid RSA private key header magic.");
 
             uint bitLength = reader.ReadUInt32();
@@ -49,9 +48,12 @@ namespace AsmResolver.PE.DotNet.StrongName
                 PublicExponent = reader.ReadUInt32(),
             };
 
+            // CryptoAPI PRIVATEKEYBLOB stores every RSA integer (Modulus, P, Q,
+            // DP, DQ, InverseQ, D) in little-endian. The in-memory representation
+            // here is big-endian (matching StrongNamePublicKey's storage and the
+            // big-endian RSAParameters that ToRsaParameters returns), so each
+            // integer is read as raw little-endian bytes and then reversed.
             reader.ReadBytes(result.Modulus, 0, result.Modulus.Length);
-
-            // Read private data.
             reader.ReadBytes(result.P, 0, result.P.Length);
             reader.ReadBytes(result.Q, 0, result.Q.Length);
             reader.ReadBytes(result.DP, 0, result.DP.Length);
@@ -90,16 +92,20 @@ namespace AsmResolver.PE.DotNet.StrongName
         /// <summary>
         /// Imports a public/private key pair from an instance of <see cref="RSAParameters"/>.
         /// </summary>
-        /// <param name="parameters">The RSA parameters to import.</param>
+        /// <param name="parameters">The RSA parameters to import. All integers
+        /// are expected in the big-endian byte order <see cref="RSA"/> uses and
+        /// are stored verbatim (big-endian) so <see cref="ToRsaParameters"/>
+        /// returns them unchanged.</param>
         public StrongNamePrivateKey(in RSAParameters parameters)
             : base(parameters.Modulus ?? throw new ArgumentException("The provided RSA parameters do not define a modulus."),
                 ByteSwap(parameters))
         {
-            Modulus = parameters.Modulus;
+            // base() set Modulus to a clone of the big-endian input - keep it
+            // big-endian (matches the on-disk reverse done in Write/FromReader).
             P = parameters.P ?? throw new ArgumentException("The provided RSA parameters do not define prime P.");
-            Q = parameters.Q ?? throw new ArgumentException("The provided RSA parameters do not define prime Q.");;
-            DP = parameters.DP ?? throw new ArgumentException("The provided RSA parameters do not define DP.");;
-            DQ = parameters.DQ ?? throw new ArgumentException("The provided RSA parameters do not define DQ.");;
+            Q = parameters.Q ?? throw new ArgumentException("The provided RSA parameters do not define prime Q.");
+            DP = parameters.DP ?? throw new ArgumentException("The provided RSA parameters do not define DP.");
+            DQ = parameters.DQ ?? throw new ArgumentException("The provided RSA parameters do not define DQ.");
 
             InverseQ = parameters.InverseQ
                        ?? throw new ArgumentException("The provided RSA parameters do not define InverseQ.");
@@ -171,23 +177,23 @@ namespace AsmResolver.PE.DotNet.StrongName
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// All integers are stored internally big-endian (the byte order
+        /// <see cref="RSA.ImportParameters"/> expects), so they are returned
+        /// verbatim. The on-disk CryptoAPI little-endian layout is handled by
+        /// reversing in <see cref="Write"/> and <see cref="FromReader"/>.
+        /// </remarks>
         public override RSAParameters ToRsaParameters()
         {
-            var exponentBytes = new List<byte>(sizeof(uint))
-            {
-                (byte) (PublicExponent & 0xFF),
-                (byte) ((PublicExponent >> 8) & 0xFF),
-                (byte) ((PublicExponent >> 16) & 0xFF),
-                (byte) ((PublicExponent >> 24) & 0xFF),
-            };
-
-            for (int i = exponentBytes.Count - 1; i >= 0 && exponentBytes[i] == 0; i--)
-                exponentBytes.RemoveAt(i);
-
             return new RSAParameters
             {
                 Modulus = Modulus,
-                Exponent = exponentBytes.ToArray(),
+                // RSAParameters.Exponent is big-endian with no leading zeros
+                // (shared helper on StrongNamePublicKey; the old code built
+                // little-endian bytes and trimmed trailing zeros, which only
+                // produced the right big-endian bytes for palindromic exponents
+                // like 65537 = [01 00 01]).
+                Exponent = UIntToBigEndianBytes(PublicExponent),
                 P = P,
                 Q = Q,
                 DP = DP,
@@ -200,8 +206,8 @@ namespace AsmResolver.PE.DotNet.StrongName
         /// <inheritdoc />
         public override uint GetPhysicalSize()
         {
-            uint length8 = (uint) (BitLength / 8);
-            uint length16 = (uint) (BitLength / 16);
+            uint length8 = (uint)(BitLength / 8);
+            uint length16 = (uint)(BitLength / 16);
             return base.GetPhysicalSize()
                    + length16 // p
                    + length16 // q
@@ -215,13 +221,18 @@ namespace AsmResolver.PE.DotNet.StrongName
         /// <inheritdoc />
         public override void Write(BinaryStreamWriter writer)
         {
+            // base.Write emits BLOBHEADER + RSAPUBKEY + Modulus. The base
+            // StrongNamePublicKey.Write reverses Modulus (big-endian storage ->
+            // little-endian on-disk). The private RSA integers (P, Q, DP, DQ,
+            // InverseQ, D) are likewise stored big-endian internally and must be
+            // reversed here to produce a valid CryptoAPI PRIVATEKEYBLOB.
             base.Write(writer);
-            writer.WriteBytes(P);
-            writer.WriteBytes(Q);
-            writer.WriteBytes(DP);
-            writer.WriteBytes(DQ);
-            writer.WriteBytes(InverseQ);
-            writer.WriteBytes(PrivateExponent);
+            writer.WriteBytes(Reverse(P));
+            writer.WriteBytes(Reverse(Q));
+            writer.WriteBytes(Reverse(DP));
+            writer.WriteBytes(Reverse(DQ));
+            writer.WriteBytes(Reverse(InverseQ));
+            writer.WriteBytes(Reverse(PrivateExponent));
         }
 
         private static uint ByteSwap(RSAParameters parameters)
@@ -229,10 +240,12 @@ namespace AsmResolver.PE.DotNet.StrongName
             if (parameters.Exponent is null)
                 throw new ArgumentException("The provided RSA parameters do not define an exponent.");
 
-            uint exponent = 0;
-            for (int i = 0; i < Math.Min(sizeof(uint), parameters.Exponent.Length); i++)
-                exponent |= (uint) (parameters.Exponent[i] << (8 * i));
-            return exponent;
+            // RSAParameters.Exponent is big-endian (no leading zeros). Read it
+            // as big-endian into the uint. (The previous little-endian read
+            // happened to work for the palindromic 65537 = [01 00 01] but produced
+            // the wrong uint for any other exponent, e.g. [01 00 02] would become
+            // 0x020001 instead of 0x010002.)
+            return BigEndianBytesToUInt(parameters.Exponent);
         }
     }
 }

--- a/src/AsmResolver.PE/DotNet/StrongName/StrongNamePrivateKey.cs
+++ b/src/AsmResolver.PE/DotNet/StrongName/StrongNamePrivateKey.cs
@@ -93,9 +93,7 @@ namespace AsmResolver.PE.DotNet.StrongName
         /// Imports a public/private key pair from an instance of <see cref="RSAParameters"/>.
         /// </summary>
         /// <param name="parameters">The RSA parameters to import. All integers
-        /// are expected in the big-endian byte order <see cref="RSA"/> uses and
-        /// are stored verbatim (big-endian) so <see cref="ToRsaParameters"/>
-        /// returns them unchanged.</param>
+        /// are expected in the big-endian byte order <see cref="RSA"/> uses.</param>
         public StrongNamePrivateKey(in RSAParameters parameters)
             : base(parameters.Modulus ?? throw new ArgumentException("The provided RSA parameters do not define a modulus."),
                 ByteSwap(parameters))
@@ -177,22 +175,12 @@ namespace AsmResolver.PE.DotNet.StrongName
         }
 
         /// <inheritdoc />
-        /// <remarks>
-        /// All integers are stored internally big-endian (the byte order
-        /// <see cref="RSA.ImportParameters"/> expects), so they are returned
-        /// verbatim. The on-disk CryptoAPI little-endian layout is handled by
-        /// reversing in <see cref="Write"/> and <see cref="FromReader"/>.
-        /// </remarks>
         public override RSAParameters ToRsaParameters()
         {
             return new RSAParameters
             {
                 Modulus = Modulus,
-                // RSAParameters.Exponent is big-endian with no leading zeros
-                // (shared helper on StrongNamePublicKey; the old code built
-                // little-endian bytes and trimmed trailing zeros, which only
-                // produced the right big-endian bytes for palindromic exponents
-                // like 65537 = [01 00 01]).
+                // RSAParameters.Exponent is big-endian with no leading zeros.
                 Exponent = UIntToBigEndianBytes(PublicExponent),
                 P = P,
                 Q = Q,
@@ -240,11 +228,6 @@ namespace AsmResolver.PE.DotNet.StrongName
             if (parameters.Exponent is null)
                 throw new ArgumentException("The provided RSA parameters do not define an exponent.");
 
-            // RSAParameters.Exponent is big-endian (no leading zeros). Read it
-            // as big-endian into the uint. (The previous little-endian read
-            // happened to work for the palindromic 65537 = [01 00 01] but produced
-            // the wrong uint for any other exponent, e.g. [01 00 02] would become
-            // 0x020001 instead of 0x010002.)
             return BigEndianBytesToUInt(parameters.Exponent);
         }
     }

--- a/src/AsmResolver.PE/DotNet/StrongName/StrongNamePublicKey.cs
+++ b/src/AsmResolver.PE/DotNet/StrongName/StrongNamePublicKey.cs
@@ -41,21 +41,82 @@ namespace AsmResolver.PE.DotNet.StrongName
             ReadBlobHeader(ref reader, StrongNameKeyStructureType.PublicKeyBlob, 2, SignatureAlgorithm.RsaSign);
 
             // Read RSAPUBKEY
-            if ((RsaPublicKeyMagic) reader.ReadUInt32() != RsaPublicKeyMagic.Rsa1)
+            if ((RsaPublicKeyMagic)reader.ReadUInt32() != RsaPublicKeyMagic.Rsa1)
                 throw new FormatException("Input stream does not contain a valid RSA public key header magic.");
 
             uint bitLength = reader.ReadUInt32();
 
             var result = new StrongNamePublicKey(new byte[bitLength / 8], reader.ReadUInt32());
+            // CryptoAPI PUBLICKEYBLOB stores the modulus in little-endian; the
+            // in-memory representation here is big-endian (matching the
+            // RSAParameters constructor and ToRsaParameters), so reverse it.
             reader.ReadBytes(result.Modulus, 0, result.Modulus.Length);
+            Array.Reverse(result.Modulus);
             return result;
         }
 
-        private byte[] CopyReversed(byte[] data)
+        /// <summary>
+        /// Reverses the byte order of the provided byte array, returning a new
+        /// array. Used to translate between the little-endian on-disk CryptoAPI
+        /// key blob layout and the big-endian layout <see cref="RSAParameters"/>
+        /// expects.
+        /// </summary>
+        protected static byte[] Reverse(byte[] data)
         {
+            if (data is null)
+                return null!;
             var result = new byte[data.Length];
             for (int i = 0; i < data.Length; i++)
                 result[result.Length - i - 1] = data[i];
+            return result;
+        }
+
+        /// <summary>
+        /// Reads a big-endian byte array (as <see cref="RSAParameters.Exponent"/>
+        /// is encoded) into a <see cref="uint"/>.
+        /// </summary>
+        protected static uint BigEndianBytesToUInt(byte[] bytes)
+        {
+            if (bytes is null)
+                throw new ArgumentNullException(nameof(bytes));
+
+            uint value = 0;
+            int start = 0;
+            while (start < bytes.Length && bytes[start] == 0)
+                start++;
+
+            int significant = bytes.Length - start;
+            if (significant > sizeof(uint))
+                throw new ArgumentException("RSA exponent is too large to fit in a 32-bit CryptoAPI public exponent.");
+
+            for (int i = start; i < bytes.Length; i++)
+                value = (value << 8) | bytes[i];
+            return value;
+        }
+
+        /// <summary>
+        /// Converts a <see cref="uint"/> to the big-endian, no-leading-zero byte
+        /// array <see cref="RSAParameters.Exponent"/> expects (e.g. 65537 ->
+        /// <c>[01 00 01]</c>). A zero input yields a single zero byte.
+        /// </summary>
+        protected static byte[] UIntToBigEndianBytes(uint value)
+        {
+            if (value == 0)
+                return new byte[] { 0 };
+
+            int length = value <= 0xFF
+                ? 1
+                : value <= 0xFFFF
+                    ? 2
+                    : value <= 0xFFFFFF
+                        ? 3
+                        : 4;
+            var result = new byte[length];
+            for (int i = length - 1; i >= 0; i--)
+            {
+                result[i] = (byte)value;
+                value >>= 8;
+            }
             return result;
         }
 
@@ -81,11 +142,10 @@ namespace AsmResolver.PE.DotNet.StrongName
             if (parameters.Exponent is null)
                 throw new ArgumentException("RSA parameters does not define an exponent.");
 
-            Modulus = CopyReversed(parameters.Modulus);
-            uint exponent = 0;
-            for (int i = 0; i < Math.Min(sizeof(uint), parameters.Exponent.Length); i++)
-                exponent |= (uint) (parameters.Exponent[i] << (8 * i));
-            PublicExponent = exponent;
+            // RSAParameters stores integers big-endian; keep that as the
+            // in-memory representation and only reverse at the blob boundary.
+            Modulus = (byte[])parameters.Modulus.Clone();
+            PublicExponent = BigEndianBytesToUInt(parameters.Exponent);
         }
 
         /// <inheritdoc />
@@ -134,30 +194,35 @@ namespace AsmResolver.PE.DotNet.StrongName
         {
             using var tempStream = new MemoryStream();
             var writer = new BinaryStreamWriter(tempStream);
-            writer.WriteUInt32((uint) SignatureAlgorithm);
-            writer.WriteUInt32((uint) hashAlgorithm);
-            writer.WriteUInt32((uint) (0x14 + Modulus.Length));
-            writer.WriteByte((byte) StrongNameKeyStructureType.PublicKeyBlob);
+            writer.WriteUInt32((uint)SignatureAlgorithm);
+            writer.WriteUInt32((uint)hashAlgorithm);
+            writer.WriteUInt32((uint)(0x14 + Modulus.Length));
+            writer.WriteByte((byte)StrongNameKeyStructureType.PublicKeyBlob);
             writer.WriteByte(2);
             writer.WriteUInt16(0);
-            writer.WriteUInt32((uint) SignatureAlgorithm);
-            writer.WriteUInt32((uint) RsaPublicKeyMagic.Rsa1);
-            writer.WriteUInt32((uint) BitLength);
+            writer.WriteUInt32((uint)SignatureAlgorithm);
+            writer.WriteUInt32((uint)RsaPublicKeyMagic.Rsa1);
+            writer.WriteUInt32((uint)BitLength);
             writer.WriteUInt32(PublicExponent);
-            writer.WriteBytes(CopyReversed(Modulus));
+            // Modulus is stored big-endian internally; the on-disk CryptoAPI
+            // PUBLICKEYBLOB layout uses little-endian, so reverse on write.
+            writer.WriteBytes(Reverse(Modulus));
             return tempStream.ToArray();
         }
 
         /// <summary>
         /// Translates the strong name parameters to an instance of <see cref="RSAParameters"/>.
         /// </summary>
-        /// <returns>The converted RSA parameters.</returns>
+        /// <returns>The converted RSA parameters, with all integers in the
+        /// big-endian byte order <see cref="RSA.ImportParameters"/> expects.</returns>
         public virtual RSAParameters ToRsaParameters()
         {
             return new RSAParameters
             {
                 Modulus = Modulus,
-                Exponent = BitConverter.GetBytes(PublicExponent)
+                // RSAParameters.Exponent is big-endian with no leading zeros.
+                // BitConverter.GetBytes would emit little-endian 4 bytes (wrong).
+                Exponent = UIntToBigEndianBytes(PublicExponent)
             };
         }
 
@@ -168,7 +233,7 @@ namespace AsmResolver.PE.DotNet.StrongName
                    + sizeof(RsaPublicKeyMagic) // magic
                    + sizeof(uint) // bitlen
                    + sizeof(uint) // pubexp
-                   + (uint) Modulus.Length / 8 // modulus
+                   + (uint)Modulus.Length // modulus
                 ;
         }
 
@@ -176,10 +241,13 @@ namespace AsmResolver.PE.DotNet.StrongName
         public override void Write(BinaryStreamWriter writer)
         {
             base.Write(writer);
-            writer.WriteUInt32((uint) Magic);
-            writer.WriteUInt32((uint) BitLength);
+            writer.WriteUInt32((uint)Magic);
+            writer.WriteUInt32((uint)BitLength);
             writer.WriteUInt32(PublicExponent);
-            writer.WriteBytes(Modulus);
+            // Modulus is stored big-endian internally; the on-disk CryptoAPI
+            // layout uses little-endian, so reverse on write (mirrors FromReader,
+            // which reverses the little-endian file bytes back into big-endian).
+            writer.WriteBytes(Reverse(Modulus));
         }
     }
 }

--- a/src/AsmResolver.PE/DotNet/StrongName/StrongNamePublicKey.cs
+++ b/src/AsmResolver.PE/DotNet/StrongName/StrongNamePublicKey.cs
@@ -104,13 +104,13 @@ namespace AsmResolver.PE.DotNet.StrongName
             if (value == 0)
                 return new byte[] { 0 };
 
-            int length = value <= 0xFF
-                ? 1
-                : value <= 0xFFFF
-                    ? 2
-                    : value <= 0xFFFFFF
-                        ? 3
-                        : 4;
+            int length = value switch
+            {
+                <= 0xFF => 1,
+                <= 0xFFFF => 2,
+                <= 0xFFFFFF => 3,
+                _ => 4
+            };
             var result = new byte[length];
             for (int i = length - 1; i >= 0; i--)
             {
@@ -213,8 +213,7 @@ namespace AsmResolver.PE.DotNet.StrongName
         /// <summary>
         /// Translates the strong name parameters to an instance of <see cref="RSAParameters"/>.
         /// </summary>
-        /// <returns>The converted RSA parameters, with all integers in the
-        /// big-endian byte order <see cref="RSA.ImportParameters"/> expects.</returns>
+        /// <returns>The converted RSA parameters.</returns>
         public virtual RSAParameters ToRsaParameters()
         {
             return new RSAParameters

--- a/test/AsmResolver.PE.Tests/DotNet/StrongName/StrongNamePrivateKeyTest.cs
+++ b/test/AsmResolver.PE.Tests/DotNet/StrongName/StrongNamePrivateKeyTest.cs
@@ -1,0 +1,228 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using AsmResolver.IO;
+using AsmResolver.PE.DotNet.StrongName;
+using Xunit;
+
+namespace AsmResolver.PE.Tests.DotNet.StrongName
+{
+    public class StrongNamePrivateKeyTest
+    {
+        /// <summary>
+        /// A private key constructed from <see cref="RSAParameters"/> must round-trip
+        /// through <see cref="StrongNamePrivateKey.Write"/> and
+        /// <see cref="StrongNamePrivateKey.FromReader"/> and still produce parameters
+        /// that <see cref="RSA.ImportParameters"/> accepts. This guards the CryptoAPI
+        /// PRIVATEKEYBLOB byte order (all RSA integers are little-endian in the blob).
+        /// </summary>
+        [Fact]
+        public void PersistentStrongNamePrivateKey()
+        {
+            using var rsa = RSA.Create(1024);
+            var rsaParameters = rsa.ExportParameters(true);
+            var privateKey = new StrongNamePrivateKey(rsaParameters);
+
+            using var tempStream = new MemoryStream();
+            privateKey.Write(new BinaryStreamWriter(tempStream));
+
+            tempStream.Position = 0;
+            var reader = new BinaryStreamReader(tempStream);
+            var newPrivateKey = StrongNamePrivateKey.FromReader(ref reader);
+
+            // Round-trip preserves the stored integers (both are in the
+            // little-endian on-disk CryptoAPI layout).
+            Assert.Equal(privateKey.Modulus, newPrivateKey.Modulus);
+            Assert.Equal(privateKey.P, newPrivateKey.P);
+            Assert.Equal(privateKey.Q, newPrivateKey.Q);
+            Assert.Equal(privateKey.DP, newPrivateKey.DP);
+            Assert.Equal(privateKey.DQ, newPrivateKey.DQ);
+            Assert.Equal(privateKey.InverseQ, newPrivateKey.InverseQ);
+            Assert.Equal(privateKey.PrivateExponent, newPrivateKey.PrivateExponent);
+
+            // The ORIGINAL key (constructed directly from RSAParameters) must
+            // produce RSA parameters usable for signing.
+            using var rsaOriginal = RSA.Create();
+            rsaOriginal.ImportParameters(privateKey.ToRsaParameters());
+
+            // The ROUND-TRIPPED key must produce RSA parameters usable for signing.
+            using var rsa2 = RSA.Create();
+            rsa2.ImportParameters(newPrivateKey.ToRsaParameters());
+
+            // Both must produce the same strong-name signature over a sample hash.
+            byte[] hash = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 };
+            Assert.Equal(SignWithRsa(rsaOriginal, hash), SignWithRsa(rsa2, hash));
+        }
+
+        /// <summary>
+        /// A private key written to a file must be readable back to a key that
+        /// produces the same SHA-1 strong-name signature as the original.
+        /// </summary>
+        [Fact]
+        public void WriteAndReadPrivateKey_ProducesEquivalentSigningKey()
+        {
+            using var rsa = RSA.Create(1024);
+            var rsaParameters = rsa.ExportParameters(true);
+            var original = new StrongNamePrivateKey(rsaParameters);
+
+            using var tempStream = new MemoryStream();
+            original.Write(new BinaryStreamWriter(tempStream));
+
+            tempStream.Position = 0;
+            var reader = new BinaryStreamReader(tempStream);
+            var roundTripped = StrongNamePrivateKey.FromReader(ref reader);
+
+            byte[] hash = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 };
+
+            using var rsaOriginal = RSA.Create();
+            rsaOriginal.ImportParameters(original.ToRsaParameters());
+            using var rsaRound = RSA.Create();
+            rsaRound.ImportParameters(roundTripped.ToRsaParameters());
+
+            Assert.Equal(SignWithRsa(rsaOriginal, hash), SignWithRsa(rsaRound, hash));
+        }
+
+        /// <summary>
+        /// Verifies that the PRIVATEKEYBLOB written by <see cref="StrongNamePrivateKey.Write"/>
+        /// lays every RSA integer out in little-endian, matching the CryptoAPI
+        /// on-disk format (and what <c>sn -k</c> produces). The default exponent
+        /// 65537 = [01 00 01] is a palindrome, so this is the only way to catch a
+        /// wrong byte order in the modulus/private integers or the pubexp field.
+        /// </summary>
+        [Fact]
+        public void Write_ProducesCryptoApiCompliantLittleEndianBlob()
+        {
+            using var rsa = RSA.Create(1024);
+            var rsaParameters = rsa.ExportParameters(true);
+            var privateKey = new StrongNamePrivateKey(rsaParameters);
+
+            using var tempStream = new MemoryStream();
+            privateKey.Write(new BinaryStreamWriter(tempStream));
+            byte[] blob = tempStream.ToArray();
+
+            Assert.Equal(privateKey.GetPhysicalSize(), (uint)blob.Length);
+
+            // BLOBHEADER (8) + RSAPUBKEY magic (4) + bitlen (4) + pubexp (4) = 20.
+            Assert.Equal(0x07, blob[0]); // bType = PRIVATEKEYBLOB
+            Assert.Equal(0x02, blob[1]); // bVersion
+            Assert.Equal(0x00002400u, BitConverter.ToUInt32(blob, 4)); // CALG_RSA_SIGN
+            Assert.Equal(0x32415352u, BitConverter.ToUInt32(blob, 8)); // "RSA2" magic, LE
+            Assert.Equal(1024u, BitConverter.ToUInt32(blob, 12)); // bitlen LE
+
+            // pubexp is a little-endian uint32 at offset 16.
+            // 65537 = 0x00010001 -> blob bytes [01 00 01 00].
+            Assert.Equal(65537u, BitConverter.ToUInt32(blob, 16));
+            Assert.Equal(new byte[] { 0x01, 0x00, 0x01, 0x00 }, blob[16..20]);
+
+            // Modulus (128 bytes, little-endian in the blob). RSAParameters.Modulus
+            // is big-endian, so the blob bytes must be its reverse.
+            byte[] blobModulus = blob[20..(20 + 128)];
+            Assert.Equal(ReverseBytes(rsaParameters.Modulus), blobModulus);
+
+            int len16 = 1024 / 16;
+            int offset = 20 + 128;
+            Assert.Equal(ReverseBytes(rsaParameters.P), blob[offset..(offset + len16)]);
+            offset += len16;
+            Assert.Equal(ReverseBytes(rsaParameters.Q), blob[offset..(offset + len16)]);
+            offset += len16;
+            Assert.Equal(ReverseBytes(rsaParameters.DP), blob[offset..(offset + len16)]);
+            offset += len16;
+            Assert.Equal(ReverseBytes(rsaParameters.DQ), blob[offset..(offset + len16)]);
+            offset += len16;
+            Assert.Equal(ReverseBytes(rsaParameters.InverseQ), blob[offset..(offset + len16)]);
+            offset += len16;
+            Assert.Equal(ReverseBytes(rsaParameters.D), blob[offset..(offset + 128)]);
+        }
+
+        /// <summary>
+        /// The exponent byte order must be handled big-endian, not little-endian.
+        /// 65537 = [01 00 01] is a palindrome and hides a wrong byte order; a
+        /// non-palindrome exponent such as 0x010002 = [01 00 02] must be read as
+        /// 65538 (not 131073) and round-trip back to the same big-endian bytes.
+        /// This guards the exponent (the modulus/private integers are covered by
+        /// <see cref="Write_ProducesCryptoApiCompliantLittleEndianBlob"/>).
+        /// </summary>
+        [Fact]
+        public void Constructor_ReadsExponent_BigEndian()
+        {
+            // Non-palindrome: big-endian [01 00 02] = 0x010002 = 65538.
+            // A buggy little-endian reader would produce 0x020001 = 131073.
+            var rsaParams = new RSAParameters
+            {
+                Modulus = new byte[128],
+                Exponent = new byte[] { 0x01, 0x00, 0x02 }
+            };
+
+            var publicKey = new StrongNamePublicKey(rsaParams);
+            Assert.Equal(65538u, publicKey.PublicExponent);
+
+            // ToRsaParameters must emit the exponent back big-endian with no
+            // leading zeros (RSAParameters convention). The previous code
+            // returned BitConverter.GetBytes(...) = little-endian 4 bytes.
+            Assert.Equal(rsaParams.Exponent, publicKey.ToRsaParameters().Exponent);
+        }
+
+        /// <summary>
+        /// A private key constructed with a non-palindrome exponent must round-trip
+        /// through Write/FromReader preserving the exponent as well. (The
+        /// <c>sn -k</c>-default 65537 masks any exponent byte-order bug because it
+        /// is a palindrome; this test uses a synthetic non-palindrome exponent and
+        /// does not require a mathematically valid RSA key, only that the exponent
+        /// survives the blob round-trip and ToRsaParameters.)
+        /// </summary>
+        [Fact]
+        public void WriteAndReadPrivateKey_PreservesNonPalindromicExponent()
+        {
+            // Build a dummy private key with a non-palindrome exponent. The P/Q/D
+            // values are not mathematically valid, but the blob round-trip and the
+            // exponent conversion are what we assert here (no RSA signing).
+            var rsaParams = new RSAParameters
+            {
+                Modulus = new byte[128],
+                Exponent = new byte[] { 0x01, 0x00, 0x02 }, // 65538, non-palindrome
+                P = new byte[64],
+                Q = new byte[64],
+                DP = new byte[64],
+                DQ = new byte[64],
+                InverseQ = new byte[64],
+                D = new byte[128]
+            };
+
+            var original = new StrongNamePrivateKey(rsaParams);
+            Assert.Equal(65538u, original.PublicExponent);
+
+            using var tempStream = new MemoryStream();
+            original.Write(new BinaryStreamWriter(tempStream));
+
+            // The pubexp field in the blob is a little-endian uint32 = 65538
+            // = [02 00 01 00]. A buggy big-endian writer would emit [01 00 02 00].
+            byte[] blob = tempStream.ToArray();
+            Assert.Equal(65538u, BitConverter.ToUInt32(blob, 16));
+
+            tempStream.Position = 0;
+            var reader = new BinaryStreamReader(tempStream);
+            var roundTripped = StrongNamePrivateKey.FromReader(ref reader);
+
+            Assert.Equal(65538u, roundTripped.PublicExponent);
+            Assert.Equal(rsaParams.Exponent, roundTripped.ToRsaParameters().Exponent);
+        }
+
+        private static byte[] SignWithRsa(RSA rsa, byte[] hash)
+        {
+            var formatter = new RSAPKCS1SignatureFormatter(rsa);
+            formatter.SetHashAlgorithm("SHA1");
+            var signature = formatter.CreateSignature(hash);
+            Array.Reverse(signature);
+            return signature;
+        }
+
+        private static byte[] ReverseBytes(byte[]? data)
+        {
+            Assert.NotNull(data);
+            var result = new byte[data.Length];
+            for (int i = 0; i < data.Length; i++)
+                result[i] = data[data.Length - 1 - i];
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
## Problem
Strong-name key blobs use two different byte-order conventions at the same API boundary:

- .NET `RSAParameters` stores RSA integers such as `Modulus`, `P`, `Q`, `DP`, `DQ`, `InverseQ`, and `D` as big-endian byte arrays.
- CryptoAPI `PUBLICKEYBLOB` and `PRIVATEKEYBLOB` store those same RSA integers in little-endian order on disk.
- The CryptoAPI `pubexp` field is different again: it is a 32-bit integer field, so it is serialized as a little-endian `uint`, while `RSAParameters.Exponent` is still a big-endian, no-leading-zero byte array.

The previous implementation mixed these representations. In particular, a strong-name key constructed from `RSAParameters` could be serialized as a CryptoAPI blob with big-endian RSA integer bytes, even though consumers expect little-endian blob integers. Reading public-key blobs also left the modulus in the on-disk byte order, so converting it back to `RSAParameters` could produce parameters that `RSA.ImportParameters` rejects or interprets incorrectly.

The exponent issue was easy to miss because the common exponent `65537` is encoded by `RSAParameters` as `[01 00 01]`, which reads the same forwards and backwards. Non-palindromic exponent byte sequences expose the wrong conversion.

`StrongNamePublicKey.GetPhysicalSize()` also divided the modulus byte length by 8, causing the reported serialized size to be smaller than the number of bytes actually written.

## Fix
- Use `RSAParameters`' big-endian byte order as the internal representation for strong-name RSA integer fields.
- Reverse RSA integer byte arrays only when reading from or writing to CryptoAPI key blobs.
- Convert `RSAParameters.Exponent` as a big-endian integer and serialize `pubexp` as the CryptoAPI little-endian `uint32` field.
- Fix `StrongNamePublicKey.GetPhysicalSize()` to include the full modulus byte length.
- Add regression tests covering CryptoAPI blob layout, non-palindromic exponent conversion, RSA import/signing round-trips, and physical size consistency.

## Tests
- `dotnet format whitespace --verify-no-changes --include src/AsmResolver.PE/DotNet/StrongName/StrongNamePublicKey.cs src/AsmResolver.PE/DotNet/StrongName/StrongNamePrivateKey.cs test/AsmResolver.PE.Tests/DotNet/StrongName/StrongNamePrivateKeyTest.cs`
- `dotnet test test/AsmResolver.PE.Tests/AsmResolver.PE.Tests.csproj`