### PR TITLE
Fix editor config for visual studio

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,6 @@ csharp_preferred_modifier_order = public, private, protected, internal, new, abs
 csharp_style_var_elsewhere = true:suggestion
 csharp_style_var_for_built_in_types = false:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_namespace_declarations = block_scoped:suggestion
 csharp_new_line_before_open_brace = all
 dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary:none
 dotnet_style_parentheses_in_other_binary_operators = never_if_unnecessary:none

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,7 @@ csharp_preferred_modifier_order = public, private, protected, internal, new, abs
 csharp_style_var_elsewhere = true:suggestion
 csharp_style_var_for_built_in_types = false:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_namespace_declarations = block_scoped:suggestion
 csharp_new_line_before_open_brace = all
 dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary:none
 dotnet_style_parentheses_in_other_binary_operators = never_if_unnecessary:none

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,3 @@
-
 [*]
 charset = utf-8
 end_of_line = crlf
@@ -8,6 +7,7 @@ indent_style = space
 indent_size = 4
 
 # Microsoft .NET properties
+csharp_space_after_cast = true
 csharp_new_line_before_members_in_object_initializers = false
 csharp_preferred_modifier_order = public, private, protected, internal, new, abstract, virtual, sealed, override, static, readonly, extern, unsafe, volatile, async:suggestion
 csharp_style_var_elsewhere = true:suggestion
@@ -65,11 +65,11 @@ resharper_web_config_module_not_resolved_highlighting = warning
 resharper_web_config_type_not_resolved_highlighting = warning
 resharper_web_config_wrong_module_highlighting = warning
 
-[{*.bash,*.sh,*.zsh}]
+[*.{bash,sh,zsh}]
 indent_style = space
 indent_size = 2
 
-[{*.yaml,*.yml}]
+[*.{yaml,yml}]
 indent_style = space
 indent_size = 2
 
@@ -77,3 +77,6 @@ indent_size = 2
 indent_style = space
 indent_size = 4
 tab_width = 4
+
+[*.{sln,slnx}]
+insert_final_newline = false


### PR DESCRIPTION
Fixed the issue where visual studio does not add a space after a cast.
Example: (int)MyVariable instead of the correct (int) MyVariable

Fixed the issue with adding a new line for slnx files that caused a soft lock in VS 18