### PR TITLE
BUGFIX: Use types from RuntimeContext instead of ContextModule when determining DirectBaseClass

### DIFF
--- a/src/AsmResolver.DotNet/RuntimeContext.cs
+++ b/src/AsmResolver.DotNet/RuntimeContext.cs
@@ -52,7 +52,9 @@ public partial class RuntimeContext
         AddSearchDirectories(resolver, searchDirectories);
         AssemblyResolver = resolver;
 
-        RuntimeCorLib = TargetRuntime.GetAssumedImplCorLib();
+        var corLib = TargetRuntime.GetAssumedImplCorLib();
+        RuntimeCorLib = corLib;
+        CorLibTypeFactory = new CorLibTypeFactory(corLib ?? TargetRuntime.GetDefaultCorLib());
         SignatureComparer = CreateSignatureComparer(TargetRuntime);
         _loadedAssemblies = new Dictionary<AssemblyDescriptor, AssemblyDefinition>(SignatureComparer);
     }
@@ -132,7 +134,9 @@ public partial class RuntimeContext
             AssemblyResolver = CreateAssemblyResolver(TargetRuntime, is32Bit, DefaultReaderParameters, searchDirectories);
         }
 
-        RuntimeCorLib = TargetRuntime.GetAssumedImplCorLib();
+        var corLib = TargetRuntime.GetAssumedImplCorLib();
+        RuntimeCorLib = corLib;
+        CorLibTypeFactory = new CorLibTypeFactory(corLib ?? TargetRuntime.GetDefaultCorLib());
         SignatureComparer = CreateSignatureComparer(TargetRuntime);
         _loadedAssemblies = new Dictionary<AssemblyDescriptor, AssemblyDefinition>(SignatureComparer);
     }
@@ -156,7 +160,13 @@ public partial class RuntimeContext
 
         TargetRuntime = targetRuntime;
         AssemblyResolver = CreateAssemblyResolver(TargetRuntime, is32Bit, DefaultReaderParameters, searchDirectories);
-        RuntimeCorLib = corLibReference ?? targetRuntime.GetAssumedImplCorLib();
+
+        corLibReference ??= targetRuntime.GetAssumedImplCorLib();
+        RuntimeCorLib = corLibReference;
+        CorLibTypeFactory = new CorLibTypeFactory(
+            corLibReference?.ToAssemblyReference()
+            ?? targetRuntime.GetDefaultCorLib()
+        );
 
         SignatureComparer = CreateSignatureComparer(targetRuntime);
         _loadedAssemblies = new Dictionary<AssemblyDescriptor, AssemblyDefinition>(SignatureComparer);
@@ -178,7 +188,14 @@ public partial class RuntimeContext
         DefaultReaderParameters = readerParameters ?? new ModuleReaderParameters(new ByteArrayFileService());
         TargetRuntime = targetRuntime;
         AssemblyResolver = assemblyResolver;
-        RuntimeCorLib = corLibReference ?? targetRuntime.GetAssumedImplCorLib();
+
+        corLibReference ??= targetRuntime.GetAssumedImplCorLib();
+        RuntimeCorLib = corLibReference;
+        CorLibTypeFactory = new CorLibTypeFactory(
+            corLibReference?.ToAssemblyReference()
+            ?? targetRuntime.GetDefaultCorLib()
+        );
+
         SignatureComparer = CreateSignatureComparer(targetRuntime);
         _loadedAssemblies = new Dictionary<AssemblyDescriptor, AssemblyDefinition>(SignatureComparer);
     }
@@ -205,6 +222,12 @@ public partial class RuntimeContext
         {
             RuntimeCorLib = type.DeclaringModule?.Assembly;
         }
+
+        CorLibTypeFactory = new CorLibTypeFactory(
+            RuntimeCorLib?.ToAssemblyReference()
+            ?? TargetRuntime.GetAssumedImplCorLib()
+            ?? TargetRuntime.GetDefaultCorLib()
+        );
     }
 
     /// <summary>
@@ -235,6 +258,14 @@ public partial class RuntimeContext
     /// Gets the corlib for this runtime
     /// </summary>
     public AssemblyDescriptor? RuntimeCorLib
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets the default corlib type factory for this runtime.
+    /// </summary>
+    public CorLibTypeFactory CorLibTypeFactory
     {
         get;
     }

--- a/src/AsmResolver.DotNet/Signatures/ArrayTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/ArrayTypeSignature.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using AsmResolver.IO;
@@ -197,9 +197,11 @@ namespace AsmResolver.DotNet.Signatures
 
         /// <inheritdoc />
         public override TypeSignature? GetDirectBaseClass(RuntimeContext? context)
-            => ContextModule?.CorLibTypeFactory.CorLibScope
+        {
+            return context?.CorLibTypeFactory.CorLibScope
                 .CreateTypeReference("System", "Array")
                 .ToTypeSignature(false);
+        }
 
         /// <inheritdoc />
         public override TResult AcceptVisitor<TResult>(ITypeSignatureVisitor<TResult> visitor) =>

--- a/src/AsmResolver.DotNet/Signatures/GenericInstanceTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/GenericInstanceTypeSignature.cs
@@ -143,7 +143,7 @@ namespace AsmResolver.DotNet.Signatures
 
             // Interfaces have System.Object as direct base class.
             if (genericType.IsInterface)
-                return ContextModule!.CorLibTypeFactory.Object;
+                return context?.CorLibTypeFactory.Object;
 
             if (genericType.BaseType is not { } baseType)
                 return null;

--- a/src/AsmResolver.DotNet/Signatures/SzArrayTypeSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/SzArrayTypeSignature.cs
@@ -33,10 +33,11 @@ namespace AsmResolver.DotNet.Signatures
 
         /// <inheritdoc />
         public override TypeSignature? GetDirectBaseClass(RuntimeContext? context)
-            => ContextModule?.CorLibTypeFactory.CorLibScope
+        {
+            return context?.CorLibTypeFactory.CorLibScope
                 .CreateTypeReference("System", "Array")
                 .ToTypeSignature(false);
-
+        }
 
         /// <inheritdoc />
         public override TResult AcceptVisitor<TResult>(ITypeSignatureVisitor<TResult> visitor)

--- a/src/AsmResolver.DotNet/Signatures/TypeDefOrRefSignature.cs
+++ b/src/AsmResolver.DotNet/Signatures/TypeDefOrRefSignature.cs
@@ -113,8 +113,8 @@ namespace AsmResolver.DotNet.Signatures
 
             // Interfaces have System.Object as direct base class.
             return type.IsInterface
-                ? ContextModule!.CorLibTypeFactory.Object
-                : type.BaseType!.ToTypeSignature(false).StripModifiers();
+                ? context?.CorLibTypeFactory.Object
+                : type.BaseType?.ToTypeSignature(false).StripModifiers();
         }
 
         /// <inheritdoc />

--- a/test/AsmResolver.DotNet.Tests/Signatures/TypeSignatureTest.cs
+++ b/test/AsmResolver.DotNet.Tests/Signatures/TypeSignatureTest.cs
@@ -343,6 +343,17 @@ namespace AsmResolver.DotNet.Tests.Signatures
         }
 
         [Fact]
+        public void GetDirectBaseClassOfInterface()
+        {
+            var context = new RuntimeContext(DotNetRuntimeInfo.NetFramework(4, 0));
+            var interfaceType = context.RuntimeCorLib!.ToAssemblyReference()
+                .CreateTypeReference("System", "IDisposable")
+                .ToTypeSignature(isValueType: false);
+
+            Assert.Equal("System.Object", interfaceType.GetDirectBaseClass(context)!.FullName);
+        }
+
+        [Fact]
         public void GetDirectBaseClassOfGenericTypeInstanceWithGenericBaseClass()
         {
             var module = ModuleDefinition.FromFile(typeof(GenericDerivedType<,>).Assembly.Location, TestReaderParameters);


### PR DESCRIPTION
Closes #770 