### PR TITLE
Update Microsoft.SourceLink.Github from 8.0.0 (transit Microsoft.Build.Tasks.Git 8.0.0 with vulnerability) to 10.0.401

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.401">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
## Summary
Fixed a recently detected vulnerability by updating Microsoft.SourceLink.Github package version to the patched version

## Current Behavior
Warning As Error: Package 'Microsoft.Build.Tasks.Git' 8.0.0 has a known moderate severity vulnerability.

## Updated Behavior
No errors