### PR TITLE
BUGFIX: Guard oversized user string tokens

### DIFF
--- a/src/AsmResolver.DotNet/Code/Cil/CilOperandBuilder.cs
+++ b/src/AsmResolver.DotNet/Code/Cil/CilOperandBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using AsmResolver.DotNet.Builder;
 using AsmResolver.DotNet.Collections;
 using AsmResolver.PE.DotNet.Cil;
 using AsmResolver.PE.DotNet.Metadata.Tables;
@@ -65,11 +66,20 @@ namespace AsmResolver.DotNet.Code.Cil
         /// <inheritdoc />
         public uint GetStringToken(object? operand) => operand switch
         {
-            string value => 0x70000000 | _provider.GetUserStringIndex(value),
+            string value => GetStringToken(value),
             MetadataToken token => token.ToUInt32(),
             uint raw => raw,
             _ => _errorListener.NotSupportedAndReturn<uint>($"{DiagnosticPrefix}Invalid or unsupported string operand ({operand.SafeToString()}).")
         };
+
+        private uint GetStringToken(string value)
+        {
+            uint index = _provider.GetUserStringIndex(value);
+            return index <= 0x00FFFFFF
+                ? 0x70000000 | index
+                : _errorListener.RegisterExceptionAndReturnDefault<uint>(new MetadataBuilderException(
+                    $"{DiagnosticPrefix}User string index 0x{index:X8} does not fit in a 24-bit metadata token."));
+        }
 
         /// <inheritdoc />
         public MetadataToken GetMemberToken(object? operand) => operand switch

--- a/test/AsmResolver.DotNet.Tests/Code/Cil/CilOperandBuilderTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Code/Cil/CilOperandBuilderTest.cs
@@ -1,0 +1,44 @@
+using AsmResolver.DotNet.Builder;
+using AsmResolver.DotNet.Code.Cil;
+using Xunit;
+
+namespace AsmResolver.DotNet.Tests.Code.Cil
+{
+    public class CilOperandBuilderTest
+    {
+        [Fact]
+        public void MaximumUserStringIndexProducesValidToken()
+        {
+            var diagnostics = new DiagnosticBag();
+            var builder = new CilOperandBuilder(new UserStringTokenProvider(0x00FFFFFF), diagnostics);
+
+            Assert.Equal(0x70FFFFFFu, builder.GetStringToken("value"));
+            Assert.False(diagnostics.HasErrors);
+        }
+
+        [Fact]
+        public void OversizedUserStringIndexProducesDiagnostic()
+        {
+            var diagnostics = new DiagnosticBag();
+            var builder = new CilOperandBuilder(new UserStringTokenProvider(0x01000000), diagnostics);
+
+            Assert.Equal(0u, builder.GetStringToken("value"));
+            var exception = Assert.IsType<MetadataBuilderException>(Assert.Single(diagnostics.Exceptions));
+            Assert.Contains("does not fit in a 24-bit metadata token", exception.Message);
+            Assert.False(diagnostics.IsFatal);
+        }
+
+        private sealed class UserStringTokenProvider : OriginalMetadataTokenProvider, IMetadataTokenProvider
+        {
+            private readonly uint _index;
+
+            public UserStringTokenProvider(uint index)
+                : base(null)
+            {
+                _index = index;
+            }
+
+            public new uint GetUserStringIndex(string value) => _index;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #775

User-string indices above the 24-bit metadata-token limit now register a nonfatal metadata-builder diagnostic and emit token zero instead of corrupting the token table byte.

Boundary coverage verifies that 0x00FFFFFF remains valid and 0x01000000 takes the recoverable diagnostic path.

Tests:
- dotnet test test/AsmResolver.DotNet.Tests/AsmResolver.DotNet.Tests.csproj --configuration Release --filter FullyQualifiedName~AsmResolver.DotNet.Tests.Code.Cil (142 passed)
- dotnet build src/AsmResolver.DotNet/AsmResolver.DotNet.csproj --configuration Release --framework net10.0 (0 warnings, 0 errors)
