### PR TITLE
Restrict the publicity of the method semantics

### DIFF
--- a/src/AsmResolver.DotNet/MethodDefinition.cs
+++ b/src/AsmResolver.DotNet/MethodDefinition.cs
@@ -746,7 +746,7 @@ namespace AsmResolver.DotNet
         public partial MethodSemantics? Semantics
         {
             get;
-            set;
+            internal set;
         }
 
         /// <summary>


### PR DESCRIPTION
public access to this property setter bypasses the correct logic set by semantics collection