### PR TITLE
Stop propagating IsExternalInit as a dependency

### DIFF
--- a/src/AsmResolver.DotNet/AsmResolver.DotNet.csproj
+++ b/src/AsmResolver.DotNet/AsmResolver.DotNet.csproj
@@ -8,7 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IsExternalInit" Version="1.0.3" />
+    <PackageReference Include="IsExternalInit" Version="1.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <ProjectReference Include="..\AsmResolver.PE\AsmResolver.PE.csproj" />
     <ProjectReference
       Include="..\..\tools\AsmResolver.SourceGenerators\AsmResolver.SourceGenerators.csproj"


### PR DESCRIPTION
## Summary

Removes IsExternalInit as a required dependency of consuming projects, so it is just a dev-dependency.

## Checklist

- [x] Followed code guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] Added unit tests (when possible)


## AI Usage Disclosure

- [ ] AI was used in writing the code of this PR
- [ ] AI was used in writing the text of this PR
- [x] I am not a meat proxy
