### PR TITLE
Improve AsmResolver.Benchmark

### DIFF
--- a/test/AsmResolver.Benchmarks/AsmResolver.Benchmarks.csproj
+++ b/test/AsmResolver.Benchmarks/AsmResolver.Benchmarks.csproj
@@ -6,18 +6,31 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-      <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+        <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+        <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
+        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(UsePackage)' != 'false'">
+        <ProjectReference Include="..\..\src\AsmResolver.DotNet\AsmResolver.DotNet.csproj" />
+        <ProjectReference Include="..\..\src\AsmResolver.PE.File\AsmResolver.PE.File.csproj" />
+        <ProjectReference Include="..\..\src\AsmResolver.PE.Win32Resources\AsmResolver.PE.Win32Resources.csproj" />
+        <ProjectReference Include="..\..\src\AsmResolver.PE\AsmResolver.PE.csproj" />
+        <ProjectReference Include="..\..\src\AsmResolver\AsmResolver.csproj" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(UsePackage)' == 'true'">
+        <PackageReference Include="AsmResolver" Version="$(PackagesBaselineVersion)" />
+        <PackageReference Include="AsmResolver.PE.File" Version="$(PackagesBaselineVersion)" />
+        <PackageReference Include="AsmResolver.PE" Version="$(PackagesBaselineVersion)" />
+        <PackageReference Include="AsmResolver.PE.Win32Resources" Version="$(PackagesBaselineVersion)" />
+        <PackageReference Include="AsmResolver.DotNet" Version="$(PackagesBaselineVersion)" />
+        <PackageReference Include="AsmResolver.DotNet.Dynamic" Version="$(PackagesBaselineVersion)" />
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\src\AsmResolver.DotNet\AsmResolver.DotNet.csproj" />
-      <ProjectReference Include="..\..\src\AsmResolver.PE.File\AsmResolver.PE.File.csproj" />
-      <ProjectReference Include="..\..\src\AsmResolver.PE.Win32Resources\AsmResolver.PE.Win32Resources.csproj" />
-      <ProjectReference Include="..\..\src\AsmResolver.PE\AsmResolver.PE.csproj" />
-      <ProjectReference Include="..\..\src\AsmResolver\AsmResolver.csproj" />
-      <ProjectReference Include="..\TestBinaries\DotNet\AsmResolver.DotNet.TestCases.Methods\AsmResolver.DotNet.TestCases.Methods.csproj" />
-      <ProjectReference Include="..\TestBinaries\DotNet\AsmResolver.DotNet.TestCases.Types\AsmResolver.DotNet.TestCases.Types.csproj" />
+        <ProjectReference Include="..\TestBinaries\DotNet\AsmResolver.DotNet.TestCases.Methods\AsmResolver.DotNet.TestCases.Methods.csproj" />
+        <ProjectReference Include="..\TestBinaries\DotNet\AsmResolver.DotNet.TestCases.Types\AsmResolver.DotNet.TestCases.Types.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/AsmResolver.Benchmarks/Program.cs
+++ b/test/AsmResolver.Benchmarks/Program.cs
@@ -1,12 +1,13 @@
-﻿using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using System;
 using System.CommandLine;
-using System.CommandLine.Builder;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using BenchmarkDotNet.Configs;
-using BenchmarkDotNet.Jobs;
-using BenchmarkDotNet.Running;
 
 namespace AsmResolver.Benchmarks
 {
@@ -21,46 +22,79 @@ namespace AsmResolver.Benchmarks
 
             var baselineVersionOption = new Option<string?>("--baseline",
                 "Compare the results to a different nuget version of AsmResolver.");
-            var onlyOption = new Option<string?>("--type",
+            var useProfilerOption = new Option<bool>("--profiler",
+                "Enable a profiler.");
+            var hardwareCountersOption = new Option<bool>("--counters",
+                "Include hardware counters in the benchmark (automatically enables the --profiler option).");
+            var onlyTypeOption = new Option<string?>("--type",
                 "Only run the benchmarks in the specified benchmark type.");
 
             runCommand.AddOption(baselineVersionOption);
-            runCommand.AddOption(onlyOption);
+            runCommand.AddOption(useProfilerOption);
+            runCommand.AddOption(hardwareCountersOption);
+            runCommand.AddOption(onlyTypeOption);
 
-            runCommand.SetHandler((baselineVersion, benchmarkType) =>
+            runCommand.SetHandler((baselineVersion, useProfiler, hardwareCounters, benchmarkType) =>
             {
                 var config = new ManualConfig();
                 var job = Job.Default;
 
-                if (!string.IsNullOrEmpty(baselineVersion))
+                if (baselineVersion is not null)
                 {
                     config.AddJob(job
-                        .WithNuGet(new NuGetReferenceList
-                        {
-                            new("AsmResolver", baselineVersion),
-                            new("AsmResolver.PE.File", baselineVersion),
-                            new("AsmResolver.PE", baselineVersion),
-                            new("AsmResolver.PE.Win32Resources", baselineVersion),
-                            new("AsmResolver.DotNet", baselineVersion),
-                            new("AsmResolver.DotNet.Dynamic", baselineVersion),
-                        }).WithId(baselineVersion)
+                        .WithMsBuildArguments($"/p:PackagesBaselineVersion={baselineVersion}").WithId(baselineVersion)
                         .AsBaseline());
                 }
 
                 config.AddExporter(DefaultConfig.Instance.GetExporters().ToArray());
                 config.AddLogger(DefaultConfig.Instance.GetLoggers().ToArray());
                 config.AddColumnProvider(DefaultConfig.Instance.GetColumnProviders().ToArray());
-                config.HideColumns("NuGetReferences");
+                config.HideColumns("Arguments");
                 config.AddJob(job);
 
-                if (string.IsNullOrEmpty(benchmarkType))
-                    BenchmarkRunner.Run(Assembly.GetExecutingAssembly(), config);
-                else if (Type.GetType($"AsmResolver.Benchmarks.{benchmarkType}") is { } type)
-                    BenchmarkRunner.Run(type, config);
-                else
-                    Console.Error.WriteLine($"Could not find benchmark {benchmarkType}.");
+                if (hardwareCounters)
+                {
+                    config.AddHardwareCounters(
+                        HardwareCounter.CacheMisses,
+                        HardwareCounter.BranchMispredictions,
+                        HardwareCounter.InstructionRetired
+                    );
+                }
+                else if (useProfiler)
+                {
+                    config.AddDiagnoser(EventPipeProfiler.Default);
+                }
 
-            }, baselineVersionOption, onlyOption);
+                if (benchmarkType is null)
+                {
+                    BenchmarkRunner.Run(Assembly.GetExecutingAssembly(), config);
+                }
+                else if (Type.GetType($"AsmResolver.Benchmarks.{benchmarkType}") is { } type)
+                {
+                    BenchmarkRunner.Run(type, config);
+                }
+                else
+                {
+                    Console.Error.WriteLine($"Could not find benchmark {benchmarkType}.");
+                    Console.Error.WriteLine("Available benchmarks:");
+                    var assemblyTypes = Assembly.GetExecutingAssembly().GetTypes();
+                    foreach (var asemblyType in assemblyTypes)
+                    {
+                        var typeMethods = asemblyType.GetMethods();
+                        foreach (var typeMethod in typeMethods)
+                        {
+                            var benchmarkAttribute = typeMethod.GetCustomAttribute<BenchmarkAttribute>();
+                            if (benchmarkAttribute is not null)
+                            {
+                                var typeName = asemblyType.Name;
+                                Console.Error.WriteLine($"  {typeName}");
+                                break;
+                            }
+                        }
+                    }
+                }
+
+            }, baselineVersionOption, useProfilerOption, hardwareCountersOption, onlyTypeOption);
 
             return await root.InvokeAsync(args);
         }


### PR DESCRIPTION
Add BenchmarkDotNet.Diagnostics.Windows nuget package.
Show available benchmarks on type typo failure.
Update BenchmarkDotNet 0.14.0 -> 0.15.8.