### PR TITLE
Add missing portable PDB debug data types and fix the FPO value

### DIFF
--- a/src/AsmResolver.PE/Debug/DebugDataType.cs
+++ b/src/AsmResolver.PE/Debug/DebugDataType.cs
@@ -25,7 +25,7 @@ namespace AsmResolver.PE.Debug
         /// Indicates frame pointer omission (FPO) information. This information tells the debugger how to
         /// interpret nonstandard stack frames, which use the EBP register for a purpose other than as a frame pointer. 
         /// </summary>
-        Fpo = 0,
+        Fpo = 3,
         
         /// <summary>
         /// Indicates the location of a DBG file. 
@@ -91,6 +91,16 @@ namespace AsmResolver.PE.Debug
         /// Indicates PE determinism or reproducibility.
         /// </summary>
         Repro = 16,
+        
+        /// <summary>
+        /// Indicates that the debug directory entry stores a portable PDB that is embedded in the image itself.
+        /// </summary>
+        EmbeddedPortablePdb = 17,
+        
+        /// <summary>
+        /// Indicates a cryptographic hash of the content of the symbol file the image was compiled with.
+        /// </summary>
+        PdbChecksum = 19,
         
         /// <summary>
         /// Indicates extended DLL characteristics bits.

--- a/test/AsmResolver.PE.Tests/Debug/DebugDataEntryTest.cs
+++ b/test/AsmResolver.PE.Tests/Debug/DebugDataEntryTest.cs
@@ -73,5 +73,27 @@ namespace AsmResolver.PE.Tests.Debug
                 "UNICODE_RSDS_FIXTURE_OK\n"
             );
         }
+
+        [Fact]
+        public void PersistentPortablePdbEntries()
+        {
+            var image = PEImage.FromBytes(Properties.Resources.HelloWorld, TestReaderParameters);
+
+            image.DebugData.Clear();
+            image.DebugData.Add(new DebugDataEntry(
+                new CustomDebugDataSegment(DebugDataType.EmbeddedPortablePdb, new DataSegment(new byte[] {1, 2, 3, 4}))));
+            image.DebugData.Add(new DebugDataEntry(
+                new CustomDebugDataSegment(DebugDataType.PdbChecksum, new DataSegment(new byte[] {5, 6, 7, 8}))));
+            image.DebugData.Add(new DebugDataEntry(new EmptyDebugDataSegment(DebugDataType.Repro)));
+
+            var newImage = RebuildAndReloadManagedPE(image);
+
+            Assert.Equal(new[]
+            {
+                DebugDataType.EmbeddedPortablePdb,
+                DebugDataType.PdbChecksum,
+                DebugDataType.Repro
+            }, newImage.DebugData.Select(d => d.Contents!.Type));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds the two portable PDB debug data types that `DebugDataType` was missing, and fixes `Fpo`, which was defined as `0` instead of `3`.

## Motivation

`DebugDataType` has no members for two of the debug directory entry types that every deterministic .NET assembly built with embedded symbols carries:

| Constant | Value | Status |
|---|---|---|
| `IMAGE_DEBUG_TYPE_EMBEDDED_PORTABLE_PDB` | 17 | missing |
| `IMAGE_DEBUG_TYPE_PDBCHECKSUM` | 19 | missing |

Both are defined by the [Portable PDB specification](https://github.com/dotnet/runtime/blob/main/docs/design/specs/PE-COFF.md#debug-directory-entries) and are present in `System.Reflection.PortableExecutable.DebugDirectoryEntryType`. Reading and writing these entries already works (they fall through to `CustomDebugDataSegment` in `DefaultDebugDataReader`), but callers have to cast a magic number to name them:

```csharp
// Today
image.DebugData.Add(new DebugDataEntry(new CustomDebugDataSegment((DebugDataType)17, pdb)));

// With this change
image.DebugData.Add(new DebugDataEntry(new CustomDebugDataSegment(DebugDataType.EmbeddedPortablePdb, pdb)));
```

Separately, `Fpo` is declared as `0`, but `IMAGE_DEBUG_TYPE_FPO` is `3`. As a result `DebugDataType.Fpo == DebugDataType.Unknown` is `true`, and a real type 3 entry is surfaced as an unnamed `(DebugDataType)3` instead of `Fpo`. This looks like a typo rather than something intentional, since every other member matches its `winnt.h` value.

## Changes

- **`src/AsmResolver.PE/Debug/DebugDataType.cs`**: adds `EmbeddedPortablePdb = 17` and `PdbChecksum = 19`, and corrects `Fpo` from `0` to `3`.

- **`test/AsmResolver.PE.Tests/Debug/DebugDataEntryTest.cs`**: adds `PersistentPortablePdbEntries`, asserting that entries of the newly named types survive a build and reload round trip alongside `Repro`.

## Notes

Changing the value of `Fpo` is technically a source and binary compatible but behavior changing fix, so it is worth calling out explicitly. In practice nothing can be relying on the current value in a meaningful way: it is indistinguishable from `Unknown`, so any code branching on `DebugDataType.Fpo` today is matching unknown entries rather than FPO entries. I am happy to split it into its own pull request if you would rather keep the additions separate from the fix.

`18` is deliberately not added: unlike 17 and 19 it is not part of the specification linked above and has no `winnt.h` constant.

All 313 tests in `AsmResolver.PE.Tests` pass.
