### PR TITLE
[DeUnsafication & ByRefication] Simplified, moved away from unsafe manual implementation

### DIFF
--- a/src/AsmResolver/ByteArrayEqualityComparer.cs
+++ b/src/AsmResolver/ByteArrayEqualityComparer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace AsmResolver
 {
@@ -26,57 +27,15 @@ namespace AsmResolver
         }
 
         /// <inheritdoc />
-        public unsafe bool Equals(byte[]? x, byte[]? y)
+        public bool Equals(byte[]? x, byte[]? y)
         {
-            // Original code by Hafthor Stefansson
-            // Copyright (c) 2008-2013
-
-            if (x == y)
-                return true;
-            if (x == null || y == null || x.Length != y.Length)
-                return false;
-
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
             return x.AsSpan().SequenceEqual(y);
 #else
-            fixed (byte* p1 = x, p2 = y)
-            {
-                byte* x1 = p1;
-                byte* x2 = p2;
-                int length = x.Length;
+            if (x is null || y is null)
+                return x == y;
 
-                for (int i = 0; i < length / sizeof(long); i++, x1 += sizeof(long), x2 += sizeof(long))
-                {
-                    if (*(long*) x1 != *(long*) x2)
-                        return false;
-                }
-
-                if ((length & sizeof(int)) != 0)
-                {
-                    if (*(int*) x1 != *(int*) x2)
-                        return false;
-
-                    x1 += sizeof(int);
-                    x2 += sizeof(int);
-                }
-
-                if ((length & sizeof(short)) != 0)
-                {
-                    if (*(short*) x1 != *(short*) x2)
-                        return false;
-
-                    x1 += sizeof(short);
-                    x2 += sizeof(short);
-                }
-
-                if ((length & sizeof(byte)) != 0)
-                {
-                    if (*x1 != *x2)
-                        return false;
-                }
-
-                return true;
-            }
+            return x.SequenceEqual(y);
 #endif
         }
 


### PR DESCRIPTION
For .netstandard2.0 and lower:
\- 500 bytes native size
```
| Method   | Mean     | Error    | StdDev   |
|---------:|---------:)---------:/---------:o
| Old      | 40.77 ns | 0.235 ns | 0.219 ns |
| New      | 21.26 ns | 0.281 ns | 0.249 ns |
```